### PR TITLE
Set Spring allow-circular-references to true

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
+++ b/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
@@ -97,7 +97,6 @@ class GrailsApp extends SpringApplication {
     @Override
     ConfigurableApplicationContext run(String... args) {
         ConfigurableApplicationContext applicationContext = super.run(args)
-
         Environment environment = Environment.getCurrent()
 
         log.info("Application starting in environment: {}", environment.getName())
@@ -143,6 +142,7 @@ class GrailsApp extends SpringApplication {
     @Override
     protected ConfigurableApplicationContext createApplicationContext() {
         setAllowBeanDefinitionOverriding(true)
+        setAllowCircularReferences(true)
         ConfigurableApplicationContext applicationContext = super.createApplicationContext()
         def now = System.currentTimeMillis()
 


### PR DESCRIPTION
In Spring 2.6.0, the circular references are disabled by default. In order to prevent breaking change, we are manually setting it to true.