### PR TITLE
Remove usages of deprecated createSpringApplication(Class<?>... sources)

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/GrailsAppBuilder.groovy
+++ b/grails-core/src/main/groovy/grails/boot/GrailsAppBuilder.groovy
@@ -4,6 +4,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.InheritConstructors
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.core.io.ResourceLoader
 
 /**
  * Fluent API for constructing GrailsApp instances. Simple extension of {@link SpringApplicationBuilder}.
@@ -16,7 +17,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder
 class GrailsAppBuilder extends SpringApplicationBuilder {
 
     @Override
-    protected SpringApplication createSpringApplication(Class<?>... sources) {
-        return new GrailsApp(sources)
+    protected SpringApplication createSpringApplication(ResourceLoader resourceLoader, Class < ? > ... sources) {
+        return new GrailsApp(resourceLoader, sources)
     }
 }


### PR DESCRIPTION
The method `createSpringApplication(Class<?>... sources)` is deprecated and never called, instead override `createSpringApplication(ResourceLoader resourceLoader, Class < ? > ... sources)`. Fixes #12288