### PR TITLE
Fix issues with loading logback during transformation

### DIFF
--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -5,6 +5,7 @@ import grails.compiler.ast.ClassInjector
 import grails.core.ArtefactHandler
 import grails.io.IOUtils
 import grails.plugins.metadata.GrailsPlugin
+import grails.util.Environment
 import grails.util.GrailsNameUtils
 import grails.util.GrailsUtil
 import groovy.transform.CompilationUnitAware
@@ -69,7 +70,7 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
             def projectName = classNode.getNodeMetaData("projectName")
             def projectVersion = classNode.getNodeMetaData("projectVersion")
             if(projectVersion == null) {
-                projectVersion = GrailsUtil.getGrailsVersion()
+                projectVersion = Environment.getGrailsVersion()
             }
 
             pluginVersion = projectVersion


### PR DESCRIPTION
Using GrailsUtil.getGrailsVersion() try to loads logback during transformation. Instead use Environment.getGrailsVersion().