### PR TITLE
Update Grails BOM Base Profile to 5.0.5

### DIFF
--- a/grails-bom/profiles.properties
+++ b/grails-bom/profiles.properties
@@ -1,5 +1,5 @@
 rest-api=5.0.1
-base=5.0.4
+base=5.0.5
 web=5.0.3
 react=5.0.0
 vue=5.0.0


### PR DESCRIPTION
This version use logback.xml instead of logback.groovy for a Grails application.