### PR TITLE
Fix streaming json encoder support

### DIFF
--- a/grails-test-suite-web/src/test/groovy/org/grails/web/converters/JSONConverterTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/converters/JSONConverterTests.groovy
@@ -145,7 +145,7 @@ class JSONConverterTests extends Specification implements ControllerUnitTest<JSO
     // GRAILS-11517
     void testMoreStringsWithQuotes2() {
         expect:
-        '{"key":"<a href=\\"#\\" class=\\"link\\">link<\\/a>"}' == (['key': '<a href="#" class="link">link</a>'] as JSON).toString()
+        '{"key":"<a href=\\"#\\" class=\\"link\\">link<\\u002fa>"}' == (['key': '<a href="#" class="link">link</a>'] as JSON).toString()
     }
 
     // GRAILS-10393

--- a/grails-web-common/src/main/groovy/org/grails/web/json/JSONObject.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/JSONObject.java
@@ -95,7 +95,7 @@ public class JSONObject implements JSONElement, Map {
     private static boolean useStreamingJavascriptEncoder=false;
     static {
         try {
-            javascriptEncoder = (StreamingEncoder)ClassUtils.forName("org.grails.plugins.codecs.JSONEncoder", JSONObject.class.getClassLoader()).newInstance();
+            javascriptEncoder = (StreamingEncoder)ClassUtils.forName("grails.encoders.JSONEncoder", JSONObject.class.getClassLoader()).newInstance();
             javascriptEncoderStateless = (EncodesToWriter)javascriptEncoder;
             useStreamingJavascriptEncoder = true;
         }


### PR DESCRIPTION
JSONObject enables efficient streaming encoding support by trying to dynamically resolve class JSONEncoder (from plugin grails-plugin-converters), but fails to do so due to an obsolete fully qualified name reference.

This PR updates this fully qualified name reference (from "org.grails.plugins.codecs.JSONEncoder" to "grails.encoders.JSONEncoder").