### PR TITLE
Issue 11753 - Make HSQL/H2 DBs test-related

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -440,8 +440,8 @@ subprojects { project ->
 
     if(project.name =~ /^(grails-plugin-datasource|grails-test-suite)/) {
         dependencies {
-            api 'hsqldb:hsqldb:1.8.1.1'
-            api "com.h2database:h2:$h2Version"
+            testImplementation 'hsqldb:hsqldb:1.8.1.1'
+            testImplementation "com.h2database:h2:$h2Version"
         }
     }
 


### PR DESCRIPTION
There should be no need to include the HSQL/H2 databases in the main
source set. The Grails profiles/apps declare their DB driver dependencies
on their own.

This should improve the situation described by #11753.