### PR TITLE
Remove usage of NavigableMap from MimeTypesConfiguration

### DIFF
--- a/grails-core/src/main/groovy/org/grails/config/NavigableMapConfig.java
+++ b/grails-core/src/main/groovy/org/grails/config/NavigableMapConfig.java
@@ -24,13 +24,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.ConversionException;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
-import org.springframework.util.ClassUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -276,7 +275,7 @@ public abstract class NavigableMapConfig implements Config {
         if (cache.containsKey(from)) {
             return cache.get(from);
         }
-        final HashMap<Object, Object> to = new HashMap<>();
+        final Map<Object, Object> to = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry: from.entrySet()) {
             if (entry.getValue() instanceof NavigableMap) {
                 to.put(entry.getKey(), convertToMap((NavigableMap) entry.getValue(), cache));

--- a/grails-plugin-mimetypes/src/main/groovy/org/grails/plugins/web/mime/MimeTypesConfiguration.groovy
+++ b/grails-plugin-mimetypes/src/main/groovy/org/grails/plugins/web/mime/MimeTypesConfiguration.groovy
@@ -26,7 +26,6 @@ import grails.web.mime.MimeUtility
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import io.micronaut.context.annotation.Factory
-import org.grails.config.NavigableMap
 import org.grails.web.mime.DefaultMimeTypeResolver
 import org.grails.web.mime.DefaultMimeUtility
 import org.springframework.context.ApplicationContext
@@ -108,7 +107,7 @@ class MimeTypesConfiguration {
 
     @CompileStatic(TypeCheckingMode.SKIP)
     protected Map<CharSequence, Object> getMimeConfig(Config config) {
-        return config.getProperty(Settings.MIME_TYPES, NavigableMap.class)
+        return config.getProperty(Settings.MIME_TYPES, Map.class)
     }
 
     private void processProviders(List<MimeType> mimes, Iterable<MimeTypeProvider> mimeTypeProviders) {

--- a/grails-plugin-mimetypes/src/main/groovy/org/grails/plugins/web/mime/MimeTypesFactoryBean.groovy
+++ b/grails-plugin-mimetypes/src/main/groovy/org/grails/plugins/web/mime/MimeTypesFactoryBean.groovy
@@ -17,16 +17,15 @@ package org.grails.plugins.web.mime
 
 import grails.config.Config
 import grails.config.Settings
-import groovy.transform.CompileStatic
-import groovy.transform.TypeCheckingMode
+import grails.core.GrailsApplication
 import grails.web.mime.MimeType
 import grails.web.mime.MimeTypeProvider
-import org.grails.config.NavigableMap
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
 import org.springframework.beans.factory.FactoryBean
-import grails.core.GrailsApplication
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.ApplicationContextAware
 import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
 
 /**
  * Creates the MimeType[] object that defines the configured mime types.
@@ -89,6 +88,6 @@ class MimeTypesFactoryBean implements FactoryBean<MimeType[]>, ApplicationContex
 
     @CompileStatic(TypeCheckingMode.SKIP)
     protected Map<CharSequence, CharSequence> getMimeConfig(Config config) {
-        return config.getProperty(Settings.MIME_TYPES, NavigableMap.class)
+        return config.getProperty(Settings.MIME_TYPES, Map.class)
     }
 }


### PR DESCRIPTION
Use LinkedHasMap instead of Map to preserve order while converting value to a Map in NavigableMapConfig.

For example, we need to preserve order of MimeType configuration which sometimes uses first value defined in the config as default.