### PR TITLE
Grails core plugin load domainClass plugin duplicated

### DIFF
--- a/grails-core/src/main/resources/META-INF/grails-plugin.xml
+++ b/grails-core/src/main/resources/META-INF/grails-plugin.xml
@@ -1,4 +1,3 @@
 <plugin name='core'>
   <type>org.grails.plugins.CoreGrailsPlugin</type>
-  <type>org.grails.plugins.domain.DomainClassGrailsPlugin</type>
 </plugin>


### PR DESCRIPTION
Grails core why load domainClass plugin? If a grails app not have Domain and GORM layer, it will be also OK.
So, I submit a PR to remove it, to keep Grails Clean and flexible.

Like this demo,
[https://github.com/rainboyan/grails-app-without-grails-demo](https://github.com/rainboyan/grails-app-without-grails-demo)

In `grails-core` module,  
```
<plugin name='core'>
  <type>org.grails.plugins.CoreGrailsPlugin</type>
  <type>org.grails.plugins.domain.DomainClassGrailsPlugin</type>
</plugin>
```

In `grails-plugin-domain-class` module,
```
<plugin name='domainClass'>
  <type>org.grails.plugins.domain.DomainClassGrailsPlugin</type>
</plugin>
```