### PR TITLE
Improvement: Load profile with given Url first

### DIFF
--- a/grails-shell/src/main/groovy/org/grails/cli/profile/repository/AbstractJarProfileRepository.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/profile/repository/AbstractJarProfileRepository.groovy
@@ -92,7 +92,7 @@ abstract class AbstractJarProfileRepository implements ProfileRepository {
     protected void registerProfile(URL url, ClassLoader parent) {
         if(registeredUrls.contains(url)) return
 
-        def classLoader = new URLClassLoader([url] as URL[], parent)
+        def classLoader = new URLClassLoader([url] as URL[])
         def profileYml = classLoader.getResource("META-INF/grails-profile/profile.yml")
         if (profileYml != null) {
             registeredUrls.add(url)


### PR DESCRIPTION
When profile jar or other jar include `META-INF/grails-profile/profile.yml` on the classpath, load profile with url will return wrong profile, because `getResource` will find parent loader path first, if not found then find the urls. But I think the given Urls should be find first, this is also efficient.