### PR TITLE
Allow defining localeResolver in Configuration

### DIFF
--- a/grails-plugin-i18n/build.gradle
+++ b/grails-plugin-i18n/build.gradle
@@ -1,5 +1,11 @@
 dependencies {
     api project(":grails-web")
 
+    annotationProcessor "io.micronaut:micronaut-inject-java:$micronautVersion"
+    annotationProcessor "io.micronaut.spring:micronaut-spring-boot-annotation:$micronautSpringVersion"
+    compileOnly "io.micronaut:micronaut-inject-java:$micronautVersion"
+    compileOnly "io.micronaut.spring:micronaut-spring-annotation:$micronautSpringVersion"
+
+    api("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
     api "org.codehaus.groovy:groovy-ant:$groovyVersion"
 }

--- a/grails-plugin-i18n/src/main/groovy/org/grails/plugins/i18n/DefaultLocaleConfiguration.java
+++ b/grails-plugin-i18n/src/main/groovy/org/grails/plugins/i18n/DefaultLocaleConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2004-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.plugins.i18n;
+
+import org.grails.web.i18n.ParamsAwareLocaleChangeInterceptor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
+import org.springframework.web.servlet.i18n.SessionLocaleResolver;
+import org.springframework.web.servlet.LocaleResolver;
+
+/**
+ * Default locale configuration.
+ *
+ * @author Michael Yan
+ * @since 5.1
+ */
+@Configuration
+public class DefaultLocaleConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LocaleChangeInterceptor localeChangeInterceptor() {
+        ParamsAwareLocaleChangeInterceptor localeChangeInterceptor = new ParamsAwareLocaleChangeInterceptor();
+        localeChangeInterceptor.setParamName("lang");
+        return localeChangeInterceptor;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LocaleResolver localeResolver() {
+        return new SessionLocaleResolver();
+    }
+}

--- a/grails-plugin-i18n/src/main/groovy/org/grails/plugins/i18n/I18nGrailsPlugin.groovy
+++ b/grails-plugin-i18n/src/main/groovy/org/grails/plugins/i18n/I18nGrailsPlugin.groovy
@@ -24,10 +24,8 @@ import grails.util.Environment
 import grails.util.GrailsUtil
 import groovy.util.logging.Slf4j
 import org.grails.spring.context.support.PluginAwareResourceBundleMessageSource
-import org.grails.web.i18n.ParamsAwareLocaleChangeInterceptor
 import org.springframework.context.support.ReloadableResourceBundleMessageSource
 import org.springframework.core.io.Resource
-import org.springframework.web.servlet.i18n.SessionLocaleResolver
 
 import java.nio.file.Files
 
@@ -59,12 +57,6 @@ class I18nGrailsPlugin extends Plugin {
             }
             defaultEncoding = encoding
         }
-
-        localeChangeInterceptor(ParamsAwareLocaleChangeInterceptor) {
-            paramName = "lang"
-        }
-
-        localeResolver(SessionLocaleResolver)
     }}
 
     @Override


### PR DESCRIPTION
Currently custom localeResolver only allow defining beans in `resources.groovy`, I think custom localeResolver and localeChangeInterceptor beans could be defined in `Configuration`, this will be benefit from Spring Boot `@EnableAutoConfiguration` with spring-boot-starters.
 
The priority order of loading `Bean` is, 
GrailsPlugin > Configuration > resources.groovy

So, this PR will not change the default Grails way.