### PR TITLE
Fixed publish guide issue

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
@@ -32,7 +32,7 @@ class PublishGuide extends DefaultTask {
     @Input @Optional Boolean asciidoc = false
     @Input @Optional String sourceRepo
     @Input @Optional Properties properties = new Properties()
-    @Input @Nested Collection macros = []
+    @Input @Optional Collection macros = []
     @OutputDirectory File workDir = project.buildDir as File
 
     @TaskAction


### PR DESCRIPTION
Use Grails 5.0.2 build docs successful, should remove `@Nested` on `macros` property.

```
@Input @Nested Collection macros = []
```

related commit : https://github.com/grails/grails-core/commit/835498fa6816fddafd932cee197fb86b96429d31