### PR TITLE
Deprecated org.grails.plugins.CodecsGrailsPlugin

### DIFF
--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -5,9 +5,7 @@ import grails.compiler.ast.ClassInjector
 import grails.core.ArtefactHandler
 import grails.io.IOUtils
 import grails.plugins.metadata.GrailsPlugin
-import grails.util.Environment
 import grails.util.GrailsNameUtils
-import grails.util.GrailsUtil
 import groovy.transform.CompilationUnitAware
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
@@ -70,7 +68,7 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
             def projectName = classNode.getNodeMetaData("projectName")
             def projectVersion = classNode.getNodeMetaData("projectVersion")
             if(projectVersion == null) {
-                projectVersion = Environment.getGrailsVersion()
+                projectVersion = getClass().getPackage().getImplementationVersion()
             }
 
             pluginVersion = projectVersion

--- a/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
@@ -32,7 +32,7 @@ class PublishGuide extends DefaultTask {
     @Input @Optional Boolean asciidoc = false
     @Input @Optional String sourceRepo
     @Input @Optional Properties properties = new Properties()
-    @Input @Nested Collection macros = []
+    @Input @Optional Collection macros = []
     @OutputDirectory File workDir = project.buildDir as File
 
     @TaskAction

--- a/grails-plugin-codecs/src/main/groovy/org/grails/plugins/CodecsGrailsPlugin.java
+++ b/grails-plugin-codecs/src/main/groovy/org/grails/plugins/CodecsGrailsPlugin.java
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.grails.plugins
+package org.grails.plugins;
 
-import org.grails.plugins.codecs.DefaultCodecLookup
+import org.grails.plugins.codecs.DefaultCodecLookup;
 
 /**
  * @deprecated Use {@link org.grails.plugins.codecs.CodecsGrailsPlugin} instead
  */
 @Deprecated
-class CodecsGrailsPlugin extends org.grails.plugins.codecs.CodecsGrailsPlugin {
+public class CodecsGrailsPlugin extends org.grails.plugins.codecs.CodecsGrailsPlugin {
 
-    Closure doWithSpring() {{->
-        codecLookup(DefaultCodecLookup)
-    }}
 }

--- a/grails-plugin-codecs/src/main/groovy/org/grails/plugins/codecs/CodecsGrailsPlugin.groovy
+++ b/grails-plugin-codecs/src/main/groovy/org/grails/plugins/codecs/CodecsGrailsPlugin.groovy
@@ -45,4 +45,7 @@ class CodecsGrailsPlugin extends Plugin {
             RawCodec
     ]
 
+    Closure doWithSpring() {{->
+        codecLookup(DefaultCodecLookup)
+    }}
 }


### PR DESCRIPTION
Use org.grails.plugins.codecs.CodecsGrailsPlugin instead

Generate the correct descriptor grails-plugin.xml, because there are two `CodecsGrailsPlugin`.