### PR TITLE
Fixed generate plugin xml with wrong version and dependon

### DIFF
--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -148,14 +148,12 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
             }
         }
 
-        if (pluginClassNode) {
-            def pluginXmlFile = new File(compilationTargetDirectory, "META-INF/grails-plugin.xml")
-            // now create or update grails-plugin.xml
-            // first check if plugin.xml exists
-            pluginXmlFile.parentFile.mkdirs()
+        def pluginXmlFile = new File(compilationTargetDirectory, "META-INF/grails-plugin.xml")
+        // now create or update grails-plugin.xml
+        // first check if plugin.xml exists
+        pluginXmlFile.parentFile.mkdirs()
 
-            generatePluginXml(pluginClassNode, projectVersion, transformedClasses, pluginXmlFile)
-        }
+        generatePluginXml(pluginClassNode, projectVersion, transformedClasses, pluginXmlFile)
     }
 
     static File resolveCompilationTargetDirectory(SourceUnit source) {

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.grails.compiler.injection
 
 import grails.artefact.Artefact
@@ -30,6 +45,7 @@ import java.lang.reflect.Modifier
  * A global transformation that applies Grails' transformations to classes within a Grails project
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 3.0
  */
 @GroovyASTTransformation(phase= CompilePhase.CANONICALIZATION)

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -81,8 +81,8 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
         def compilationTargetDirectory = resolveCompilationTargetDirectory(source)
 
         for (ClassNode classNode : classes) {
-            projectName = String.valueOf(classNode.getNodeMetaData("projectName"))
-            projectVersion = String.valueOf(classNode.getNodeMetaData("projectVersion"))
+            projectName = classNode.getNodeMetaData("projectName") ? String.valueOf(classNode.getNodeMetaData("projectName")) : null
+            projectVersion = classNode.getNodeMetaData("projectVersion") ? String.valueOf(classNode.getNodeMetaData("projectVersion")) : null
             if(projectVersion == null) {
                 projectVersion = getClass().getPackage().getImplementationVersion()
             }

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/PluginAstReader.java
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/PluginAstReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 original authors
+ * Copyright 2014-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Reads plugin info from the AST
  *
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 3.0
  */
 class PluginAstReader {

--- a/grails-core/src/test/groovy/org/grails/compiler/injection/PluginAstReaderSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/compiler/injection/PluginAstReaderSpec.groovy
@@ -1,0 +1,50 @@
+package org.grails.compiler.injection
+
+import grails.plugins.GrailsPluginInfo
+import groovy.xml.MarkupBuilder
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.classgen.GeneratorContext
+import org.codehaus.groovy.control.CompilationFailedException
+import org.codehaus.groovy.control.CompilationUnit
+import org.codehaus.groovy.control.Phases
+import org.codehaus.groovy.control.SourceUnit
+import spock.lang.Specification
+
+/**
+ * @author Michael Yan
+ * @since 5.1.8
+ */
+class PluginAstReaderSpec extends Specification {
+
+    void "Test read the plugin info from classNode"() {
+        given:"A Grails Plugin class"
+            ClassNode classNode = null
+            CompilationUnit cu = new CompilationUnit(new GroovyClassLoader())
+            cu.addSource("FooGrailsPlugin", '''
+import grails.util.GrailsUtil
+
+class FooGrailsPlugin {
+    def version = '0.1'
+    def dependsOn = [core: version]
+}
+''')
+            cu.addPhaseOperation(new CompilationUnit.PrimaryClassNodeOperation() {
+                @Override
+                void call(SourceUnit source, GeneratorContext context, ClassNode cn) throws CompilationFailedException {
+                    if(cn.name == "FooGrailsPlugin") {
+                         classNode = cn
+                    }
+                }
+            }, Phases.CANONICALIZATION)
+            cu.compile(Phases.CANONICALIZATION)
+
+        when:"read info of the plugin classNode"
+            def reader = new PluginAstReader()
+            GrailsPluginInfo info = reader.readPluginInfo(classNode)
+
+        then:"The info and properties are correct"
+            info.name == "foo"
+            info.version == "0.1"
+            info.properties.dependsOn == [core: "0.1"]
+    }
+}

--- a/grails-core/src/test/groovy/org/grails/plugins/GrailsPluginTests.groovy
+++ b/grails-core/src/test/groovy/org/grails/plugins/GrailsPluginTests.groovy
@@ -3,15 +3,98 @@ package org.grails.plugins
 import grails.core.DefaultGrailsApplication
 import grails.plugins.DefaultGrailsPluginManager
 import grails.util.Environment
+import grails.util.GrailsUtil
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.*
 
 /**
  * @author Graeme Rocher
+ * @author Michael Yan
  * @since 1.0
  */
 class GrailsPluginTests {
+
+    @Test
+    void testPluginVersion() {
+
+        def gcl = new GroovyClassLoader()
+        def test1 = gcl.parseClass('''
+class TestOneGrailsPlugin {
+    def version = '0.1'
+    def scopes = 'test'
+}
+''')
+
+        DefaultGrailsApplication application = new DefaultGrailsApplication()
+        def plugin = new DefaultGrailsPlugin(test1, application)
+
+        assertEquals "0.1", plugin.version
+    }
+
+    @Test
+    void testPluginGrailsVersion() {
+
+        def gcl = new GroovyClassLoader()
+        def test1 = gcl.parseClass('''
+import grails.util.GrailsUtil
+
+class TestOneGrailsPlugin {
+    def version = '0.1'
+    def grailsVersion = GrailsUtil.getGrailsVersion()
+}
+''')
+
+        DefaultGrailsApplication application = new DefaultGrailsApplication()
+        def plugin = new DefaultGrailsPlugin(test1, application)
+
+        assertEquals "0.1", plugin.version
+        assertEquals GrailsUtil.getGrailsVersion(), plugin.properties.grailsVersion
+    }
+
+    @Test
+    void testPluginName() {
+
+        def gcl = new GroovyClassLoader()
+        def test1 = gcl.parseClass('''
+class TestOneGrailsPlugin {
+    def version = '0.1'
+    def scopes = 'test'
+}
+''')
+
+        DefaultGrailsApplication application = new DefaultGrailsApplication()
+        def plugin = new DefaultGrailsPlugin(test1, application)
+
+        assertEquals "testOne", plugin.name
+        assertEquals "testOne-0.1", plugin.fullName
+    }
+
+    @Test
+    void testPluginProperties() {
+
+        def gcl = new GroovyClassLoader()
+        def test1 = gcl.parseClass('''
+class TestOneGrailsPlugin {
+    def version = '0.1'
+    def scopes = 'test'
+    def environments = 'dev'    
+    def pluginExcludes = [
+        "grails-app/views/error.gsp"
+    ]
+    def dependsOn = [core: version, domainClass: version, services: version]
+}
+''')
+
+        DefaultGrailsApplication application = new DefaultGrailsApplication()
+        def plugin = new DefaultGrailsPlugin(test1, application)
+
+        assertEquals "0.1", plugin.properties.version
+        assertEquals "test", plugin.properties.scopes
+        assertEquals "dev", plugin.properties.environments
+        assertEquals ["grails-app/views/error.gsp"], plugin.properties.pluginExcludes
+        assertEquals [core: '0.1', domainClass: '0.1', services: '0.1'], plugin.properties.dependsOn
+    }
 
     @Test
     void testPluginPath() {

--- a/grails-core/src/test/groovy/org/grails/plugins/GrailsPluginTests.groovy
+++ b/grails-core/src/test/groovy/org/grails/plugins/GrailsPluginTests.groovy
@@ -145,6 +145,7 @@ class TestGrailsPlugin {
 
         DefaultGrailsApplication application = new DefaultGrailsApplication()
         def pluginManager = new DefaultGrailsPluginManager([test1] as Class[], application)
+        pluginManager.setLoadCorePlugins(false)
 
         pluginManager.loadPlugins()
         assertNotNull pluginManager.getGrailsPlugin("test")
@@ -153,6 +154,7 @@ class TestGrailsPlugin {
             System.setProperty(Environment.KEY, Environment.PRODUCTION.getName())
 
             pluginManager = new DefaultGrailsPluginManager([test1] as Class[], application)
+            pluginManager.setLoadCorePlugins(false)
             pluginManager.loadPlugins()
             assertNull pluginManager.getGrailsPlugin("test")
         } finally {


### PR DESCRIPTION
Fixed generated grails-plugin.xml with wrong version and dependOn
Update PluginAstReader to read plugin version and dependOn map from GrailsPlugin
Refactor GlobalGrailsClassInjectorTransformation
Use plugin version first, if version not set will use project version

fixed https://github.com/grails/grails-core/issues/12503