### PR TITLE
Fixed Warn ch.qos.logback.classic.Level in Grails 5.1.1 to 5.1.7 (Missing in 5.2 branch)

### DIFF
--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -5,9 +5,7 @@ import grails.compiler.ast.ClassInjector
 import grails.core.ArtefactHandler
 import grails.io.IOUtils
 import grails.plugins.metadata.GrailsPlugin
-import grails.util.Environment
 import grails.util.GrailsNameUtils
-import grails.util.GrailsUtil
 import groovy.transform.CompilationUnitAware
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
@@ -70,7 +68,7 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
             def projectName = classNode.getNodeMetaData("projectName")
             def projectVersion = classNode.getNodeMetaData("projectVersion")
             if(projectVersion == null) {
-                projectVersion = Environment.getGrailsVersion()
+                projectVersion = getClass().getPackage().getImplementationVersion()
             }
 
             pluginVersion = projectVersion


### PR DESCRIPTION
Original PR https://github.com/grails/grails-core/issues/12291 was never added to 5.2 branch and issue is now showing up on latest 5.2.4 release