### PR TITLE
Remove deprecated code usages

### DIFF
--- a/grails-core/src/test/groovy/org/grails/compiler/injection/ArtefactTypeAstTransformationSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/compiler/injection/ArtefactTypeAstTransformationSpec.groovy
@@ -122,7 +122,7 @@ class ArtefactTypeAstTransformationSpec extends Specification {
 				}
 			"""
 
-		t = clazz.newInstance()
+		t = clazz.getDeclaredConstructor().newInstance()
 
 		then: "Trait is applied"
 		t instanceof Test10531Trait


### PR DESCRIPTION
Use `clazz.getDeclaredConstructor().newInstance()` instead of deprecated `clazz.newInstance()`