### PR TITLE
Use mavenCentral directly instead of using proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        maven { url "https://repo.grails.org/grails/core" }
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://repo.grails.org/grails/core" }
     }
     dependencies {
         classpath "commons-io:commons-io:2.11.0"
@@ -229,6 +229,7 @@ if (isReleaseVersion) {
 allprojects {
     repositories {
         mavenLocal()
+        mavenCentral()
         maven { url "https://repo.grails.org/grails/core" }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         if(groovyVersion.endsWith('-SNAPSHOT')) {

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://repo.grails.org/grails/core" }
     }
 }


### PR DESCRIPTION
The Grails JFrog artifactory repository actually proxies to the Maven Central instead we should avoid using proxy in order to reduce traffic on the Grails artifactory.