### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,8 +11,16 @@ on:
       - '[4-9]+.[0-9]+.x'
       - '[3-9]+.[3-9]+.x'
   workflow_dispatch:
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+      checks: write  #  to publish result as PR check (scacap/action-surefire-report)
+
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -8,6 +8,10 @@ on:
       - '[4-9]+.[0-9]+.x'
       - '[3-9]+.[3-9]+.x'
   workflow_dispatch:
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   release_notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,13 @@ name: Release
 on:
   release:
     types: [published]
+permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write  #  to create release
+      issues: write  #  to modify milestones
+
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/retry-release.yml
+++ b/.github/workflows/retry-release.yml
@@ -8,8 +8,13 @@ on:
       target_branch:
         description: The Target Branch (e.g. 5.0.x)
         required: true
+permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write  #  to create release
+      issues: read  #  to get closed issues
+
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.