### PR TITLE
Fix for Groovy STC and SC issues

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/grails/config/CodeGenConfig.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/config/CodeGenConfig.groovy
@@ -46,14 +46,15 @@ class CodeGenConfig implements Cloneable, ConfigMap {
     }
 
     CodeGenConfig(CodeGenConfig copyOf) {
-        this((Map<String, Object> )copyOf.configMap)
+        this(copyOf.getConfigMap())
     }
 
     CodeGenConfig(Map<String, Object> copyOf) {
         this()
         mergeMap(copyOf)
     }
-    
+
+    @Override
     CodeGenConfig clone() {
         new CodeGenConfig(this)
     }

--- a/grails-bootstrap/src/main/groovy/org/grails/config/NavigableMap.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/config/NavigableMap.groovy
@@ -57,9 +57,9 @@ class NavigableMap implements Map<String, Object>, Cloneable {
         delegateMap.toString()
     }
 
-    @CompileDynamic
-    public NavigableMap clone() {
-        return new NavigableMap(rootConfig, path, delegateMap.clone())
+    @Override
+    NavigableMap clone() {
+        new NavigableMap(getRootConfig(), getPath(), new LinkedHashMap<>(getDelegateMap()))
     }
 
     @Override
@@ -241,7 +241,7 @@ class NavigableMap implements Map<String, Object>, Cloneable {
                     subMap = (NavigableMap)currentValue
                 }
                 else {
-                    subMap = new NavigableMap( (NavigableMap)targetMap.rootConfig, newPathList.asImmutable())
+                    subMap = new NavigableMap(targetMap.getRootConfig(), newPathList.asImmutable())
                     if(currentValue instanceof Map) {
                         subMap.putAll((Map)currentValue)
                     }
@@ -354,7 +354,7 @@ class NavigableMap implements Map<String, Object>, Cloneable {
                 newPathList.addAll( currentMap.getPath() )
                 newPathList.add(pathElement)
 
-                Map<String, Object> newMap = new NavigableMap( (NavigableMap)currentMap.rootConfig, newPathList.asImmutable())
+                Map<String, Object> newMap = new NavigableMap(currentMap.getRootConfig(), newPathList.asImmutable())
                 currentMap.put(pathElement, newMap)
 
                 def fullPath = accumulatedPath.toString()

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -219,7 +219,7 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
 
     protected static void generatePluginXml(ClassNode pluginClassNode, String pluginVersion, Set<String> transformedClasses, File pluginXmlFile) {
         def pluginXmlExists = pluginXmlFile.exists()
-        Set pluginClasses = []
+        Set<String> pluginClasses = []
         pluginClasses.addAll(transformedClasses)
         pluginClasses.addAll(pendingPluginClasses)
 


### PR DESCRIPTION
I noticed the Grails integration build for Groovy has started failing for the Groovy 2.5.x / Grails 4.0.x branch.  https://github.com/apache/groovy/actions/runs/3978201672/jobs/6819847071

There are some minor map access and element type items that are easily fixed.  Could you please merge these back as far as the Grails 4.0.x branch?