### PR TITLE
Remove incorrect test descriptions

### DIFF
--- a/grails-test-suite-uber/src/test/groovy/grails/compiler/GrailsCompileStaticCompilationErrorsSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/compiler/GrailsCompileStaticCompilationErrorsSpec.groovy
@@ -170,7 +170,7 @@ class SomeClass {
         given:
         def gcl = new GroovyClassLoader()
 
-        when: 'a class marked with @GrailsCompileStatic invokes dynamic finders on a non-domain class inside of a method marked with TypeCheckingMode.SKIP'
+        when:
         def c = gcl.parseClass('''
 package grails.compiler
 
@@ -193,7 +193,7 @@ class SomeClass implements grails.validation.Validateable {
         given:
         def gcl = new GroovyClassLoader()
 
-        when: 'a class marked with @GrailsCompileStatic invokes dynamic finders on a non-domain class inside of a method marked with TypeCheckingMode.SKIP'
+        when:
         def c = gcl.parseClass('''
 package grails.compiler
 
@@ -229,7 +229,7 @@ class SomeClass implements grails.validation.Validateable {
         given:
         def gcl = new GroovyClassLoader()
 
-        when: 'a class marked with @GrailsCompileStatic invokes dynamic finders on a non-domain class inside of a method marked with TypeCheckingMode.SKIP'
+        when:
         def c = gcl.parseClass('''
 package grails.compiler
 


### PR DESCRIPTION
These descriptions have been copied by accident from another test in this class.

The test method name is actually sufficient in these cases.