### PR TITLE
Backport: Fix @GrailsCompileStatic on domain objects with inner classes (#13013)

### DIFF
--- a/grails-core/src/main/groovy/org/grails/compiler/DomainMappingTypeCheckingExtension.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/DomainMappingTypeCheckingExtension.groovy
@@ -44,6 +44,8 @@ class DomainMappingTypeCheckingExtension extends TypeCheckingDSL {
                         mappingClosureCode = mappingProperty.initialExpression.code
                     }
                     mappingProperty.initialExpression.code = new EmptyStatement()
+                } else {
+                    newScope()
                 }
             } else {
                 newScope()
@@ -56,8 +58,8 @@ class DomainMappingTypeCheckingExtension extends TypeCheckingDSL {
                 mappingProperty.initialExpression.code = currentScope.mappingClosureCode
                 currentScope.checkingMappingClosure = true
                 withTypeChecker { visitClosureExpression mappingProperty.initialExpression }
-                scopeExit()
             }
+            scopeExit()
         }
 
         methodNotFound { ClassNode receiver, String name, ArgumentListExpression argList, ClassNode[] argTypes, MethodCall call ->

--- a/grails-core/src/main/groovy/org/grails/compiler/NamedQueryTypeCheckingExtension.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/NamedQueryTypeCheckingExtension.groovy
@@ -52,8 +52,8 @@ class NamedQueryTypeCheckingExtension extends TypeCheckingDSL {
                 def namedQueryProperty = classNode.getField('namedQueries')
                 namedQueryProperty.initialExpression.code = currentScope.namedQueryClosureCode
                 currentScope.checkingNamedQueryClosure = true
-                scopeExit()
             }
+            scopeExit()
         }
 
         methodNotFound { ClassNode receiver, String name, ArgumentListExpression argList, ClassNode[] argTypes, MethodCall call ->

--- a/grails-core/src/main/groovy/org/grails/compiler/ValidateableTypeCheckingExtension.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/ValidateableTypeCheckingExtension.groovy
@@ -52,8 +52,8 @@ class ValidateableTypeCheckingExtension extends TypeCheckingDSL {
                 constraintsProperty.initialExpression.code = currentScope.constraintsClosureCode
                 currentScope.checkingConstraintsClosure = true
                 withTypeChecker { visitClosureExpression constraintsProperty.initialExpression }
-                scopeExit()
             }
+            scopeExit()
         }
 
         methodNotFound { ClassNode receiver, String name, ArgumentListExpression argList, ClassNode[] argTypes, MethodCall call ->

--- a/grails-test-suite-uber/src/test/groovy/grails/compiler/DomainClassWithInnerClassUsingStaticCompilationSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/compiler/DomainClassWithInnerClassUsingStaticCompilationSpec.groovy
@@ -1,0 +1,60 @@
+package grails.compiler
+
+import grails.compiler.GrailsCompileStatic
+import grails.persistence.Entity
+import grails.testing.gorm.DomainUnitTest
+import grails.validation.Validateable
+import spock.lang.Issue
+import spock.lang.Specification
+
+class DomainClassWithInnerClassUsingStaticCompilationSpec extends Specification implements DomainUnitTest<SomeClass> {
+
+    @Issue('https://github.com/grails/grails-core/issues/12461')
+    void 'a domain class marked with @GrailsCompileStatic containing an inner class and a "constraints" block'() {
+        expect: 'the configuration from the "constraints" closure is available'
+            SomeClass.constraints instanceof Closure
+            SomeClass.constraintsClosureCalled
+    }
+
+    @Issue('https://github.com/grails/grails-core/issues/12461')
+    void 'a domain class marked with @GrailsCompileStatic containing an inner class and a "mapping" block'() {
+        expect: 'the configuration from the "mapping" closure is available'
+            SomeClass.mapping instanceof Closure
+            SomeClass.mappingClosureCalled
+    }
+
+    @Issue('https://github.com/grails/grails-core/issues/12461')
+    void 'a domain class marked with @GrailsCompileStatic containing an inner class and a "namedQueries" block'() {
+        setup:
+            SomeClass.getNamedQuery('test')
+
+        expect: 'the configuration from the "namedQueries" closure is available'
+            SomeClass.namedQueries instanceof Closure
+            SomeClass.namedQueriesClosureCalled
+    }
+}
+
+@GrailsCompileStatic
+@Entity
+class SomeClass implements Validateable {
+
+    class SomeInnerClass {}
+
+    SomeInnerClass foo
+
+    static boolean constraintsClosureCalled = false
+    static boolean mappingClosureCalled = false
+    static boolean namedQueriesClosureCalled = false
+
+    static constraints = {
+        constraintsClosureCalled = true
+    }
+
+    static mapping = {
+        mappingClosureCalled = true
+    }
+
+    static namedQueries = {
+        namedQueriesClosureCalled = true
+    }
+}


### PR DESCRIPTION
Make sure that for every class a new scope is added to and removed from the stack.

Previously a new scope was added for nearly every class but not removed. This had the effect that the wrong (empty) scope (from the inner class) was used for the entity class. This was then missing any of its `mapping`, `constraints` and `namedQueries` closures.