### PR TITLE
Make org.grails:grails-web-sitemesh optional. It is now included with org.grails.plugins:sitemesh2

### DIFF
--- a/grails-web-mvc/build.gradle
+++ b/grails-web-mvc/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(":grails-web-common"),
             project(":grails-web-url-mappings")
 
-    api "org.grails:grails-web-sitemesh:$gspVersion", {
+    compileOnly "org.grails:grails-web-sitemesh:$gspVersion", {
         exclude group:'org.grails', module:'grails-web-common'
     }
 }

--- a/grails-web/build.gradle
+++ b/grails-web/build.gradle
@@ -11,7 +11,7 @@ dependencies {
         exclude group:'org.grails', module:'grails-encoder'
         exclude group:'org.grails', module:'grails-web-common'
     }
-    api "org.grails:grails-web-sitemesh:$gspVersion", {
+    compileOnly "org.grails:grails-web-sitemesh:$gspVersion", {
         exclude group:'org.grails', module:'grails-core'
         exclude group:'org.grails', module:'grails-encoder'
         exclude group:'org.grails', module:'grails-web-common'


### PR DESCRIPTION
Make org.grails:grails-web-sitemesh optional. It is now included with org.grails.plugins:sitemesh2