### PR TITLE
DefaultGrailsPlugin: set delegation strategy before calling doWithSpring Closure

### DIFF
--- a/grails-core/src/main/groovy/org/grails/plugins/DefaultGrailsPlugin.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/DefaultGrailsPlugin.java
@@ -540,6 +540,8 @@ public class DefaultGrailsPlugin extends AbstractGrailsPlugin implements ParentA
             if(c != null) {
                 BeanBuilder bb = new BeanBuilder(getParentCtx(),springConfig, grailsApplication.getClassLoader());
                 bb.setBinding(b);
+                c.setDelegate(bb);
+                c.setResolveStrategy(Closure.DELEGATE_FIRST);
                 bb.invokeMethod("beans", new Object[]{c});
             }
         }
@@ -557,6 +559,7 @@ public class DefaultGrailsPlugin extends AbstractGrailsPlugin implements ParentA
             BeanBuilder bb = new BeanBuilder(getParentCtx(),springConfig, grailsApplication.getClassLoader());
             bb.setBinding(b);
             c.setDelegate(bb);
+            c.setResolveStrategy(Closure.DELEGATE_FIRST);
             bb.invokeMethod("beans", new Object[]{c});
         }
 

--- a/grails-core/src/main/groovy/org/grails/plugins/DefaultGrailsPlugin.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/DefaultGrailsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2005 the original author or authors.
+ * Copyright 2004-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-test-suite-uber/src/test/groovy/org/grails/plugins/DefaultGrailsPluginTests.java
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/plugins/DefaultGrailsPluginTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2005 the original author or authors.
+ * Copyright 2004-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-test-suite-uber/src/test/groovy/org/grails/plugins/DefaultGrailsPluginTests.java
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/plugins/DefaultGrailsPluginTests.java
@@ -33,6 +33,8 @@ import java.io.File;
 public class DefaultGrailsPluginTests extends AbstractGrailsMockTests {
 
     private Class<?> versioned;
+    private Class<?> versioned2;
+    private Class<?> versioned3;
     private Class<?> notVersion;
     private Class<?> notPluginClass;
     private Class<?> disabled;
@@ -54,6 +56,21 @@ public class DefaultGrailsPluginTests extends AbstractGrailsMockTests {
                         "assert event != null" +
                         "}" +
                         "}");
+        versioned2 = gcl.parseClass("class MyTwoGrailsPlugin extends grails.plugins.Plugin {\n" +
+                "def version = 1.1;" +
+                "Closure doWithSpring() { {->" +
+                "classEditor(org.springframework.beans.propertyeditors.ClassEditor,application.classLoader)" +
+                "}}\n" +
+                "}");
+        versioned3 = gcl.parseClass("class MyThreeGrailsPlugin extends grails.plugins.Plugin {\n" +
+                "def version = 1.1;" +
+                "Object invokeMethod(String name, Object args) {" +
+                "true" +
+                "}\n" +
+                "Closure doWithSpring() { {->" +
+                "classEditor(org.springframework.beans.propertyeditors.ClassEditor,application.classLoader)" +
+                "}}\n" +
+                "}");
         notVersion = gcl.parseClass("class AnotherGrailsPlugin {\n" +
                         "}");
         notPluginClass = gcl.parseClass("class SomeOtherPlugin {\n" +
@@ -135,6 +152,26 @@ public class DefaultGrailsPluginTests extends AbstractGrailsMockTests {
         ApplicationContext ctx = springConfig.getApplicationContext();
 
         assertTrue(ctx.containsBean("classEditor"));
+
+        // Version 2
+        GrailsPlugin versionPlugin2 = new DefaultGrailsPlugin(versioned2, ga);
+
+        RuntimeSpringConfiguration springConfig2 = new DefaultRuntimeSpringConfiguration();
+        versionPlugin2.doWithRuntimeConfiguration(springConfig2);
+
+        ApplicationContext ctx2 = springConfig2.getApplicationContext();
+
+        assertTrue(ctx2.containsBean("classEditor"));
+
+        // Version 3
+        GrailsPlugin versionPlugin3 = new DefaultGrailsPlugin(versioned3, ga);
+
+        RuntimeSpringConfiguration springConfig3 = new DefaultRuntimeSpringConfiguration();
+        versionPlugin3.doWithRuntimeConfiguration(springConfig3);
+
+        ApplicationContext ctx3 = springConfig3.getApplicationContext();
+
+        assertTrue(ctx3.containsBean("classEditor"));
     }
 
     public void testGetName() {


### PR DESCRIPTION
This resolves the problem if Grails plugin has defined invokeMethod, an error will occur when `doWithSpring` is executed