### PR TITLE
Make grails-web-sitemesh optional due to GroovyPageLayoutFinder being required by ResponseRenderer trait.

### DIFF
--- a/grails-plugin-controllers/build.gradle
+++ b/grails-plugin-controllers/build.gradle
@@ -6,8 +6,11 @@ dependencies {
             project(':grails-plugin-domain-class')
 
     api("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
+    compileOnly "org.grails:grails-web-sitemesh:$gspVersion"
+
     runtimeOnly project(':grails-plugin-i18n')
 
     testRuntimeOnly "jline:jline:$jlineVersion"
     testRuntimeOnly "org.fusesource.jansi:jansi:$jansiVersion"
+    testImplementation "org.grails:grails-web-sitemesh:$gspVersion"
 }

--- a/grails-plugin-interceptors/build.gradle
+++ b/grails-plugin-interceptors/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
     api project(":grails-plugin-controllers")
     api project(":grails-plugin-url-mappings")
+    compileOnly "org.grails:grails-web-sitemesh:$gspVersion"
+    testImplementation "org.grails:grails-web-sitemesh:$gspVersion"
 }

--- a/grails-plugin-rest/build.gradle
+++ b/grails-plugin-rest/build.gradle
@@ -7,8 +7,10 @@ dependencies {
             project(":grails-plugin-datasource")
 
     api "org.grails.plugins:converters:$legacyConvertersVersion"
+    compileOnly "org.grails:grails-web-sitemesh:$gspVersion"
 
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     testImplementation project(":grails-plugin-url-mappings"),
                 project(":grails-test-suite-base")
+    testImplementation "org.grails:grails-web-sitemesh:$gspVersion"
 }

--- a/grails-web-boot/build.gradle
+++ b/grails-web-boot/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
     testImplementation project(":grails-plugin-controllers")
 
+    testImplementation "org.grails:grails-web-sitemesh:$gspVersion"
     testImplementation "org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion"
     testRuntimeOnly "org.apache.tomcat.embed:tomcat-embed-logging-juli:$tomcatLog4jVersion"
     testRuntimeOnly project(":grails-plugin-i18n")


### PR DESCRIPTION
Unfortunately GroovyPageLayoutFinder is coupled to [ResponseRenderer](https://github.com/grails/grails-core/blob/ea30f160d8b7f207bc0c0e9919453eb41148bf70/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy#L73-L80rl) 

and because it is a trait, changing it in any way would break any controller in a previously compiled plugin. 

So basically, we are stuck with this dependency which will be resolved if either the grails sitemesh 2 or sitemesh 3 plugin is installed.   Sitemesh 2 was made a transitive dependency of the `org.grails.plugins:gsp` because the plugin is responsible for configuring `GroovyPageLayoutFinder`. 

This pull request makes all `grails-web-sitemesh` dependencies optional since they will be resolved by `org.grails.plugins:gsp`

