### PR TITLE
make grails-web-sitemesh an api dependency of grails-plugin-controllers since GroovyPageLayoutFinder is tightly coupled to ResponseRenderer

### DIFF
--- a/grails-plugin-controllers/build.gradle
+++ b/grails-plugin-controllers/build.gradle
@@ -6,11 +6,9 @@ dependencies {
             project(':grails-plugin-domain-class')
 
     api("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
-    compileOnly "org.grails:grails-web-sitemesh:$gspVersion"
-
+    api "org.grails:grails-web-sitemesh:$gspVersion"
     runtimeOnly project(':grails-plugin-i18n')
 
     testRuntimeOnly "jline:jline:$jlineVersion"
     testRuntimeOnly "org.fusesource.jansi:jansi:$jansiVersion"
-    testImplementation "org.grails:grails-web-sitemesh:$gspVersion"
 }

--- a/grails-plugin-interceptors/build.gradle
+++ b/grails-plugin-interceptors/build.gradle
@@ -1,6 +1,4 @@
 dependencies {
     api project(":grails-plugin-controllers")
     api project(":grails-plugin-url-mappings")
-    compileOnly "org.grails:grails-web-sitemesh:$gspVersion"
-    testImplementation "org.grails:grails-web-sitemesh:$gspVersion"
 }

--- a/grails-plugin-rest/build.gradle
+++ b/grails-plugin-rest/build.gradle
@@ -7,10 +7,8 @@ dependencies {
             project(":grails-plugin-datasource")
 
     api "org.grails.plugins:converters:$legacyConvertersVersion"
-    compileOnly "org.grails:grails-web-sitemesh:$gspVersion"
 
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     testImplementation project(":grails-plugin-url-mappings"),
                 project(":grails-test-suite-base")
-    testImplementation "org.grails:grails-web-sitemesh:$gspVersion"
 }

--- a/grails-web-boot/build.gradle
+++ b/grails-web-boot/build.gradle
@@ -3,7 +3,6 @@ dependencies {
 
     testImplementation project(":grails-plugin-controllers")
 
-    testImplementation "org.grails:grails-web-sitemesh:$gspVersion"
     testImplementation "org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion"
     testRuntimeOnly "org.apache.tomcat.embed:tomcat-embed-logging-juli:$tomcatLog4jVersion"
     testRuntimeOnly project(":grails-plugin-i18n")


### PR DESCRIPTION
I was hoping for a less coupled solution, but that would require the sitemesh 2 dependencies added to existing apps that do not use the gsp plugin.

This fix should cause all the functional tests to pass.  If we are going this route, I will end up removing grails-web-sitemesh as a dependency of the gsp plugin, but no need to hold up a release for that.