### PR TITLE
Remove explicit 1.33 from SnakeYaml to auto resolve to Snake YAML 2

### DIFF
--- a/grails-bootstrap/build.gradle
+++ b/grails-bootstrap/build.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 dependencies {
     api ( "org.codehaus.groovy:groovy-xml:$groovyVersion" )
     api ( "org.codehaus.groovy:groovy-templates:$groovyVersion" )
-    api "org.yaml:snakeyaml:1.33"
+    api "org.yaml:snakeyaml"
     api "io.micronaut:micronaut-inject:$micronautVersion"
     
     compileOnly("io.methvin:directory-watcher:$methvinDirectoryWatcherVersion")

--- a/grails-docs/src/main/groovy/grails/doc/DocPublisher.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/DocPublisher.groovy
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory
 import org.radeox.api.engine.WikiRenderEngine
 import org.radeox.engine.context.BaseInitialRenderContext
 import org.radeox.engine.context.BaseRenderContext
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
 
@@ -265,7 +266,7 @@ class DocPublisher {
         def legacyLinks = [:]
         if (legacyLinksFile.exists()) {
             legacyLinksFile.withInputStream { input ->
-                legacyLinks = new Yaml(new SafeConstructor()).load(input)
+                legacyLinks = new Yaml(new SafeConstructor(new LoaderOptions())).load(input)
             }
         }
 
@@ -537,7 +538,7 @@ class DocPublisher {
             }
             else if(propertiesFile.name.endsWith('.yml')) {
                 propertiesFile.withInputStream { input ->
-                    def ymls = new Yaml(new SafeConstructor()).loadAll(input)
+                    def ymls = new Yaml(new SafeConstructor(new LoaderOptions())).loadAll(input)
                     for(yml in ymls) {
                         if(yml instanceof Map) {
                             def config = yml.grails?.doc

--- a/grails-docs/src/main/groovy/grails/doc/internal/YamlTocStrategy.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/internal/YamlTocStrategy.groovy
@@ -1,5 +1,6 @@
 package grails.doc.internal
 
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
 
@@ -7,7 +8,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor
  * Class representing a Grails user guide table of contents defined in YAML.
  */
 class YamlTocStrategy {
-    private final parser = new Yaml(new SafeConstructor())
+    private final parser = new Yaml(new SafeConstructor(new LoaderOptions()))
     private resourceChecker
     private String ext = ".gdoc"
 


### PR DESCRIPTION
Even though branch `6.1.x` resolves `org.yaml:snakeyaml` to version `2.0` via `io.micronaut:micronaut-inject:3.10.2`, we should get rid of the unnecessary version number `1.33`.