### PR TITLE
Parse CORS mappings

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/cors/GrailsCorsConfiguration.groovy
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/cors/GrailsCorsConfiguration.groovy
@@ -17,6 +17,7 @@ package grails.web.mapping.cors
 
 import grails.util.TypeConvertingMap
 import groovy.transform.CompileStatic
+import java.util.function.Consumer
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.web.cors.CorsConfiguration
 
@@ -47,18 +48,10 @@ class GrailsCorsConfiguration {
                     GrailsDefaultCorsConfiguration corsConfiguration = new GrailsDefaultCorsConfiguration(grailsCorsMapping)
                     if (value instanceof Map) {
                         TypeConvertingMap config = new TypeConvertingMap((Map)value)
-                        if (config.containsKey('allowedOrigins')) {
-                            corsConfiguration.allowedOrigins = config.list('allowedOrigins')
-                        }
-                        if (config.containsKey('allowedMethods')) {
-                            corsConfiguration.allowedMethods = config.list('allowedMethods')
-                        }
-                        if (config.containsKey('allowedHeaders')) {
-                            corsConfiguration.allowedHeaders = config.list('allowedHeaders')
-                        }
-                        if (config.containsKey('exposedHeaders')) {
-                            corsConfiguration.exposedHeaders = config.list('exposedHeaders')
-                        }
+                        parseConfigList(config, 'allowedOrigins', corsConfiguration::setAllowedOrigins)
+                        parseConfigList(config, 'allowedMethods', corsConfiguration::setAllowedMethods)
+                        parseConfigList(config, 'allowedHeaders', corsConfiguration::setAllowedHeaders)
+                        parseConfigList(config, 'exposedHeaders', corsConfiguration::setExposedHeaders)
                         if (config.containsKey('maxAge')) {
                             corsConfiguration.maxAge = config.long('maxAge')
                         }
@@ -74,5 +67,19 @@ class GrailsCorsConfiguration {
         }
 
         corsConfigurationMap
+    }
+
+    private List<String> parseConfigList(TypeConvertingMap config, String key, Consumer<List<String>> setter) {
+        // Most of the times the config is defined as a single entry: "key"
+        if (config.containsKey(key)) {
+            setter.accept(config.list(key))
+        } else {
+            // Some times the config is defined as multiples entries: "key[0]", "key[1]"...
+            List<String> list = []
+            for (int index = 0; config.containsKey(key + "[$index]"); index++) {
+                list << config.get(key + "[$index]").toString()
+            }
+            if (!list.empty) setter.accept(list)
+        }
     }
 }

--- a/grails-web-url-mappings/src/test/groovy/grails/web/mapping/cors/GrailsCorsConfigurationSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/grails/web/mapping/cors/GrailsCorsConfigurationSpec.groovy
@@ -172,6 +172,51 @@ class GrailsCorsConfigurationSpec extends Specification {
         config["/foo"].maxAge == 3600L
     }
 
+    void "test multiple mappings"() {
+        given:
+        Map<String, CorsConfiguration> config
 
+        when:
+        config = buildConfig([
+                "[/a/**]": [
+                        "allowedOrigins": [
+                                "https://a.example.com",
+                                "https://a.example.org"
+                        ]
+                ],
+                "[/b/**]": [
+                        "allowedOrigins[0]": "https://b.example.com",
+                        "allowedOrigins[1]": "https://b.example.org"
+                ],
+                "[/c/**]": [
+                        "allowedMethods[0]": "GET",
+                        "allowedHeaders[0]": "Foo",
+                        "allowedHeaders[1]": "Bar",
+                        "exposedHeaders": "Foo",
+                        "allowCredentials": "true",
+                        "maxAge": "1234",
+                ]
+        ])
 
+        then: //The global mapping is not created. Provided values override defaults
+        config.size() == 3
+        config["[/a/**]"].allowedOrigins == ["https://a.example.com", "https://a.example.org"]
+        config["[/a/**]"].allowedMethods == DEFAULT_METHODS
+        config["[/a/**]"].allowedHeaders == DEFAULT_ALLOWED_HEADERS
+        config["[/a/**]"].exposedHeaders == DEFAULT_EXPOSED_HEADERS
+        config["[/a/**]"].allowCredentials == null
+        config["[/a/**]"].maxAge == DEFAULT_MAX_AGE
+        config["[/b/**]"].allowedOrigins == ["https://b.example.com", "https://b.example.org"]
+        config["[/b/**]"].allowedMethods == DEFAULT_METHODS
+        config["[/b/**]"].allowedHeaders == DEFAULT_ALLOWED_HEADERS
+        config["[/b/**]"].exposedHeaders == DEFAULT_EXPOSED_HEADERS
+        config["[/b/**]"].allowCredentials == null
+        config["[/b/**]"].maxAge == DEFAULT_MAX_AGE
+        config["[/c/**]"].allowedOrigins == DEFAULT_ORIGINS
+        config["[/c/**]"].allowedMethods == ["GET"]
+        config["[/c/**]"].allowedHeaders == ["Foo", "Bar"]
+        config["[/c/**]"].exposedHeaders == ["Foo"]
+        config["[/c/**]"].allowCredentials == true
+        config["[/c/**]"].maxAge == 1234
+    }
 }


### PR DESCRIPTION
@puneetbehl I implemented additional parsing in case the config map comes as multiple indexed entries, because I think it's more backward-compatible than changing `Map<String, Object>` to `Map<Sting, List<Sting>>`. Please let me know if you'd rather change the type of the `mappings` field.

Fixes #12821, fixes #12719