### PR TITLE
Explicitly bump Spring Framework to 5.3.30

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,6 +39,7 @@ spockVersion=2.1-groovy-3.0
 springBootVersion=2.7.17
 springLoadedVersion=1.2.8.RELEASE
 springVersion=5.3.30
+spring.version=5.3.30
 testingSupportVersion=3.1.0
 testingSupportVersionForTests=3.1.0
 tomcatLog4jVersion=8.5.2


### PR DESCRIPTION
This change resolves Spring Framework 5.3.30 instead of 5.3.27