### PR TITLE
Modernise uber test suite build file

### DIFF
--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -92,9 +92,9 @@ def isolatedTestPatterns = [
         'org.grails.web.util.WebUtilsTests'
     ],
     isolatedTestsTwo: [
-        'UrlMappingsTestMixinTests',
-        'SetupTeardownInvokeTests',
-        'TestMixinSetupTeardownInvokeTests'
+        'grails.test.mixin.UrlMappingsTestMixinTests',
+        'grails.test.mixin.SetupTeardownInvokeTests',
+        'grails.test.mixin.TestMixinSetupTeardownInvokeTests'
     ],
     isolatedRestRendererTests: [
         '*.rest.render.*Spec'
@@ -104,8 +104,8 @@ def isolatedTestPatterns = [
         'org.grails.validation.CascadingErrorCountSpec'
     ],
     isolatedRestfulControllerTests: [
-        'RestfulControllerSpec',
-        'ResourceAnnotationRestfulControllerSpec'
+        'grails.test.mixin.RestfulControllerSpec',
+        'grails.test.mixin.ResourceAnnotationRestfulControllerSpec'
     ]
 ]
 

--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -1,5 +1,5 @@
 configurations.testCompileClasspath {
-    exclude module: "grails-plugin-testing"
+    exclude module: 'grails-plugin-testing'
 }
 
 dependencies {
@@ -86,66 +86,54 @@ dependencies {
     }
 }
 
-test {
-     maxParallelForks = isCiBuild ? 2 : 4
-     forkEvery = isCiBuild ? 25 : 100
-     if(!isCiBuild) {
-         maxHeapSize = '1024m'
-     }
-     excludes = [
-         "**/grails/test/PersonTests.class",
-         "**/rest/render/**/*Spec.class",
-         "**/*TestCase.class",
-         "**/DataSourceGrailsPluginTests",
-         "**/DefaultGrailsControllerClassTests.class",
-         "**/GrailsUnitTestCaseTests.class",
-         "**/SetupTeardownInvokeTests.class",
-         "**/TestMixinSetupTeardownInvokeTests.class",
-         "**/UrlMappingsTestMixinTests.class",
-         "**/WebUtilsTests.class",
-         "**/RestfulControllerSpec.class",
-         "**/ResourceAnnotationRestfulControllerSpec.class",
-         "**/TestingValidationSpec.class",
-         "**/CascadingErrorCountSpec"
-     ]
-}
-
-task isolatedTestsOne(type:Test) {
-    includes = [
-        "**/DataSourceGrailsPluginTests.class",
-        "**/GrailsUnitTestCaseTests.class",
-        "**/WebUtilsTests.class"
+def isolatedTestPatterns = [
+    isolatedTestsOne: [
+        'org.grails.core.DefaultGrailsControllerClassSpec',
+        'org.grails.web.util.WebUtilsTests'
+    ],
+    isolatedTestsTwo: [
+        'UrlMappingsTestMixinTests',
+        'SetupTeardownInvokeTests',
+        'TestMixinSetupTeardownInvokeTests'
+    ],
+    isolatedRestRendererTests: [
+        '*.rest.render.*Spec'
+    ],
+    isolatedPersonTests: [
+        'org.grails.validation.TestingValidationSpec',
+        'org.grails.validation.CascadingErrorCountSpec'
+    ],
+    isolatedRestfulControllerTests: [
+        'RestfulControllerSpec',
+        'ResourceAnnotationRestfulControllerSpec'
     ]
+]
+
+tasks.withType(Test).configureEach {
+    maxParallelForks = isCiBuild ? 2 : 4
+    forkEvery = isCiBuild ? 25 : 100
+    if(!isCiBuild) {
+        maxHeapSize = '1024m'
+    }
 }
 
-task isolatedTestsTwo(type:Test) {
+tasks.named('test', Test) {
+    filter.excludePatterns = isolatedTestPatterns.values().flatten()
+    dependsOn(provider {
+        tasks.findAll({
+            isolatedTestPatterns.containsKey(it.name)
+        })
+    })
+}
+
+isolatedTestPatterns.keySet().each { taskName ->
+    tasks.register(taskName, Test) {
+        group = 'verification'
+        filter.includePatterns = isolatedTestPatterns[taskName]
+    }
+}
+
+tasks.named('isolatedTestsTwo', Test) {
     maxParallelForks = 1
     forkEvery = 100
-    includes = [
-        "**/UrlMappingsTestMixinTests.class",
-        "**/SetupTeardownInvokeTests.class",
-        "**/TestMixinSetupTeardownInvokeTests.class"
-    ]
 }
-
-task isolatedRestRendererTests(type:Test) {
-    includes = ['**/rest/render/**/*Spec.class']
-}
-
-task isolatedDefaultGrailsControllerClassTests(type: Test) {
-    includes = ['**/DefaultGrailsControllerClassTests.class']
-}
-
-task isolatedPersonTests(type: Test) {
-    includes = ['**/grails/test/PersonTests.class',
-                "**/TestingValidationSpec.class",
-                "**/CascadingErrorCountSpec"
-                ]
-}
-
-task isolatedRestfulControllerTests(type:Test) {
-    includes = ["**/RestfulControllerSpec.class",
-        "**/ResourceAnnotationRestfulControllerSpec.class"]
-}
-
-test.dependsOn isolatedPersonTests, isolatedTestsOne, isolatedTestsTwo, isolatedRestRendererTests, isolatedDefaultGrailsControllerClassTests, isolatedRestfulControllerTests


### PR DESCRIPTION
- Make tasks lazily configured
- Remove non-existing tests from isolated test tasks
- Remove duplication for make it easier to maintain