### PR TITLE
Change resolve strategy `DELEGATE_FIRST` => `OWNER_FIRST`

### DIFF
--- a/grails-core/src/main/groovy/org/grails/plugins/DefaultGrailsPlugin.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/DefaultGrailsPlugin.java
@@ -541,7 +541,7 @@ public class DefaultGrailsPlugin extends AbstractGrailsPlugin implements ParentA
                 BeanBuilder bb = new BeanBuilder(getParentCtx(),springConfig, grailsApplication.getClassLoader());
                 bb.setBinding(b);
                 c.setDelegate(bb);
-                c.setResolveStrategy(Closure.DELEGATE_FIRST);
+                c.setResolveStrategy(Closure.OWNER_FIRST);
                 bb.invokeMethod("beans", new Object[]{c});
             }
         }


### PR DESCRIPTION
Fixes #13250

Since the closure's resolve strategy was changed to [`DELEGATE_FIRST`](https://github.com/grails/grails-core/pull/13150/files#diff-2226701447a270b094a7eb52800a92b7d818d10fac64927e709efd4206294bcfR544), `thisObject.beanTypeResolver` is no longer updated by the next [assignment in `SpringSecurityCoreGrailsPlugin`](https://github.com/grails/grails-spring-security-core/blob/5.3.x/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy#L215):

```groovy
beanTypeResolver = beanTypeResolverClass.newInstance(conf, grailsApplication)
```

Instead, the assignment is intercepted by [`BeanBuilder.setProperty`](https://github.com/grails/grails-core/blob/5.3.x/grails-spring/src/main/groovy/grails/spring/BeanBuilder.java#L771) and then discarded because `currentBeanConfig` is `null`:

```groovy
public void setProperty(String name, Object value) {
  if (currentBeanConfig != null) {
    setPropertyOnBeanConfig(name, value);
  }
}
```

@puneetbehl I'm not sure what's the specific problem that we were trying to solve in https://github.com/grails/grails-core/pull/13150, so please let me know if you think using `OWNER_FIRST` here makes more sense than using `DELEGATE_FIRST`.
