### PR TITLE
Set remote build cache to push only if authenticated

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,7 +19,8 @@ gradleEnterprise {
 buildCache {
     local { enabled = System.getenv('CI') != 'true' }
     remote(HttpBuildCache) {
-        push = System.getenv('CI') == 'true'
+        def isAuthenticated = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER') && System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY')
+        push = System.getenv('CI') == 'true' && isAuthenticated
         enabled = true
         url = 'https://ge.grails.org/cache/'
         credentials {


### PR DESCRIPTION
Fixed remote build cache setup for forked PRs. This addresses the case where a PR from a fork runs on the C, but is missing the remote build cache credentials as it's not running in a secure environment. In that case we want to disable pushing to remote cache. If left enabled, the build will try to push and fail, which will in return turn remote build cache off for the rest of the build, causing build performance degradation.