### PR TITLE
Update 2.5.x continuous integration workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,20 +59,3 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         with:
           arguments: -Dorg.gradle.internal.publish.checksums.insecure=true publish
-      - name: Extract branch name
-        if: success()
-        id: extract_branch
-        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-      - name: Create Snapshot Message for the Workflow Dispatch
-        if: success()
-        id: dispatch_message
-        run: echo "value={\"message\":\"New Core Snapshot $(date) - $GITHUB_SHA\"}" >> $GITHUB_OUTPUT
-      - name: Invoke the Java CI workflow in Grails Functional Tests
-        if: success()
-        uses: benc-uk/workflow-dispatch@v1.2
-        with:
-          workflow: Java CI
-          repo: grails/grails-functional-tests
-          ref: ${{ steps.extract_branch.outputs.value }}
-          token: ${{ secrets.GH_TOKEN }}
-          inputs: ${{ steps.dispatch_message.outputs.value }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,6 +48,16 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '8'
+      - name: Run Assemble
+        id: assemble
+        if: success()
+        uses: gradle/gradle-build-action@v2
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+        with:
+          arguments: assemble -x :grails-dependencies:assemble -x :grails-dependencies:install
       - name: Publish to Artifactory (repo.grails.org)
         id: publish
         uses: gradle/gradle-build-action@v2
@@ -58,4 +68,17 @@ jobs:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         with:
-          arguments: -Dorg.gradle.internal.publish.checksums.insecure=true publish
+          arguments: upload -x :grails-dependencies:assemble -x :grails-dependencies:install -x :grails-dependencies:uploadPublished
+      - name: Publish to Sonatype OSSRH
+        id: publish_to_sonatype
+        if: success() || failure()
+        uses: gradle/gradle-build-action@v2
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_NEXUS_URL: ${{ secrets.SONATYPE_NEXUS_URL }}
+        with:
+          arguments: upload -x :grails-dependencies:assemble -x :grails-dependencies:install -x :grails-dependencies:uploadPublished

--- a/build.gradle
+++ b/build.gradle
@@ -353,14 +353,25 @@ subprojects { project ->
                     }
 
                     if(System.getenv('SONATYPE_USERNAME')) {
-                        repository(url: isBuildSnapshot ? "https://s01.oss.sonatype.org/content/repositories/snapshots/" :
-                                "https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/${System.env.SONATYPE_REPOSITORY_ID}/") {
-                            authentication(userName: System.env.SONATYPE_USERNAME, password: System.env.SONATYPE_PASSWORD)
+                        if (isBuildSnapshot) {
+                            snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+                                authentication(userName: System.env.SONATYPE_USERNAME, password: System.env.SONATYPE_PASSWORD)
+                            }
+                        } else {
+                            repository(url: "https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/${System.env.SONATYPE_REPOSITORY_ID}/") {
+                                authentication(userName: System.env.SONATYPE_USERNAME, password: System.env.SONATYPE_PASSWORD)
+                            }
                         }
                     }
                     if(System.getenv('ARTIFACTORY_USERNAME')) {
-                        snapshotRepository(url: "https://repo.grails.org/grails/libs-snapshots-local") {
-                            authentication(userName: System.env.ARTIFACTORY_USERNAME, password: System.env.ARTIFACTORY_PASSWORD)
+                        if (isBuildSnapshot) {
+                            snapshotRepository(url: "https://repo.grails.org/grails/libs-snapshots-local") {
+                                authentication(userName: System.env.ARTIFACTORY_USERNAME, password: System.env.ARTIFACTORY_PASSWORD)
+                            }
+                        } else {
+                            repository(url: "https://repo.grails.org/grails/libs-releases-local") {
+                                authentication(userName: System.env.ARTIFACTORY_USERNAME, password: System.env.ARTIFACTORY_PASSWORD)
+                            }
                         }
                     }
 


### PR DESCRIPTION
@puneetbehl I made the workflow publish snapshot artifacts independently to `s01.oss.sonatype.org` and `repo.grails.org` because the latter keeps failing randomly every now and then with *Internal Server Error*:

```
Execution failed for task ':grails-plugin-filters:uploadPublished'.
> Could not publish configuration 'published'
   > Failed to deploy metadata:
     Could not transfer metadata org.grails:grails-plugin-filters/maven-metadata.xml
     from/to remote (https://repo.grails.org/grails/libs-snapshots-local):
       Failed to transfer file:
       https://repo.grails.org/grails/libs-snapshots-local/org/grails/grails-plugin-filters/maven-metadata.xml.
       Return code is: 500, ReasonPhrase: Internal Server Error.
```