### PR TITLE
feat: Change default controller scope from prototype to singleton

### DIFF
--- a/grails-core/src/main/groovy/org/grails/core/DefaultGrailsControllerClass.java
+++ b/grails-core/src/main/groovy/org/grails/core/DefaultGrailsControllerClass.java
@@ -77,7 +77,7 @@ public class DefaultGrailsControllerClass extends AbstractInjectableGrailsClass 
     public void setGrailsApplication(GrailsApplication grailsApplication) {
         this.grailsApplication = grailsApplication;
         if (this.scope == null) {
-            this.scope = grailsApplication.getConfig().getProperty(Settings.CONTROLLERS_DEFAULT_SCOPE, "prototype");
+            this.scope = grailsApplication.getConfig().getProperty(Settings.CONTROLLERS_DEFAULT_SCOPE, SCOPE_SINGLETON);
         }
     }
 

--- a/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
@@ -16,12 +16,12 @@ class DefaultGrailsControllerClassSpec extends Specification {
         given:
         def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
         def grailsApplication = new DefaultGrailsApplication()
-        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, SINGLETON)
+        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, PROTOTYPE)
         controllerClass.setGrailsApplication(grailsApplication)
 
         expect: "the configuration value is used"
-        controllerClass.getScope() == SINGLETON
-        controllerClass.isSingleton()
+        controllerClass.getScope() == PROTOTYPE
+        !controllerClass.isSingleton()
     }
 
     void "test getScope when scope is not specified on the controller, and not specified in config"() {
@@ -30,35 +30,35 @@ class DefaultGrailsControllerClassSpec extends Specification {
         controllerClass.setGrailsApplication(new DefaultGrailsApplication())
 
         expect: "the default scope is prototype"
-        controllerClass.getScope() == PROTOTYPE
-        !controllerClass.isSingleton()
+        controllerClass.getScope() == SINGLETON
+        controllerClass.isSingleton()
     }
 
     void "test getScope when scope is specified on the controller, and not specified in config"() {
         given:
-        def controllerClass = new DefaultGrailsControllerClass(SingletonController)
+        def controllerClass = new DefaultGrailsControllerClass(PrototypeController)
 
         expect:
-        controllerClass.getScope() == SINGLETON
-        controllerClass.isSingleton()
+        controllerClass.getScope() == PROTOTYPE
+        !controllerClass.isSingleton()
     }
 
     void "test getScope when scope is specified both in the controller and config"() {
         given:
-        def controllerClass = new DefaultGrailsControllerClass(SingletonController)
+        def controllerClass = new DefaultGrailsControllerClass(PrototypeController)
         def grailsApplication = new DefaultGrailsApplication()
-        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, PROTOTYPE)
+        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, SINGLETON)
         controllerClass.setGrailsApplication(grailsApplication)
 
         expect: "controller's setting to have priority"
-        controllerClass.getScope() == SINGLETON
-        controllerClass.isSingleton()
+        controllerClass.getScope() == PROTOTYPE
+        !controllerClass.isSingleton()
     }
 
     class NotSpecifiedController {
     }
 
-    class SingletonController {
-        static scope = "singleton"
+    class PrototypeController {
+        static scope = "prototype"
     }
 }

--- a/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
@@ -11,17 +11,22 @@ class DefaultGrailsControllerClassSpec extends Specification {
 
     static final String SINGLETON = "singleton"
     static final String PROTOTYPE = "prototype"
+    static final String SESSION = "session"
 
-    void "test getScope when scope is not specified on the controller, but it specified in config"() {
+    void "test getScope when scope is not specified on the controller, but it specified in config"(final String configScopeValue) {
         given:
         def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
         def grailsApplication = new DefaultGrailsApplication()
-        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, PROTOTYPE)
+        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, configScopeValue)
         controllerClass.setGrailsApplication(grailsApplication)
 
         expect: "the configuration value is used"
-        controllerClass.getScope() == PROTOTYPE
-        !controllerClass.isSingleton()
+        controllerClass.getScope() == configScopeValue
+        (SINGLETON == configScopeValue) == controllerClass.isSingleton()
+        (SINGLETON != configScopeValue) != controllerClass.isSingleton()
+
+        where:
+        configScopeValue << [SINGLETON, PROTOTYPE, SESSION]
     }
 
     void "test getScope when scope is not specified on the controller, and not specified in config"() {
@@ -29,7 +34,7 @@ class DefaultGrailsControllerClassSpec extends Specification {
         def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
         controllerClass.setGrailsApplication(new DefaultGrailsApplication())
 
-        expect: "the default scope is prototype"
+        expect: "the default scope is singleton"
         controllerClass.getScope() == SINGLETON
         controllerClass.isSingleton()
     }
@@ -43,16 +48,19 @@ class DefaultGrailsControllerClassSpec extends Specification {
         !controllerClass.isSingleton()
     }
 
-    void "test getScope when scope is specified both in the controller and config"() {
+    void "test getScope when scope is specified both in the controller and config"(final String configScopeValue) {
         given:
         def controllerClass = new DefaultGrailsControllerClass(PrototypeController)
         def grailsApplication = new DefaultGrailsApplication()
-        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, SINGLETON)
+        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, configScopeValue)
         controllerClass.setGrailsApplication(grailsApplication)
 
         expect: "controller's setting to have priority"
         controllerClass.getScope() == PROTOTYPE
         !controllerClass.isSingleton()
+
+        where:
+        configScopeValue << [SINGLETON, SESSION]
     }
 
     class NotSpecifiedController {


### PR DESCRIPTION
This feature was rejected for 4.0.x (because it was a breaking change) and was suggested for inclusion in 4.1.x instead.
But it has never been included.

I'm proposing to include it in 6.2.0.

See #11592 and #11595