### PR TITLE
fix(build): Set groovyVersion property in joint workflow

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -27,8 +27,6 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-env:
-  CI_GROOVY_VERSION:
 jobs:
   build_groovy:
     strategy:
@@ -52,11 +50,10 @@ jobs:
       - name: Checkout Groovy 3_0_X (Grails 5 and later)
         if: startsWith(github.ref, 'refs/heads/6.') || startsWith(github.base_ref, '6.') || startsWith(github.ref, 'refs/heads/5.') || startsWith(github.base_ref, '5.')
         run: cd .. && git clone --depth 1 https://github.com/apache/groovy.git -b GROOVY_3_0_X --single-branch
-      - name: Set CI_GROOVY_VERSION for Grails
+      - name: Get Groovy version for Grails
         id: groovy-version
         run: |
           cd ../groovy
-          echo "CI_GROOVY_VERSION=$(cat gradle.properties | grep groovyVersion | cut -d\= -f2 |  tr -d '[:space:]')" >> $GITHUB_ENV
           echo "value=$(cat gradle.properties | grep groovyVersion | cut -d\= -f2 |  tr -d '[:space:]')" >> $GITHUB_OUTPUT
       - name: Prepare GE Set-up Configuration
         id: ge_conf
@@ -136,13 +133,11 @@ jobs:
             ~/groovy
             ~/.m2/repository
           key: cache-local-groovy-maven-${{ github.sha }}
-      - name: Set CI_GROOVY_VERSION for Grails
-        run: |
-          echo "CI_GROOVY_VERSION=${{needs.build_groovy.outputs.groovyVersion}}" >> $GITHUB_ENV
       - name: Build Grails
         id: build_grails
         uses: gradle/gradle-build-action@v2
         env:
+          ORG_GRADLE_PROJECT_groovyVersion: ${{ needs.build_groovy.outputs.groovyVersion }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ apply plugin: 'idea'
 ext {
     isJava8Compatible = org.gradle.api.JavaVersion.current().isJava8Compatible()
     grailsVersion = project.projectVersion
-    groovyVersion = System.getenv('CI_GROOVY_VERSION') ?: project.groovyVersion
     isBuildSnapshot = grailsVersion.endsWith("-SNAPSHOT")
     isReleaseVersion = !isBuildSnapshot
     isCiBuild = System.getenv().get("CI") as Boolean
@@ -232,14 +231,14 @@ if (isReleaseVersion) {
 
 allprojects {
     repositories {
-        mavenLocal()
+        mavenLocal() // Used by the Groovy Joint Validation Github workflow after building groovy locally in CI
         mavenCentral()
-        maven { url "https://repo.grails.org/grails/core" }
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url = "https://repo.grails.org/grails/core" }
+        maven { url = "https://oss.sonatype.org/content/repositories/snapshots/" } // TODO: Is this still used?
         if(groovyVersion.endsWith('-SNAPSHOT')) {
-            maven {
-                name 'JFrog OSS snapshot repo'
-                url 'https://oss.jfrog.org/oss-snapshot-local/'
+            maven { // Used for testing with Groovy snapshots locally
+                name = 'Groovy Snapshot repository'
+                url = 'https://groovy.jfrog.io/artifactory/libs-snapshot-local/'
             }
         }
     }


### PR DESCRIPTION
Currently, CI_GROOVY_VERSION does not make the build properly override the groovy version. This changes the workflow from using CI_GROOVY_VERSION environment variable to overriding groovyVersion property via a Gradle environment variable project property.