### PR TITLE
refactor: Add events-plugin to app dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ cglibVersion=2.2.2
 commonsLangVersion=2.6
 datastoreVersion=8.0.3
 directoryWatcherVersion=0.9.9
+eventsVersion=5.0.2
 gdocEngineVersion=1.0.1
 gradleNexusPluginVersion=2.3.1
 gradleNexusStagingPluginVersion=0.12.0

--- a/grails-dependencies/build.gradle
+++ b/grails-dependencies/build.gradle
@@ -49,12 +49,12 @@ publishing {
                             delegate.artifactId "async"
                             delegate.version asyncVersion
                             delegate.scope "api"
-                            delegate.exclusions {
-                                delegate.exclusion {
-                                    delegate.groupId 'javax'
-                                    delegate.artifactId 'javaee-web-api'
-                                }
-                            }
+                        }
+                        delegate.dependency {
+                            delegate.groupId "org.grails.plugins"
+                            delegate.artifactId "events"
+                            delegate.version eventsVersion
+                            delegate.scope "api"
                         }
                         delegate.dependency {
                             delegate.groupId "org.grails.plugins"


### PR DESCRIPTION
The events-plugin is an essential dependency anticipated to be automatically integrated into Grails applications. Previously, its inclusion relied on the async-plugin, which is not optimal. Separating the responsibility, this commit integrates the events-plugin directly into the dependencies, streamlining the project structure.