### PR TITLE
fix(core): Add explicity type information to method parameters/args

### DIFF
--- a/grails-shell/src/main/groovy/org/grails/cli/GrailsCli.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/GrailsCli.groovy
@@ -27,6 +27,7 @@ import groovy.transform.CompileStatic
 import jline.UnixTerminal
 import jline.console.UserInterruptException
 import jline.console.completer.ArgumentCompleter
+import jline.console.completer.Completer
 import jline.internal.NonBlockingInputStream
 import org.gradle.tooling.BuildActionExecuter
 import org.gradle.tooling.BuildCancelledException
@@ -417,7 +418,7 @@ class GrailsCli {
                 new RegexCompletor("!\\w+"), new EscapingFileNameCompletor())
         )
 
-        completers.addAll((profile.getCompleters(projectContext) ?: []) as Collection)
+        completers.addAll((profile.getCompleters(projectContext) ?: []) as Collection<Completer>)
         consoleReader.addCompleter(aggregateCompleter)
         return console
     }

--- a/grails-shell/src/main/groovy/org/grails/cli/profile/AbstractProfile.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/profile/AbstractProfile.groovy
@@ -166,8 +166,8 @@ abstract class AbstractProfile implements Profile {
                 }
             }
 
-            defaultFeaturesNames.addAll(defaultFeatures)
-            requiredFeatureNames.addAll(requiredFeatures)
+            defaultFeaturesNames.addAll((List<String>) defaultFeatures)
+            requiredFeatureNames.addAll((List<String>) requiredFeatures)
         }
 
 

--- a/grails-web-databinding/src/main/groovy/org/grails/web/databinding/converters/AbstractStructuredBindingEditor.groovy
+++ b/grails-web-databinding/src/main/groovy/org/grails/web/databinding/converters/AbstractStructuredBindingEditor.groovy
@@ -65,7 +65,7 @@ abstract class AbstractStructuredBindingEditor<T> implements TypedStructuredBind
      * @return A Map containing keys and values as described above.
      */
     Map<String, Object> getPropertyValuesMap(String propertyPrefix, DataBindingSource bindingSource) {
-        def valuesMap = [:]
+        Map<String, Object> valuesMap = [:]
         def prefix = propertyPrefix + '_'
         for(String key : bindingSource.propertyNames) {
             if(key.startsWith(prefix) && key.size() > prefix.size()) {


### PR DESCRIPTION
After updating to Apache Groovy 3.0.20, some classes fails to compile due to unable to resolve correct type information. So, we have added explicit type casting information to the method args/parameters.