### PR TITLE
chore(build): Increase MaxMetaspaceSize

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,4 +50,4 @@ viewsVersion=3.1.1
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.daemon=true
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1536M -XX:MaxMetaspaceSize=512M
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1536M -XX:MaxMetaspaceSize=768M


### PR DESCRIPTION
Because the groovydoc task got OutOfMemory java.lang.OutOfMemoryError: Metaspace