### PR TITLE
fix(grailsdoc): update publish guide task configurations

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
@@ -31,7 +31,7 @@ class PublishGuide extends DefaultTask {
     @Optional @Input List propertiesFiles = []
 
     @InputDirectory File sourceDir = new File(project.projectDir, "src")
-    @Optional @InputDirectory File workDir = project.layout.buildDirectory.dir("tmp").get().asFile
+    @Optional @InputDirectory File workDir = project.layout.buildDirectory.get().asFile
     @Optional @InputDirectory File resourcesDir = new File(project.projectDir, "resources")
 
     @Nested Collection macros = []


### PR DESCRIPTION
Use build directory as the workDir for DocPublisher