### PR TITLE
fix(grailsdocs): Update PublishGuide task for grails-doc

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
@@ -36,7 +36,7 @@ class PublishGuide extends DefaultTask {
 
     @Nested Collection macros = []
 
-    @OutputDirectory File targetDir = project.layout.buildDirectory.dir("doc").get().asFile
+    @OutputDirectory File targetDir = project.layout.buildDirectory.dir("docs").get().asFile
 
     @TaskAction
     def publishGuide() {


### PR DESCRIPTION
Fix the PublishGuide task in the grails-doc project to use 'docs' as the output directory name for the grailsdoc submodule instead of 'doc'. This change ensures consistency in directory naming conventions within the grails-doc project.