### PR TITLE
fix(grailsdocs): update custom gradle tasks

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/PdfPublisher.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/PdfPublisher.groovy
@@ -1,11 +1,41 @@
+/* Copyright 2004-2005 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package grails.doc
 
 import groovy.transform.CompileStatic
 import org.w3c.dom.Document
 
+/**
+ * Publishes PDF files from HTML files using the {@link PdfBuilder} class.
+ *
+ * @author Sergio del Amo
+ * @since 3.3.0
+ */
 @CompileStatic
 class PdfPublisher {
 
+    /**
+     * Publishes a PDF from a single HTML file in the same input and output directory. (Deprecated)
+     *
+     * @param outputDir The output directory for the PDF file or the same directory as the HTML file
+     * @param child The relative path to the HTML file within the output directory
+     * @param pdfName The PDF file name (optional)
+     *
+     * @deprecated Use {@link #publishPdfFromHtml(File, File, String, String)} instead
+     */
+    @Deprecated
     static void publishPdfFromHtml(File outputDir, String child, String pdfName) {
         PdfBuilder pdfBuilder = new PdfBuilder()
         File currFile = new File(outputDir, child)
@@ -14,5 +44,28 @@ class PdfPublisher {
         File outputFile = new File(currFile.parentFile, pdfName)
         File urlBase = new File(outputDir, "guide/single.html")
         pdfBuilder.createPdfWithDocument(doc, outputFile, urlBase)
+    }
+
+    /**
+     * Publishes a PDF from a single HTML file
+     *
+     * @param inputDir The input directory for the HTML file
+     * @param outputDir The output directory for the PDF file
+     * @param singleHtmlPath The path to the single HTML file
+     * @param pdfName The relative path to the PDF file within the output directory (optional)
+     */
+    static void publishPdfFromHtml(File inputDir, File outputDir, String singleHtmlPath, String pdfName) {
+        if (pdfName == null) {
+            pdfName = singleHtmlPath.replace(".html", ".pdf")
+        }
+        final PdfBuilder pdfBuilder = new PdfBuilder()
+        File singleHtmlFile = new File(inputDir, singleHtmlPath)
+        final String xml = pdfBuilder.createXml(singleHtmlFile, outputDir.absolutePath)
+        Document doc = pdfBuilder.createDocument(xml)
+        File outputFile = new File(outputDir, pdfName)
+        if (!outputFile.parentFile.exists()) {
+            outputFile.parentFile.mkdirs()
+        }
+        pdfBuilder.createPdfWithDocument(doc, outputFile, singleHtmlFile)
     }
 }

--- a/grails-docs/src/main/groovy/grails/doc/gradle/MigrateLegacyDocs.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/gradle/MigrateLegacyDocs.groovy
@@ -23,9 +23,9 @@ import org.gradle.api.tasks.*
  * a YAML-based table of contents.
  */
 class MigrateLegacyDocs extends DefaultTask {
-    @InputDirectory File guideDir = new File(project.projectDir, "src/guide")
-    @InputDirectory File resourcesDir = new File(project.projectDir, "resources")
-    @OutputDirectory File outputDir = new File(project.projectDir, "src/guide.migrated")
+    @Optional @InputDirectory File guideDir = new File(project.projectDir, "src/guide")
+    @Optional @InputDirectory File resourcesDir = new File(project.projectDir, "resources")
+    @Optional @OutputDirectory File outputDir = new File(project.projectDir, "src/guide.migrated")
 
     @TaskAction
     def migrate() {

--- a/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/gradle/PublishGuide.groovy
@@ -24,16 +24,17 @@ import org.gradle.api.tasks.*
  * Gradle task for generating a gdoc-based HTML user guide.
  */
 class PublishGuide extends DefaultTask {
-    @InputDirectory File sourceDir = new File(project.projectDir, "src")
-    @OutputDirectory File targetDir = new File(project.buildDir, "docs")
-    @InputDirectory @Optional File resourcesDir = new File(project.projectDir, "resources")
-    @Input @Optional List propertiesFiles = []
-    @Input @Optional String language = ""
-    @Input @Optional Boolean asciidoc = false
-    @Input @Optional String sourceRepo
-    @Input @Optional Properties properties = new Properties()
-    @Input @Nested Collection macros = []
-    @OutputDirectory File workDir = project.buildDir as File
+    @Optional @InputDirectory File sourceDir = new File(project.projectDir, "src")
+    @Optional @InputDirectory File resourcesDir = new File(project.projectDir, "resources")
+    @Optional @Input List propertiesFiles = []
+    @Optional @Input String language = ""
+    @Optional @Input Boolean asciidoc = false
+    @Optional @Input String sourceRepo
+    @Optional @Input Properties properties = new Properties()
+    @Optional @Nested Collection macros = []
+
+    @Optional @OutputDirectory File workDir = project.buildDir
+    @Optional @OutputDirectory File targetDir = new File(project.buildDir, "docs")
 
     @TaskAction
     def publishGuide() {

--- a/grails-docs/src/main/groovy/grails/doc/gradle/PublishPdf.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/gradle/PublishPdf.groovy
@@ -14,7 +14,6 @@
  */
 package grails.doc.gradle
 
-import grails.doc.PdfBuilder
 import grails.doc.PdfPublisher
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.*
@@ -25,15 +24,20 @@ import org.gradle.api.tasks.*
  * location.
  */
 class PublishPdf extends DefaultTask {
-    @Input String pdfName = "single.pdf"
-    @Input String language = ""
-    @OutputDirectory @Input File outputDirectory = project.outputDir as File
 
+    @Optional @Input String language = ""
+    @Optional @Input String pdfName = "single.pdf"
+    @Optional @InputDirectory File docsDir = new File(project.buildDir, "/manual")
+    @Optional @OutputDirectory File outputDirectory = new File(project.buildDir, "/manual-pdf")
+
+    /**
+     * Publishes the PDF user guide.
+     */
     @TaskAction
     def publish() {
         File outputDir = new File(outputDirectory, language ?: "")
         try {
-            PdfPublisher.publishPdfFromHtml(outputDir, "guide/single.html", pdfName)
+            PdfPublisher.publishPdfFromHtml(docsDir, outputDir, "guide/single.html", pdfName)
         }
         catch (Exception ex) {
             ex.printStackTrace()

--- a/grails-docs/src/test/groovy/grails/doc/PdfPublisherSpec.groovy
+++ b/grails-docs/src/test/groovy/grails/doc/PdfPublisherSpec.groovy
@@ -5,24 +5,47 @@ import spock.lang.Specification
 class PdfPublisherSpec extends Specification {
 
     void "generate pdf from sample docs"() {
+        given: "sample docs folder, pdf name and html path"
+        String sampleDocsFolderPath = 'src/test/resources/docs'
+        File sampleDocsFolder = new File(sampleDocsFolderPath)
+        String pdfName = 'guide/single.pdf'
+        String singleHtmlPath = "guide/single.html"
+
+        expect: "sample docs folder exists and pdf file does not exist"
+        sampleDocsFolder.exists()
+        !new File("${sampleDocsFolderPath}/${pdfName}").exists()
+
+        when: "generate pdf from sample docs"
+        PdfPublisher.publishPdfFromHtml(sampleDocsFolder, new File("build/manual-pdf"), singleHtmlPath, pdfName)
+
+        then: "pdf file is generated successfully"
+        noExceptionThrown()
+        new File("build/manual-pdf/${pdfName}").exists()
+
+        cleanup: "cleanup pdf file"
+        new File("build/manual-pdf/${pdfName}").delete()
+    }
+
+    void "generate pdf from sample docs with default pdf name"() {
         given:
         String sampleDocsFolderPath = 'src/test/resources/docs'
         File sampleDocsFolder = new File(sampleDocsFolderPath)
-        String pdfName = 'single.pdf'
-        String child = "guide/single.html"
+        String pdfName = null
+        String singleHtmlPath = "guide/single.html"
 
         expect:
         sampleDocsFolder.exists()
-        !new File("${sampleDocsFolderPath}/guide/${pdfName}").exists()
+        !new File("${sampleDocsFolderPath}/guide/single.pdf").exists()
 
         when:
-        PdfPublisher.publishPdfFromHtml(sampleDocsFolder, child, pdfName)
+        PdfPublisher.publishPdfFromHtml(sampleDocsFolder, new File("build/manual-pdf"), singleHtmlPath, pdfName)
 
         then:
         noExceptionThrown()
-        new File("${sampleDocsFolderPath}/guide/${pdfName}").exists()
+        new File("build/manual-pdf/guide/single.pdf").exists()
 
         cleanup:
-        new File("${sampleDocsFolderPath}/guide/${pdfName}").delete()
+        new File("build/manual-pdf/guide/single.pdf").delete()
     }
+
 }


### PR DESCRIPTION
* Correctly configure Gradle task Input or Output annotations.
* Add a new method to PdfPublisher, i.e. publishPdfFromHtml with more clear parameters, and deprecate the previous method.
* Update PdfPublisherSpec