### PR TITLE
Patch decouple Gradle

### DIFF
--- a/grails-bootstrap/build.gradle
+++ b/grails-bootstrap/build.gradle
@@ -1,8 +1,8 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 dependencies {
-    api ( "org.apache.groovy:groovy-xml:$groovyVersion" )
-    api ( "org.apache.groovy:groovy-templates:$groovyVersion" )
+    implementation ( "org.apache.groovy:groovy-xml:$groovyVersion" )
+    implementation ( "org.apache.groovy:groovy-templates:$groovyVersion" )
     api "org.yaml:snakeyaml:$snakeyamlVersion"
     api "io.micronaut:micronaut-inject:$micronautVersion"
     
@@ -13,7 +13,6 @@ dependencies {
 
     // Ant
     compileOnly "org.apache.groovy:groovy-ant:$groovyVersion"
-
     testImplementation("org.fusesource.jansi:jansi:$jansiVersion")
     testImplementation("jline:jline:$jlineVersion")
 

--- a/grails-spring/build.gradle
+++ b/grails-spring/build.gradle
@@ -16,4 +16,5 @@ dependencies {
 
         exclude group:"org.codehaus.gant", module:"gant_groovy1.8"
     }
+    api ( "org.apache.groovy:groovy-xml:$groovyVersion" )
 }


### PR DESCRIPTION
This decouples the gradle plugin from transitively requiring groovy 4. groovy 3 still is compatible as a compiled 4 runtime so this allows them to live next to eachother for groovy 4 transition.