### PR TITLE
ci: Remove `GH_TOKEN` from `actions/checkout`

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,8 +45,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
       - name: Set up JDK 17
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:


### PR DESCRIPTION
This commit tries to address the issue of snapshots not being published by removing the use of `GH_TOKEN` during the repository checkout process in the workflow file.

The error message is: "Error: fatal: could not read Username for 'https://github.com': terminal prompts disabled", when `actions/checkout@v4` does git fetch.