### PR TITLE
ci: Fix release notes github workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -24,36 +24,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Check if it has release drafter config file
-        id: check_release_drafter
-        run: |
-          has_release_drafter=$([ -f .github/release-drafter.yml ] && echo "true" || echo "false")
-          echo "has_release_drafter=${has_release_drafter}" >> $GITHUB_OUTPUT
-      - name: Extract branch name
-        id: extract_branch
-        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-      # If it has release drafter:
       - uses: release-drafter/release-drafter@v6
-        if: steps.check_release_drafter.outputs.has_release_drafter == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Otherwise:
-      - name: Export Gradle Properties
-        if: steps.check_release_drafter.outputs.has_release_drafter == 'false'
-        uses: micronaut-projects/github-actions/export-gradle-properties@master
-      - uses: micronaut-projects/github-actions/release-notes@master
-        if: steps.check_release_drafter.outputs.has_release_drafter == 'false'
-        id: release_notes
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-      - uses: ncipollo/release-action@v1
-        if: steps.check_release_drafter.outputs.has_release_drafter == 'false' && steps.release_notes.outputs.generated_changelog == 'true'
-        with:
-          allowUpdates: true
-          commit: ${{ steps.release_notes.outputs.current_branch }}
-          draft: true
-          name: ${{ env.title }} ${{ steps.release_notes.outputs.next_version }}
-          tag: v${{ steps.release_notes.outputs.next_version }}
-          bodyFile: CHANGELOG.md
-          token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -24,6 +24,12 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - name: Extract branch name
+        id: extract_branch
+        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitish: ${{ steps.extract_branch.outputs.value }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -9,13 +9,19 @@ on:
       - '[3-9]+.[3-9]+.x'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  pull_request_target:
-    types: [opened, reopened, synchronize, labeled]
+#  pull_request_target:
+#    types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
-  release_notes:
+  update_release_draft:
     permissions:
-      contents: read
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +37,7 @@ jobs:
       - uses: release-drafter/release-drafter@v6
         if: steps.check_release_drafter.outputs.has_release_drafter == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Otherwise:
       - name: Export Gradle Properties
         if: steps.check_release_drafter.outputs.has_release_drafter == 'false'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -8,7 +8,7 @@ on:
       - '[4-9]+.[0-9]+.x'
       - '[3-9]+.[3-9]+.x'
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
 #  pull_request_target:
 #    types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:


### PR DESCRIPTION
This commit tries to address an issue with the release notes github workflow not working.

Error messages are `Invalid config file` and `Http Status 401: Bad credentials`

I have tried to follow the README at https://github.com/release-drafter/release-drafter