### PR TITLE
Revert "Temporary - Patch GROOVY_3_0_X until https://github.com/apach…

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -51,7 +51,7 @@ jobs:
           key: cache-local-groovy-maven-${{ github.sha }}
       - name: Checkout Groovy 3_0_X (Grails 5 and later)
         if: startsWith(github.ref, 'refs/heads/6.') || startsWith(github.base_ref, '6.') || startsWith(github.ref, 'refs/heads/5.') || startsWith(github.base_ref, '5.')
-        run: cd .. && git clone --depth 1 https://github.com/apache/groovy.git -b GROOVY_3_0_X --single-branch && sed -i '/maven { url /s|^//||' groovy/build.gradle
+        run: cd .. && git clone --depth 1 https://github.com/apache/groovy.git -b GROOVY_3_0_X --single-branch
       - name: Set CI_GROOVY_VERSION for Grails
         id: groovy-version
         run: |


### PR DESCRIPTION
…e/groovy/pull/2103 is merged"

This reverts commit 49eb631bc29fa157663e6b6bc422a1cb58b1a88a.

As the problem with the Groovy build is now patched, this workaround can be removed.

Related: #13578, apache/groovy#2103