### PR TITLE
Update PublishGuide to use Gradle AntBuilder

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/DocPublisher.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/DocPublisher.groovy
@@ -21,14 +21,14 @@ import groovy.io.FileType
 import groovy.text.Template
 
 import org.apache.commons.logging.LogFactory
+import org.gradle.api.internal.project.ant.BasicAntBuilder
 import org.radeox.api.engine.WikiRenderEngine
 import org.radeox.engine.context.BaseInitialRenderContext
 import org.radeox.engine.context.BaseRenderContext
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
-
-import java.util.regex.Pattern
+import org.gradle.api.AntBuilder
 
 /**
  * Coordinated the DocEngine the produce documentation based on the gdoc format.
@@ -517,7 +517,7 @@ class DocPublisher {
             apiDir = target
         }
         if (!ant) {
-            ant = new AntBuilder()
+            ant = new BasicAntBuilder()
         }
         def metaProps = DocPublisher.metaClass.properties
         Properties props


### PR DESCRIPTION
instead of deprecated version from Groovy

required for https://github.com/grails/grails-async/pull/140