### PR TITLE
Decouple grails-plugin-controllers from Sitemesh

### DIFF
--- a/grails-plugin-controllers/build.gradle
+++ b/grails-plugin-controllers/build.gradle
@@ -6,7 +6,6 @@ dependencies {
             project(':grails-plugin-domain-class')
 
     api("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
-    api "org.grails:grails-web-sitemesh:$gspVersion"
     runtimeOnly project(':grails-plugin-i18n')
 
     testRuntimeOnly "jline:jline:$jlineVersion"

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -37,7 +37,7 @@ import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.servlet.mvc.exceptions.ControllerExecutionException
 import org.grails.web.servlet.view.CompositeViewResolver
 import org.grails.web.servlet.view.GroovyPageView
-import org.grails.web.sitemesh.GroovyPageLayoutFinder
+import org.grails.plugins.web.controllers.ControllersGrailsPlugin
 import org.grails.web.util.GrailsApplicationAttributes
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -296,7 +296,7 @@ trait ResponseRenderer extends WebAttributes {
                 }
 
 
-                boolean renderWithLayout = (explicitSiteMeshLayout || webRequest.getCurrentRequest().getAttribute(GroovyPageLayoutFinder.LAYOUT_ATTRIBUTE))
+                boolean renderWithLayout = (explicitSiteMeshLayout || webRequest.getCurrentRequest().getAttribute(ControllersGrailsPlugin.LAYOUT_ATTRIBUTE))
                 // if automatic decoration occurred unwrap, since this is a partial
 
                 if (renderWithLayout) {
@@ -533,13 +533,13 @@ trait ResponseRenderer extends WebAttributes {
     }
 
     private void applySiteMeshLayout(HttpServletRequest request, boolean renderView, String explicitSiteMeshLayout) {
-        if(explicitSiteMeshLayout == null && request.getAttribute(GroovyPageLayoutFinder.LAYOUT_ATTRIBUTE) != null) {
+        if(explicitSiteMeshLayout == null && request.getAttribute(ControllersGrailsPlugin.LAYOUT_ATTRIBUTE) != null) {
             // layout has been set already
             return
         }
-        String siteMeshLayout = explicitSiteMeshLayout != null ? explicitSiteMeshLayout : (renderView ? null : GroovyPageLayoutFinder.NONE_LAYOUT)
+        String siteMeshLayout = explicitSiteMeshLayout != null ? explicitSiteMeshLayout : (renderView ? null : ControllersGrailsPlugin.NONE_LAYOUT)
         if(siteMeshLayout != null) {
-            request.setAttribute GroovyPageLayoutFinder.LAYOUT_ATTRIBUTE, siteMeshLayout
+            request.setAttribute ControllersGrailsPlugin.LAYOUT_ATTRIBUTE, siteMeshLayout
         }
     }
 

--- a/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
@@ -63,6 +63,11 @@ class ControllersGrailsPlugin extends Plugin {
     def observe = ['domainClass']
     def dependsOn = [core: version, i18n: version, urlMappings: version]
 
+    // Although they are specific to Sitemesh, these properties need
+    // a new home that is not coupled to any sitemesh dependency
+    static final String LAYOUT_ATTRIBUTE = "org.grails.layout.name";
+    static final String NONE_LAYOUT = "_none_";
+
     @Override
     Closure doWithSpring(){ { ->
         def application = grailsApplication

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RenderDynamicMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RenderDynamicMethodTests.groovy
@@ -1,7 +1,7 @@
 package org.grails.web.servlet.mvc
 
+import org.grails.plugins.web.controllers.ControllersGrailsPlugin
 import grails.testing.web.controllers.ControllerUnitTest
-import org.grails.web.sitemesh.GroovyPageLayoutFinder
 import spock.lang.Specification
 import grails.artefact.Artefact
 import org.grails.buffer.FastStringWriter
@@ -15,7 +15,7 @@ class RenderDynamicMethodTests extends Specification implements ControllerUnitTe
         then:
         response.contentType == response.contentType
         response.contentAsString == response.contentAsString
-        request.getAttribute(GroovyPageLayoutFinder.LAYOUT_ATTRIBUTE) == "bar"
+        request.getAttribute(ControllersGrailsPlugin.LAYOUT_ATTRIBUTE) == "bar"
     }
 
     void testRenderView() {

--- a/grails-web-mvc/build.gradle
+++ b/grails-web-mvc/build.gradle
@@ -1,8 +1,4 @@
 dependencies {
     api project(":grails-web-common"),
-            project(":grails-web-url-mappings")
-
-    compileOnly "org.grails:grails-web-sitemesh:$gspVersion", {
-        exclude group:'org.grails', module:'grails-web-common'
-    }
+        project(":grails-web-url-mappings")
 }


### PR DESCRIPTION
Fixes #13623  - These changes make controllers independent of Sitemesh

Moved these attributes from [ResponseRenderer.groovy](https://github.com/grails/grails-core/blob/7.0.x/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy)
```groovy
    static final String LAYOUT_ATTRIBUTE = "org.grails.layout.name";
    static final String NONE_LAYOUT = "_none_";
```

to [ControllersGrailsPlugin.groovy](https://github.com/grails/grails-core/blob/7.0.x/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy)

Any recommendations for a different location?