### PR TITLE
Support controller attribute in tags with resource attribute and resolve correct identity Fixes #13627

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -292,14 +292,17 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
     @CompileStatic(TypeCheckingMode.SKIP)
     protected String getResourceId(resourceAttribute) {
         try {
-            // Alternative is to check instanceof GormEntity, but that would require coupling
-            // web-common to grails-datastore-gorm
-            def ident = resourceAttribute.ident().toString()
+            // Three options for using indent():
+            // 1. Check instanceof GormEntity, but that would require coupling web-common to grails-datastore-gorm
+            // 2. GrailsMetaClassUtils.invokeMethodIfExists(o, "ident", new Object[0]); Slow?
+            // 3. Just assuming resource is a GormEntity and catching an exception if it is not.
+            def ident = resourceAttribute.ident()
             if (ident) {
                 return ident.toString()
             }
         } catch (MissingMethodException | IllegalStateException e) {
             // An IllegalStateException occurs if GORM is not initialized.
+            // A MissingMethodException if it is not a GormEntity
         }
 
         final id = resourceAttribute.id

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -291,6 +291,17 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
 
     @CompileStatic(TypeCheckingMode.SKIP)
     protected String getResourceId(resourceAttribute) {
+        try {
+            // Alternative is to check instanceof GormEntity, but that would require coupling
+            // web-common to grails-datastore-gorm
+            def ident = resourceAttribute.ident().toString()
+            if (ident) {
+                return ident.toString()
+            }
+        } catch (MissingMethodException | IllegalStateException e) {
+            // An IllegalStateException occurs if GORM is not initialized.
+        }
+
         final id = resourceAttribute.id
         if (id) {
             return id.toString()

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 SpringSource
+ * Copyright 2011-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -300,7 +300,7 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
             if (ident) {
                 return ident.toString()
             }
-        } catch (MissingMethodException | IllegalStateException e) {
+        } catch (MissingMethodException | IllegalStateException ignored) {
             // An IllegalStateException occurs if GORM is not initialized.
             // A MissingMethodException if it is not a GormEntity
         }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -295,7 +295,7 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
             // Three options for using indent():
             // 1. Check instanceof GormEntity, but that would require coupling web-common to grails-datastore-gorm
             // 2. GrailsMetaClassUtils.invokeMethodIfExists(o, "ident", new Object[0]); Slow?
-            // 3. Just assuming resource is a GormEntity and catching an exception if it is not.
+            // 3. Just assuming resource is a GormEntity or has ident() implemented and catching an exception if it is not.
             def ident = resourceAttribute.ident()
             if (ident) {
                 return ident.toString()

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -189,7 +189,7 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
                         }
                     }
                     List tokens = resource.contains('/') ?  resource.tokenize('/') :[resource]
-                    controller = tokens[-1]
+                    controller = controllerAttribute?:tokens[-1]
                     if (tokens.size()>1) {
                         for(t in tokens[0..-2]) {
                             final key = "${t}Id".toString()

--- a/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/LinkGeneratorSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/LinkGeneratorSpec.groovy
@@ -290,7 +290,7 @@ class LinkGeneratorSpec extends Specification {
             cacheKey == "somePrefix[resource:org.grails.web.mapping.Widget->2]"
     }
 
-    //
+    @Issue('https://github.com/grails/grails-core/issues/13627')
     def 'resource links should use ident and allow controller override'() {
         given:
         final webRequest = GrailsWebMockUtil.bindMockWebRequest()

--- a/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/LinkGeneratorSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/LinkGeneratorSpec.groovy
@@ -301,7 +301,7 @@ class LinkGeneratorSpec extends Specification {
         linkParams.resource = new Widget(id: 1, name: 'Some Widget')
 
         then:
-        link == "/bar/widget/1/show"
+        link == "/bar/widget/show/1"
 
         then:
         linkParams.resource.identCalled
@@ -310,7 +310,7 @@ class LinkGeneratorSpec extends Specification {
         linkParams.controller = 'widgetAdmin'
 
         then:
-        link == "/bar/widgetAdmin/1/show"
+        link == "/bar/widgetAdmin/show/1"
     }
 
     def 'link should take into affect namespace'() {
@@ -366,7 +366,7 @@ class LinkGeneratorSpec extends Specification {
         final callable = { String controller, String action, String namespace, String pluginName, String httpMethod, Map params ->
             [createRelativeURL: { String c, String a, String n, String p, Map parameterValues, String encoding, String fragment ->
 
-                "${namespace ? '/' + namespace : ''}/$controller${parameterValues.id? '/'+parameterValues.id:''}/$action".toString()
+                "${namespace ? '/' + namespace : ''}/$controller/$action${parameterValues.id? '/'+parameterValues.id:''}".toString()
             }] as UrlCreator
         }
         generator.grailsUrlConverter = new CamelCaseUrlConverter()

--- a/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/LinkGeneratorSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/LinkGeneratorSpec.groovy
@@ -1,5 +1,6 @@
 package org.grails.web.mapping
 
+import grails.artefact.Artefact
 import grails.core.DefaultGrailsApplication
 import grails.plugins.DefaultGrailsPluginManager
 import grails.util.GrailsWebMockUtil
@@ -289,6 +290,29 @@ class LinkGeneratorSpec extends Specification {
             cacheKey == "somePrefix[resource:org.grails.web.mapping.Widget->2]"
     }
 
+    //
+    def 'resource links should use ident and allow controller override'() {
+        given:
+        final webRequest = GrailsWebMockUtil.bindMockWebRequest()
+        MockHttpServletRequest request = webRequest.currentRequest
+        linkParams.method = 'GET'
+
+        when: 'a resource is specified, ident() is used for id'
+        linkParams.resource = new Widget(id: 1, name: 'Some Widget')
+
+        then:
+        link == "/bar/widget/1/show"
+
+        then:
+        linkParams.resource.identCalled
+
+        when: "A controller is specified"
+        linkParams.controller = 'widgetAdmin'
+
+        then:
+        link == "/bar/widgetAdmin/1/show"
+    }
+
     def 'link should take into affect namespace'() {
         given:
         final webRequest = GrailsWebMockUtil.bindMockWebRequest()
@@ -341,7 +365,8 @@ class LinkGeneratorSpec extends Specification {
         def generator = cache ? new CachingLinkGenerator(baseUrl, context) : new DefaultLinkGenerator(baseUrl, context)
         final callable = { String controller, String action, String namespace, String pluginName, String httpMethod, Map params ->
             [createRelativeURL: { String c, String a, String n, String p, Map parameterValues, String encoding, String fragment ->
-                "${namespace ? '/' + namespace : ''}/$controller/$action".toString()
+
+                "${namespace ? '/' + namespace : ''}/$controller${parameterValues.id? '/'+parameterValues.id:''}/$action".toString()
             }] as UrlCreator
         }
         generator.grailsUrlConverter = new CamelCaseUrlConverter()
@@ -381,11 +406,14 @@ class LinkGeneratorSpec extends Specification {
     }
 }
 
+@Artefact('Domain')
 class Widget {
     Long id
     String name
+    boolean identCalled = false
     
     Long ident() {
+        identCalled = true
         id
     }
     


### PR DESCRIPTION
#13627

Fixes the following
```gsp
<g:link method="GET" resource="user" controller="userAdmin"></g:link>
```

which should link to `/userAdmin/show/1`

but instead renders `/user/show/1`

Also fixes 
```groovy
class Sample {
    Long uniqueId
    static mapping {
        id: name: 'uniqueId'
    }
}
```

Currently (bug) grails creates a link to `/sample/index` for this class instead of `/sample/${sample.indent()}/show` because it does not have an id property and uses a static id mapping.

### Design Assumptions

If a resource is a [`PersistentEntity`](https://github.com/grails/grails-data-mapping/blob/9.0.x/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/PersistentEntity.java) or a [`Domain` Artifact](https://github.com/grails/grails-core/blob/7.0.x/grails-core/src/main/groovy/org/grails/core/artefact/DomainClassArtefactHandler.java) an attempt to call `ident()` is made, otherwise a MethodMissing exception occurs and a fallback to the id property is used.   

### Reason for Incorrect Behavior

The following code is where it is problematic
https://github.com/grails/grails-core/blob/da8668daa13c9c1b2157535e11986f49615e8a4b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy#L174-L189


and is correctly handled here:
https://github.com/grails/grails-core/blob/da8668daa13c9c1b2157535e11986f49615e8a4b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/CachingLinkGenerator.java#L120-L139

https://github.com/grails/grails-core/blob/0daf7c69f98cd3f2f25ad990b52e005f7c976f5a/grails-core/src/main/groovy/grails/util/GrailsMetaClassUtils.java#L241-L248
