### PR TITLE
Remove installToHomeDist Upload task to fix PublishToMavenLocal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -417,15 +417,7 @@ subprojects { project ->
             shouldRunAfter(tasks.withType(Sign))
         }
 
-        tasks.register("installToHomeDist", Upload) {
-            configuration = configurations.archives
-            repositories {
-                flatDir name: 'libs', dirs: distInstallDir
-            }
-        }
-
         tasks.withType(PublishToMavenLocal).configureEach {
-            dependsOn installToHomeDist
             doLast {
                 ant.copy(todir: homeDistDir, flatten: true, includeEmptyDirs: false) {
                     fileset dir: distInstallDir


### PR DESCRIPTION
The `Upload` task is invalid in Gradle 8.x.  

`tasks.withType(PublishToMavenLocal) {}` already handles all necessary configuration for `PublishToMavenLocal`.  

`flatDir name: 'libs'` is no longer used in this project.