### PR TITLE
Support multiple messageSource beans

### DIFF
--- a/grails-core/src/main/groovy/grails/util/GrailsMessageSource.groovy
+++ b/grails-core/src/main/groovy/grails/util/GrailsMessageSource.groovy
@@ -1,7 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package grails.util
 
+import groovy.transform.CompileStatic
 import org.springframework.context.MessageSource
 
+
+/**
+ * A simple class that selects a single {@link  org.springframework.context.MessageSource  MessageSource}
+ * when two or more are present in the ApplicationContext.
+ * It defaults to the Grails or Spring Message Source, if present.
+ *
+ * @author James Fredley
+ * @since 7.0
+ */
+
+@CompileStatic
 class GrailsMessageSource {
     static MessageSource getMessageSource(List<MessageSource> messageSources){
         if(!messageSources) {
@@ -12,16 +40,18 @@ class GrailsMessageSource {
             return messageSources.get(0)
         }
 
-        messageSources.each { messageSource ->
+        MessageSource firstGrailsSpring = messageSources.find {messageSource ->
             String className = messageSource.class.name
-            // use the grails or spring message source
-            if(className.startsWith("org.grails") || className.startsWith("grails")
-                    || className.startsWith("org.springframework")) {
-                return messageSource
-            }
+            // use the first Grails or Spring mMessageSource
+            className.startsWith("org.grails") || className.startsWith("grails") || className.startsWith("org.springframework")
         }
 
-        //return the first message source
+        // return the first Grails or Spring MessageSource
+        if(firstGrailsSpring) {
+            return firstGrailsSpring
+        }
+
+        // return the first MessageSource from the list
         return messageSources.get(0)
     }
 }

--- a/grails-core/src/main/groovy/grails/util/GrailsMessageSource.groovy
+++ b/grails-core/src/main/groovy/grails/util/GrailsMessageSource.groovy
@@ -1,0 +1,27 @@
+package grails.util
+
+import org.springframework.context.MessageSource
+
+class GrailsMessageSource {
+    static MessageSource getMessageSource(List<MessageSource> messageSources){
+        if(!messageSources) {
+            return null
+        }
+
+        if(messageSources.size() == 1) {
+            return messageSources.get(0)
+        }
+
+        messageSources.each { messageSource ->
+            String className = messageSource.class.name
+            // use the grails or spring message source
+            if(className.startsWith("org.grails") || className.startsWith("grails")
+                    || className.startsWith("org.springframework")) {
+                return messageSource
+            }
+        }
+
+        //return the first message source
+        return messageSources.get(0)
+    }
+}

--- a/grails-core/src/main/groovy/grails/util/GrailsMessageSource.groovy
+++ b/grails-core/src/main/groovy/grails/util/GrailsMessageSource.groovy
@@ -23,7 +23,7 @@ import org.springframework.context.MessageSource
 /**
  * A simple class that selects a single {@link  org.springframework.context.MessageSource  MessageSource}
  * when two or more are present in the ApplicationContext.
- * It defaults to the Grails or Spring Message Source, if present.
+ * It defaults to the Grails or Spring {@link  org.springframework.context.MessageSource  MessageSource}, if present.
  *
  * @author James Fredley
  * @since 7.0

--- a/grails-core/src/main/groovy/grails/util/GrailsMessageSource.groovy
+++ b/grails-core/src/main/groovy/grails/util/GrailsMessageSource.groovy
@@ -42,7 +42,7 @@ class GrailsMessageSource {
 
         MessageSource firstGrailsSpring = messageSources.find {messageSource ->
             String className = messageSource.class.name
-            // use the first Grails or Spring mMessageSource
+            // use the first Grails or Spring MessageSource
             className.startsWith("org.grails") || className.startsWith("grails") || className.startsWith("org.springframework")
         }
 

--- a/grails-core/src/main/groovy/grails/util/GrailsMessageSourceUtils.groovy
+++ b/grails-core/src/main/groovy/grails/util/GrailsMessageSourceUtils.groovy
@@ -30,8 +30,8 @@ import org.springframework.context.MessageSource
  */
 
 @CompileStatic
-class GrailsMessageSource {
-    static MessageSource getMessageSource(List<MessageSource> messageSources){
+class GrailsMessageSourceUtils {
+    static MessageSource findPreferredMessageSource(List<MessageSource> messageSources){
         if(!messageSources) {
             return null
         }

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -1,6 +1,7 @@
 package org.grails.plugins.domain.support
 
 import grails.core.GrailsApplication
+import grails.util.GrailsMessageSource
 import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluator
 import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
@@ -14,9 +15,16 @@ import org.springframework.context.MessageSource
 
 class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEvaluator> {
 
-    @Autowired
-    @Qualifier("pluginAwareResourceBundleMessageSource")
     MessageSource messageSource
+
+    @Autowired
+    setMessageSource(List<MessageSource> messageSources) {
+        messageSource = GrailsMessageSource.getMessageSource(messageSources)
+    }
+
+    void setMessageSource(MessageSource messageSource) {
+        this.messageSource = messageSource
+    }
 
     @Autowired
     @Qualifier('grailsDomainClassMappingContext')

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -1,7 +1,7 @@
 package org.grails.plugins.domain.support
 
 import grails.core.GrailsApplication
-import grails.util.GrailsMessageSource
+import grails.util.GrailsMessageSourceUtils
 import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluator
 import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
@@ -19,7 +19,7 @@ class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEv
 
     @Autowired
     setMessageSource(List<MessageSource> messageSources) {
-        setMessageSource(GrailsMessageSource.getMessageSource(messageSources))
+        setMessageSource(GrailsMessageSourceUtils.findPreferredMessageSource(messageSources))
     }
 
     void setMessageSource(MessageSource messageSource) {

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -19,7 +19,7 @@ class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEv
 
     @Autowired
     setMessageSource(List<MessageSource> messageSources) {
-        messageSource = GrailsMessageSource.getMessageSource(messageSources)
+        setMessageSource(GrailsMessageSource.getMessageSource(messageSources))
     }
 
     void setMessageSource(MessageSource messageSource) {

--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/errors/AbstractVndErrorRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/errors/AbstractVndErrorRenderer.groovy
@@ -17,14 +17,13 @@ package grails.rest.render.errors
 
 import grails.rest.render.ContainerRenderer
 import grails.util.Environment
-import grails.util.GrailsMessageSource
+import grails.util.GrailsMessageSourceUtils
 import grails.util.GrailsNameUtils
 import grails.util.GrailsWebUtil
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import grails.web.mapping.LinkGenerator
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.MessageSource
 import org.springframework.validation.Errors
 import org.springframework.validation.ObjectError
@@ -52,7 +51,7 @@ abstract class AbstractVndErrorRenderer  implements ContainerRenderer<Errors, Ob
 
     @Autowired
     setMessageSource(List<MessageSource> messageSources) {
-        setMessageSource(GrailsMessageSource.getMessageSource(messageSources))
+        setMessageSource(GrailsMessageSourceUtils.findPreferredMessageSource(messageSources))
     }
 
     void setMessageSource(MessageSource messageSource) {

--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/errors/AbstractVndErrorRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/errors/AbstractVndErrorRenderer.groovy
@@ -17,6 +17,7 @@ package grails.rest.render.errors
 
 import grails.rest.render.ContainerRenderer
 import grails.util.Environment
+import grails.util.GrailsMessageSource
 import grails.util.GrailsNameUtils
 import grails.util.GrailsWebUtil
 import groovy.transform.CompileStatic
@@ -47,9 +48,16 @@ abstract class AbstractVndErrorRenderer  implements ContainerRenderer<Errors, Ob
     boolean absoluteLinks = true
     boolean prettyPrint = Environment.isDevelopmentMode()
 
-    @Autowired
-    @Qualifier("pluginAwareResourceBundleMessageSource")
     MessageSource messageSource
+
+    @Autowired
+    setMessageSource(List<MessageSource> messageSources) {
+        messageSource = GrailsMessageSource.getMessageSource(messageSources)
+    }
+
+    void setMessageSource(MessageSource messageSource) {
+        this.messageSource = messageSource
+    }
 
     @Autowired
     LinkGenerator linkGenerator

--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/errors/AbstractVndErrorRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/errors/AbstractVndErrorRenderer.groovy
@@ -52,7 +52,7 @@ abstract class AbstractVndErrorRenderer  implements ContainerRenderer<Errors, Ob
 
     @Autowired
     setMessageSource(List<MessageSource> messageSources) {
-        messageSource = GrailsMessageSource.getMessageSource(messageSources)
+        setMessageSource(GrailsMessageSource.getMessageSource(messageSources))
     }
 
     void setMessageSource(MessageSource messageSource) {

--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
@@ -23,7 +23,7 @@ import grails.rest.render.AbstractIncludeExcludeRenderer
 import grails.rest.render.RenderContext
 import grails.rest.render.RendererRegistry
 import grails.util.Environment
-import grails.util.GrailsMessageSource
+import grails.util.GrailsMessageSourceUtils
 import grails.util.GrailsWebUtil
 import grails.web.mapping.LinkGenerator
 import grails.web.mime.MimeType
@@ -66,7 +66,7 @@ abstract class AbstractLinkingRenderer<T> extends AbstractIncludeExcludeRenderer
 
     @Autowired
     setMessageSource(List<MessageSource> messageSources) {
-        setMessageSource(GrailsMessageSource.getMessageSource(messageSources))
+        setMessageSource(GrailsMessageSourceUtils.findPreferredMessageSource(messageSources))
     }
 
     void setMessageSource(MessageSource messageSource) {

--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
@@ -66,7 +66,7 @@ abstract class AbstractLinkingRenderer<T> extends AbstractIncludeExcludeRenderer
 
     @Autowired
     setMessageSource(List<MessageSource> messageSources) {
-        messageSource = GrailsMessageSource.getMessageSource(messageSources)
+        setMessageSource(GrailsMessageSource.getMessageSource(messageSources))
     }
 
     void setMessageSource(MessageSource messageSource) {

--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
@@ -23,6 +23,7 @@ import grails.rest.render.AbstractIncludeExcludeRenderer
 import grails.rest.render.RenderContext
 import grails.rest.render.RendererRegistry
 import grails.util.Environment
+import grails.util.GrailsMessageSource
 import grails.util.GrailsWebUtil
 import grails.web.mapping.LinkGenerator
 import grails.web.mime.MimeType
@@ -61,9 +62,16 @@ abstract class AbstractLinkingRenderer<T> extends AbstractIncludeExcludeRenderer
     public static final String TEMPLATED_ATTRIBUTE = 'templated'
     public static final String DEPRECATED_ATTRIBUTE = 'deprecated'
 
-    @Autowired
-    @Qualifier("pluginAwareResourceBundleMessageSource")
     MessageSource messageSource
+
+    @Autowired
+    setMessageSource(List<MessageSource> messageSources) {
+        messageSource = GrailsMessageSource.getMessageSource(messageSources)
+    }
+
+    void setMessageSource(MessageSource messageSource) {
+        this.messageSource = messageSource
+    }
 
     @Autowired
     LinkGenerator linkGenerator

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -21,7 +21,7 @@ import grails.databinding.converters.FormattedValueConverter
 import grails.databinding.converters.ValueConverter
 import grails.databinding.events.DataBindingListener
 import grails.util.GrailsClassUtils
-import grails.util.GrailsMessageSource
+import grails.util.GrailsMessageSourceUtils
 import grails.util.GrailsMetaClassUtils
 import grails.util.GrailsNameUtils
 import grails.validation.DeferredBindingActions
@@ -643,7 +643,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
 
     @Autowired
     setMessageSource(List<MessageSource> messageSources) {
-        setMessageSource(GrailsMessageSource.getMessageSource(messageSources))
+        setMessageSource(GrailsMessageSourceUtils.findPreferredMessageSource(messageSources))
     }
 
     void setMessageSource(MessageSource messageSource) {

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -643,7 +643,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
 
     @Autowired
     setMessageSource(List<MessageSource> messageSources) {
-        messageSource = GrailsMessageSource.getMessageSource(messageSources)
+        setMessageSource(GrailsMessageSource.getMessageSource(messageSources))
     }
 
     void setMessageSource(MessageSource messageSource) {

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -20,8 +20,8 @@ import grails.databinding.*
 import grails.databinding.converters.FormattedValueConverter
 import grails.databinding.converters.ValueConverter
 import grails.databinding.events.DataBindingListener
-import grails.util.Environment
 import grails.util.GrailsClassUtils
+import grails.util.GrailsMessageSource
 import grails.util.GrailsMetaClassUtils
 import grails.util.GrailsNameUtils
 import grails.validation.DeferredBindingActions
@@ -46,13 +46,11 @@ import org.grails.datastore.mapping.model.types.OneToMany
 import org.grails.datastore.mapping.model.types.OneToOne
 import org.grails.datastore.mapping.model.types.Simple
 import org.grails.web.databinding.DataBindingEventMulticastListener
-import org.grails.web.databinding.DefaultASTDatabindingHelper
 import org.grails.web.databinding.GrailsWebDataBindingListener
 import org.grails.web.databinding.SpringConversionServiceAdapter
 import org.grails.web.databinding.converters.ByteArrayMultipartFileValueConverter
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.MessageSource
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.BindingResult
@@ -60,8 +58,6 @@ import org.springframework.validation.FieldError
 import org.springframework.validation.ObjectError
 
 import java.lang.annotation.Annotation
-import java.lang.reflect.Modifier
-import java.util.concurrent.ConcurrentHashMap
 
 import static grails.web.databinding.DataBindingUtils.*
 
@@ -646,7 +642,10 @@ class GrailsWebDataBinder extends SimpleDataBinder {
     }
 
     @Autowired
-    @Qualifier("pluginAwareResourceBundleMessageSource")
+    setMessageSource(List<MessageSource> messageSources) {
+        messageSource = GrailsMessageSource.getMessageSource(messageSources)
+    }
+
     void setMessageSource(MessageSource messageSource) {
         this.messageSource = messageSource
     }


### PR DESCRIPTION
Support multiple `MessageSource` beans, defaults to the first grails or spring instance over the MicronautApplicationContext

This is an update to https://github.com/grails/grails-core/pull/13630 which worked in the initial use cases, but fails when the MessageSource is not `PluginAwareResourceBundleMessageSource`

**Error when 2+ messageSources exist and the @Autowired method or field accepts a single value**

`org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type 'org.springframework.context.MessageSource' available:  expected single matching bean but found 2: messageSource,io.micronaut.spring.context.MicronautApplicationContext(Secondary)`

**Error when there is not a `MessageSource` of type `PluginAwareResourceBundleMessageSource`**

` Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'validateableConstraintsEvaluator': Unsatisfied dependency expressed through field 'messageSource': No qualifying bean of type 'org.springframework.context.MessageSource' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true), @org.springframework.beans.factory.annotation.Qualifier("pluginAwareResourceBundleMessageSource")}`