### PR TITLE
Set duplicates strategy for all archive tasks

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -178,3 +178,7 @@ task zipDist(type: Zip, dependsOn: [sourcesJars, install]) {
 }
 
 task assemble(dependsOn: zipDist)
+
+project.tasks.withType(AbstractArchiveTask).configureEach {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}


### PR DESCRIPTION
This is working for distTar and distZip, but does not work to bootJar.  

A solution is still needed to cover bootJar.

Currently a Grails 7 application will require specifying the duplicatesStrategy for the following tasks.

Ideally we can define this at a higher level, so it is not necessary to set it in each Grails project/application.

```
bootJar {
    duplicatesStrategy = duplicatesStrategy.INCLUDE
}

distTar {
    duplicatesStrategy = duplicatesStrategy.INCLUDE
}

distZip {
    duplicatesStrategy = duplicatesStrategy.INCLUDE
}

```
Examples

https://github.com/grails/grails-async/blob/7.0.x/examples/pubsub-demo/build.gradle#L55-L65

https://github.com/grails/grails-views/blob/577d1c5bea1d88d446dbc7d48f950bfe3160fb0e/examples/functional-tests/build.gradle#L60-L66

the following did not resolve this:

```
try {
    project.tasks.named('bootJar') {
        duplicatesStrategy = DuplicatesStrategy.INCLUDE
    }
}
catch(ignore) {
}
```