### PR TITLE
fix gdoc task

### DIFF
--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -60,7 +60,7 @@ tasks.register("stubs") {
 
 tasks.register('docs') {
     group = 'documentation'
-    outputs.dir(project.layout.buildDirectory.dir('docs'))
+    outputs.dir(project.layout.buildDirectory.dir('docs').get())
 }
 
 task javadoc(type:Javadoc, group: 'documentation') {
@@ -113,14 +113,14 @@ tasks.register('groovydoc', Groovydoc) {
 }
 
 tasks.register("fetchGrailsDocsSource", FetchGrailsDocSourceTask) {
-    checkoutDir = project.layout.buildDirectory.dir("checkout")
+    checkoutDir = project.layout.buildDirectory.dir("checkout").get()
     grailsDocBranch = "7.0.x"
 }
 
 task gdoc(type: GradleBuild, dependsOn: ["groovydoc", "fetchGrailsDocsSource"], group: 'documentation') {
     startParameter.useEmptySettings()
     dir = grailsDocSrc
-    tasks = ["clean", "assemble"]
+    tasks = []
 
     doFirst {
         ext.oldGrailsHome = System.getProperty("grails.home")
@@ -140,8 +140,8 @@ task gdoc(type: GradleBuild, dependsOn: ["groovydoc", "fetchGrailsDocsSource"], 
         }
 
         copy {
-            from file("${buildDir}/grails-docs-src/build/docs")
-            into project.layout.buildDirectory.dir("docs/api")
+            from layout.buildDirectory.dir("grails-docs-src/build/docs").get()
+            into layout.buildDirectory.dir("docs/api").get()
         }
     }
 }


### PR DESCRIPTION
The gdoc task fails with

Task 'clean' not found in project ':grails-docs-src'

Task 'assemble' not found in project ':grails-docs-src'

See: https://github.com/grails/grails-core/blob/7.0.x/gradle/docs.gradle#L125