### PR TITLE
ci: Make `groovy-joint-workflow` work as intended

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -27,8 +27,6 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-env:
-  CI_GROOVY_VERSION:
 jobs:
   build_groovy:
     strategy:
@@ -51,11 +49,10 @@ jobs:
           key: cache-local-groovy-maven-${{ github.sha }}
       - name: Checkout Groovy 4_0_X (Grails 7 and later)
         run: cd .. && git clone --depth 1 https://github.com/apache/groovy.git -b GROOVY_4_0_X --single-branch
-      - name: Set CI_GROOVY_VERSION for Grails
+      - name: Store Groovy version to use when building Grails
         id: groovy-version
         run: |
           cd ../groovy
-          echo "CI_GROOVY_VERSION=$(cat gradle.properties | grep groovyVersion | cut -d\= -f2 |  tr -d '[:space:]')" >> $GITHUB_ENV
           echo "value=$(cat gradle.properties | grep groovyVersion | cut -d\= -f2 |  tr -d '[:space:]')" >> $GITHUB_OUTPUT
       - name: Prepare Develocity Setup 1
         id: develocity_conf_1
@@ -144,9 +141,6 @@ jobs:
             ~/groovy
             ~/.m2/repository
           key: cache-local-groovy-maven-${{ github.sha }}
-      - name: Set CI_GROOVY_VERSION for Grails
-        run: |
-          echo "CI_GROOVY_VERSION=${{needs.build_groovy.outputs.groovyVersion}}" >> $GITHUB_ENV
       - name: Add mavenLocal (to load Groovy from)
         run: |
           sed -i 's|// mavenLocal() // Keep|mavenLocal() // Keep|' build.gradle
@@ -160,4 +154,5 @@ jobs:
         with:
           arguments: |
             build 
+            -PgroovyVersion=${{needs.build_groovy.outputs.groovyVersion}}
             -x groovydoc

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -147,6 +147,9 @@ jobs:
       - name: Set CI_GROOVY_VERSION for Grails
         run: |
           echo "CI_GROOVY_VERSION=${{needs.build_groovy.outputs.groovyVersion}}" >> $GITHUB_ENV
+      - name: Add mavenLocal (to load Groovy from)
+        run: |
+          sed -i 's|// mavenLocal() // Keep|mavenLocal() // Keep|' build.gradle
       - name: Build Grails
         id: build_grails
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           build-root-directory: ../groovy
           arguments: |
-            install
+            publishToMavenLocal
             -x groovydoc
             -x javadoc
             -x javadocAll

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'idea'
 ext {
     isJava8Compatible = org.gradle.api.JavaVersion.current().isJava8Compatible()
     grailsVersion = project.projectVersion
-    groovyVersion = System.getenv('CI_GROOVY_VERSION') ?: project.groovyVersion
     isBuildSnapshot = grailsVersion.endsWith("-SNAPSHOT")
     isReleaseVersion = !isBuildSnapshot
     isCiBuild = System.getenv().get("CI") as Boolean

--- a/build.gradle
+++ b/build.gradle
@@ -231,13 +231,13 @@ allprojects {
         mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
+        // mavenLocal() // Keep, this will be uncommented and used by CI (groovy-joint-workflow)
         if(groovyVersion.endsWith('-SNAPSHOT')) {
             maven {
                 name = 'ASF Snapshot repo'
                 url = 'https://repository.apache.org/content/repositories/snapshots'
             }
         }
-        mavenLocal()
     }
 
     configurations {


### PR DESCRIPTION
- Removed the `mavenLocal()` repository from the build configuration, as it was only required for the `groovy-joint-workflow` GitHub workflow.
- Updated the `groovy-joint-workflow` to dynamically add `mavenLocal()` to the build file at runtime, ensuring it is only used in the relevant workflow without affecting other builds.
- Simplify the build by removing the use of `CI_GROOVY_VERSION` enviroment var and override the project property `groovyVersion` with a command line property assignment instead.
- Use `publishToMavenLocal` instead of `install` when building Groovy as Grails will try to load the Groovy libraries from `mavenLocal()`.

With these changes the `groovy-joint-worflow` actually uses the built Groovy libraries when building Grails.