### PR TITLE
Allow customzing css classes for the ErrorsViewStackTracePrinter

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/CodeSnippetPrinter.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/CodeSnippetPrinter.groovy
@@ -27,7 +27,11 @@ interface CodeSnippetPrinter {
      * Attempts to present a preview code snippet of the code that went wrong
      *
      * @param exception The exception
+     * @param optional attributes for formatting
      * @return The code snippet or nothing if it can't be previewed
      */
+    String prettyPrintCodeSnippet(Throwable exception, Map attrs)
+
+    @Deprecated
     String prettyPrintCodeSnippet(Throwable exception)
 }

--- a/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/DefaultStackTracePrinter.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/DefaultStackTracePrinter.groovy
@@ -23,7 +23,7 @@ import org.codehaus.groovy.control.MultipleCompilationErrorsException
  */
 class DefaultStackTracePrinter implements StackTracePrinter {
 
-    String prettyPrint(Throwable t) {
+    String prettyPrint(Throwable t, Map attrs = [:]) {
         if (t == null) return ''
         if (!t.stackTrace) return 'No stack trace available'
         final sw = new StringWriter()

--- a/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/DefaultStackTracePrinter.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/DefaultStackTracePrinter.groovy
@@ -23,7 +23,13 @@ import org.codehaus.groovy.control.MultipleCompilationErrorsException
  */
 class DefaultStackTracePrinter implements StackTracePrinter {
 
-    String prettyPrint(Throwable t, Map attrs = [:]) {
+    @Deprecated
+    String prettyPrint(Throwable t) {
+        prettyPrint(t, [:])
+    }
+
+    @Override
+    String prettyPrint(Throwable t, Map attrs) {
         if (t == null) return ''
         if (!t.stackTrace) return 'No stack trace available'
         final sw = new StringWriter()

--- a/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/StackTracePrinter.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/StackTracePrinter.groovy
@@ -29,5 +29,16 @@ interface StackTracePrinter {
      * @param throwable The throwable
      * @return The result
      */
+    @Deprecated
     String prettyPrint(Throwable throwable)
+
+    /**
+     * Pretty print the given stack trace and return the result
+     *
+     * @param throwable The throwable
+     * @param optional attributes for formatting
+     * @return The result
+     */
+    String prettyPrint(Throwable throwable, Map attrs)
+
 }

--- a/grails-core/src/main/groovy/org/grails/core/exceptions/DefaultErrorsPrinter.groovy
+++ b/grails-core/src/main/groovy/org/grails/core/exceptions/DefaultErrorsPrinter.groovy
@@ -47,7 +47,12 @@ class DefaultErrorsPrinter extends DefaultStackTracePrinter implements CodeSnipp
         res == null ? te.className : res.getFilename()
     }
 
-    String prettyPrintCodeSnippet(Throwable exception, Map attrs = [:]) {
+    @Deprecated
+    String prettyPrintCodeSnippet(Throwable exception) {
+        prettyPrintCodeSnippet(exception, [:])
+    }
+
+    String prettyPrintCodeSnippet(Throwable exception, Map attrs) {
         if (exception == null) {
             return ''
         }
@@ -198,18 +203,32 @@ class DefaultErrorsPrinter extends DefaultStackTracePrinter implements CodeSnipp
         ""
     }
 
-    String formatCodeSnippetStart(Resource resource, int lineNumber, Map attrs = [:]) {
-        """Around line $lineNumber of $resource.filename
-"""
-
+    @Deprecated
+    String formatCodeSnippetStart(Resource resource, int lineNumber) {
+        formatCodeSnippetStart(resource, lineNumber, [:])
     }
 
-    protected String formatCodeSnippetLine(int currentLineNumber, currentLine, Map attrs = [:]) {
+    String formatCodeSnippetStart(Resource resource, int lineNumber, Map attrs) {
+        """Around line $lineNumber of $resource.filename
+"""
+    }
+
+    @Deprecated
+    protected String formatCodeSnippetLine(int currentLineNumber, currentLine) {
+        formatCodeSnippetLine(currentLineNumber, currentLine, [:])
+    }
+
+    protected String formatCodeSnippetLine(int currentLineNumber, currentLine, Map attrs) {
         """${currentLineNumber}: ${currentLine}
 """
     }
 
-    protected String formatCodeSnippetErrorLine(int currentLineNumber, currentLine, Map attrs = [:]) {
+    @Deprecated
+    protected String formatCodeSnippetErrorLine(int currentLineNumber, currentLine) {
+        formatCodeSnippetErrorLine(currentLineNumber, currentLine, [:])
+    }
+
+    protected String formatCodeSnippetErrorLine(int currentLineNumber, currentLine, Map attrs) {
         """${currentLineNumber}: ${currentLine}
 """
     }

--- a/grails-core/src/main/groovy/org/grails/core/exceptions/DefaultErrorsPrinter.groovy
+++ b/grails-core/src/main/groovy/org/grails/core/exceptions/DefaultErrorsPrinter.groovy
@@ -47,7 +47,7 @@ class DefaultErrorsPrinter extends DefaultStackTracePrinter implements CodeSnipp
         res == null ? te.className : res.getFilename()
     }
 
-    String prettyPrintCodeSnippet(Throwable exception) {
+    String prettyPrintCodeSnippet(Throwable exception, Map attrs = [:]) {
         if (exception == null) {
             return ''
         }
@@ -86,7 +86,7 @@ class DefaultErrorsPrinter extends DefaultStackTracePrinter implements CodeSnipp
                     if (lineNumbersShown[res.filename].contains(lineNumber)) continue // don't repeat the same lines twice
 
                     lineNumbersShown[res.filename] << lineNumber
-                    pw.print formatCodeSnippetStart(res, lineNumber)
+                    pw.print formatCodeSnippetStart(res, lineNumber, attrs)
                     def input = null
                     try {
                         input = res.inputStream
@@ -101,10 +101,10 @@ class DefaultErrorsPrinter extends DefaultStackTracePrinter implements CodeSnipp
                                 if (currentLineNumber in range) {
                                     boolean isErrorLine = currentLineNumber == lineNumber
                                     if (isErrorLine) {
-                                        pw.print formatCodeSnippetErrorLine(currentLineNumber, currentLine)
+                                        pw.print formatCodeSnippetErrorLine(currentLineNumber, currentLine, attrs)
                                     }
                                     else {
-                                        pw.print formatCodeSnippetLine(currentLineNumber, currentLine)
+                                        pw.print formatCodeSnippetLine(currentLineNumber, currentLine, attrs)
                                     }
                                 }
                                 else if (currentLineNumber > last) {
@@ -198,18 +198,18 @@ class DefaultErrorsPrinter extends DefaultStackTracePrinter implements CodeSnipp
         ""
     }
 
-    String formatCodeSnippetStart(Resource resource, int lineNumber) {
+    String formatCodeSnippetStart(Resource resource, int lineNumber, Map attrs = [:]) {
         """Around line $lineNumber of $resource.filename
 """
 
     }
 
-    protected String formatCodeSnippetLine(int currentLineNumber, currentLine) {
+    protected String formatCodeSnippetLine(int currentLineNumber, currentLine, Map attrs = [:]) {
         """${currentLineNumber}: ${currentLine}
 """
     }
 
-    protected String formatCodeSnippetErrorLine(int currentLineNumber, currentLine) {
+    protected String formatCodeSnippetErrorLine(int currentLineNumber, currentLine, Map attrs = [:]) {
         """${currentLineNumber}: ${currentLine}
 """
     }

--- a/grails-web-common/src/main/groovy/org/grails/web/errors/ErrorsViewStackTracePrinter.groovy
+++ b/grails-web-common/src/main/groovy/org/grails/web/errors/ErrorsViewStackTracePrinter.groovy
@@ -38,23 +38,23 @@ class ErrorsViewStackTracePrinter extends DefaultErrorsPrinter {
     }
 
     @Override
-    String prettyPrint(Throwable t) {
+    String prettyPrint(Throwable t, Map attrs = [:]) {
         if (t instanceof GrailsWrappedRuntimeException) {
             t = t.cause
         }
-        return super.prettyPrint(t)
+        return super.prettyPrint(t, attrs)
     }
 
     @Override
-    String prettyPrintCodeSnippet(Throwable t) {
+    String prettyPrintCodeSnippet(Throwable t, Map attrs = [:]) {
         if (t instanceof GrailsWrappedRuntimeException) {
             t = t.cause
         }
-        return super.prettyPrintCodeSnippet(t)
+        return super.prettyPrintCodeSnippet(t, attrs)
     }
 
     @Override
-    String formatCodeSnippetStart(Resource resource, int lineNumber) {
+    String formatCodeSnippetStart(Resource resource, int lineNumber, Map attrs = [:]) {
         String path = resource.filename
         // try calc better path
         try {
@@ -67,8 +67,8 @@ class ErrorsViewStackTracePrinter extends DefaultErrorsPrinter {
             path = resource.filename
         }
         """\
-<h2>Around line ${lineNumber} of <span class="filename">${path}</span></h2>
-<pre class="snippet">"""
+<h2>Around line ${lineNumber} of <span class="${attrs['filenameClass'] ?: 'filename'}">${path}</span></h2>
+<pre class="${attrs['snippetClass'] ?: 'snippet'}">"""
     }
 
     @Override
@@ -77,13 +77,13 @@ class ErrorsViewStackTracePrinter extends DefaultErrorsPrinter {
     }
 
     @Override
-    protected String formatCodeSnippetLine(int currentLineNumber, Object currentLine) {
-        """<code class="line"><span class="lineNumber">${currentLineNumber}:</span>${currentLine.encodeAsHTML()}</code>"""
+    protected String formatCodeSnippetLine(int currentLineNumber, Object currentLine, Map attrs = [:]) {
+        """<code class="${attrs['lineClass'] ?: 'line'}"><span class="${attrs['lineNumberClass'] ?: 'lineNumber'}">${currentLineNumber}:</span>${currentLine.encodeAsHTML()}</code>"""
     }
 
     @Override
-    protected String formatCodeSnippetErrorLine(int currentLineNumber, Object currentLine) {
-        """<code class="line error"><span class="lineNumber">${currentLineNumber}:</span>${currentLine.encodeAsHTML()}</code>"""
+    protected String formatCodeSnippetErrorLine(int currentLineNumber, Object currentLine, Map attrs = [:]) {
+        """<code class="${attrs['lineErrorClass'] ?: 'line error'}"><span class="${attrs['lineNumberClass'] ?: 'lineNumber'}">${currentLineNumber}:</span>${currentLine.encodeAsHTML()}</code>"""
     }
 
     @Override

--- a/grails-web-common/src/main/groovy/org/grails/web/errors/ErrorsViewStackTracePrinter.groovy
+++ b/grails-web-common/src/main/groovy/org/grails/web/errors/ErrorsViewStackTracePrinter.groovy
@@ -38,7 +38,7 @@ class ErrorsViewStackTracePrinter extends DefaultErrorsPrinter {
     }
 
     @Override
-    String prettyPrint(Throwable t, Map attrs = [:]) {
+    String prettyPrint(Throwable t, Map attrs) {
         if (t instanceof GrailsWrappedRuntimeException) {
             t = t.cause
         }
@@ -46,7 +46,7 @@ class ErrorsViewStackTracePrinter extends DefaultErrorsPrinter {
     }
 
     @Override
-    String prettyPrintCodeSnippet(Throwable t, Map attrs = [:]) {
+    String prettyPrintCodeSnippet(Throwable t, Map attrs) {
         if (t instanceof GrailsWrappedRuntimeException) {
             t = t.cause
         }
@@ -54,7 +54,7 @@ class ErrorsViewStackTracePrinter extends DefaultErrorsPrinter {
     }
 
     @Override
-    String formatCodeSnippetStart(Resource resource, int lineNumber, Map attrs = [:]) {
+    String formatCodeSnippetStart(Resource resource, int lineNumber, Map attrs) {
         String path = resource.filename
         // try calc better path
         try {
@@ -77,12 +77,12 @@ class ErrorsViewStackTracePrinter extends DefaultErrorsPrinter {
     }
 
     @Override
-    protected String formatCodeSnippetLine(int currentLineNumber, Object currentLine, Map attrs = [:]) {
+    protected String formatCodeSnippetLine(int currentLineNumber, Object currentLine, Map attrs) {
         """<code class="${attrs['lineClass'] ?: 'line'}"><span class="${attrs['lineNumberClass'] ?: 'lineNumber'}">${currentLineNumber}:</span>${currentLine.encodeAsHTML()}</code>"""
     }
 
     @Override
-    protected String formatCodeSnippetErrorLine(int currentLineNumber, Object currentLine, Map attrs = [:]) {
+    protected String formatCodeSnippetErrorLine(int currentLineNumber, Object currentLine, Map attrs) {
         """<code class="${attrs['lineErrorClass'] ?: 'line error'}"><span class="${attrs['lineNumberClass'] ?: 'lineNumber'}">${currentLineNumber}:</span>${currentLine.encodeAsHTML()}</code>"""
     }
 


### PR DESCRIPTION
```gsp
<g:renderException exception="${exception}" detailsClass="alert alert-danger" stackClass="bg-body-secondary" snippetClass="bg-body-secondary snippet" lineErrorClass="bg-danger" />
```