### PR TITLE
Update default servlet version in grails.util.Metadata

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/util/Metadata.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/util/Metadata.groovy
@@ -46,7 +46,7 @@ class Metadata {
     public static final String APPLICATION_GRAILS_VERSION = "info.app.grailsVersion"
     public static final String SERVLET_VERSION = "info.app.servletVersion"
     public static final String WAR_DEPLOYED = "info.app.warDeployed"
-    public static final String DEFAULT_SERVLET_VERSION = "3.0"
+    public static final String DEFAULT_SERVLET_VERSION = "6.0"
     public static final String BUILD_INFO_FILE = "META-INF/grails.build.info"
 
     private static Holder<Reference<Metadata>> holder = new Holder<Reference<Metadata>>("Metadata")


### PR DESCRIPTION
A small change I noticed while reviewing another issue.