### PR TITLE
fix: Register databinders

### DIFF
--- a/grails-plugin-databinding/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/grails-plugin-databinding/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.grails.plugins.databinding.DataBindingConfiguration


### PR DESCRIPTION
Databinders from `grails-plugin-databinders` where not registered in the application context since the removal of Micronaut. This PR should fix that.