### PR TITLE
Fix for sitemesh.  Buffering is triggered on response.setContentType so rendering needs to be done on wrapped response.

### DIFF
--- a/grails-web-common/src/main/groovy/org/grails/web/servlet/view/AbstractGrailsView.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/servlet/view/AbstractGrailsView.java
@@ -24,6 +24,7 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.grails.web.servlet.WrappedResponseHolder;
 import org.grails.web.util.GrailsApplicationAttributes;
 import org.grails.web.servlet.mvc.GrailsWebRequest;
 import org.grails.web.util.WebUtils;
@@ -68,6 +69,8 @@ public abstract class AbstractGrailsView extends AbstractUrlBasedView {
             } else {
                 webRequest = (GrailsWebRequest)requestAttributes;
             }
+            // Update response holder to latest response. Necessary for sitemesh to trigger buffering.
+            WrappedResponseHolder.setWrappedResponse(response);
             renderTemplate(model, webRequest, request, response);
         } finally {
             if(attributesChanged) {


### PR DESCRIPTION
Used in conjunction with moving sitemesh after the spring security filter chain 
https://github.com/sitemesh/sitemesh3/commit/acba228e4646178b0737fff95adacde5f4daf8d0