### PR TITLE
Add `grails-plugin-events` to `grails-dependencies`

### DIFF
--- a/grails-dependencies/build.gradle
+++ b/grails-dependencies/build.gradle
@@ -58,6 +58,12 @@ publishing {
                         }
                         delegate.dependency {
                             delegate.groupId "org.grails.plugins"
+                            delegate.artifactId "events"
+                            delegate.version asyncVersion
+                            delegate.scope "api"
+                        }
+                        delegate.dependency {
+                            delegate.groupId "org.grails.plugins"
                             delegate.artifactId "gsp"
                             delegate.version gspVersion
                             delegate.scope "api"

--- a/grails-dependencies/build.gradle
+++ b/grails-dependencies/build.gradle
@@ -49,12 +49,6 @@ publishing {
                             delegate.artifactId "async"
                             delegate.version asyncVersion
                             delegate.scope "api"
-                            delegate.exclusions {
-                                delegate.exclusion {
-                                    delegate.groupId 'javax'
-                                    delegate.artifactId 'javaee-web-api'
-                                }
-                            }
                         }
                         delegate.dependency {
                             delegate.groupId "org.grails.plugins"
@@ -67,12 +61,6 @@ publishing {
                             delegate.artifactId "gsp"
                             delegate.version gspVersion
                             delegate.scope "api"
-                            delegate.exclusions {
-                                delegate.exclusion {
-                                    delegate.groupId 'javax'
-                                    delegate.artifactId 'javaee-web-api'
-                                }
-                            }
                         }
                         delegate.dependency {
                             delegate.groupId "com.h2database"


### PR DESCRIPTION
This PR adds the Events plugin to all Grails applications by adding it to the `grails-dependencies`.
Previously this has happened transitively through the inclusion of the Async plugin in `grails-dependencies`.

However, as `grails-plugin-async` does not actually depend on `grails-plugin-events`, it makes more sense to add `grails-plugin-events` in `grails-dependencies` explicitly.

This prepares for the removal of `grails-plugins-events` to be declared as a dependency of `grails-plugin-async`.

Related:
https://github.com/grails/grails-async/pull/44
https://github.com/grails/grails-async/pull/69
https://github.com/grails/grails-async/pull/70
https://github.com/grails/grails-core/issues/13324

This PR also removes the exclusion of `javax:javaee-web-api` from `grails-plugin-async` and `grails-gsp` in `grails-dependencies` as `javax:javaee-web-api` is not included in these modules.