### PR TITLE
fix(deps): grails-bom maven group/artifact for micronaut-spring & grails-gradle-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ ext {
             'micronautSpring'        : [version: micronautSpringVersion,
                                         group  : 'io.micronaut.spring',
                                         names  : ['micronaut-spring'],
-                                        modules: ['spring', 'context', 'boot', 'web', 'boot-annotation', 'annotation', 'web-annotation']
+                                        modules: ['', 'context', 'boot', 'web', 'boot-annotation', 'annotation', 'web-annotation']
             ],
             'mongodb'                : [version: mongodbJavaDriverVersion,
                                         group  : 'org.mongodb',

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -92,7 +92,11 @@ publishing {
                                     artifactId = artifactId.replace("gorm.", "")
                                 }
                                 mkp.dependency {
-                                    mkp.groupId 'org.grails.plugins'
+                                    if(artifactId == 'grails-gradle-plugin') {
+                                        mkp.groupId 'org.grails'
+                                    } else {
+                                        mkp.groupId 'org.grails.plugins'
+                                    }
                                     mkp.artifactId artifactId
                                     String versionValue = plugin.value
                                     if (!isBuildSnapshot && versionValue.endsWith("-SNAPSHOT")) {


### PR DESCRIPTION
https://mvnrepository.com/artifact/org.grails/grails-bom/6.2.1

`io.micronaut.spring:micronaut-spring-spring:4.5.1` should be `io.micronaut.spring:micronaut-spring:4.5.1`

`org.grails.plugins:grails-gradle-plugin:6.2.1` should `org.grails:grails-gradle-plugin:6.2.1`

Test with `./gradlew grails-bom:generatePomFileForMavenPublication` and review  `/grails-bom/build/publications/maven/pom-default.xml`