### PR TITLE
Fix Bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,6 @@ ext {
                                         names  : ['grails-gradle-plugin'],
                                         modules: ['']
             ],
-            'fieldsPlugin'           : [version: fieldsPluginVersion,
-                                        group  : 'org.grails.plugins',
-                                        names  : ['fields'],
-                                        modules: ['']
-            ],
             'jakarta-annotation'     : [version: jakartaAnnotationApiVersion,
                                         group  : 'jakarta.annotation',
                                         names  : ['jakarta.annotation-api'],

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ ext {
     // When making changes in the dependencyVersions, remember to also update the Grails BOM Documentation:
     // https://docs.grails.org/snapshot/ref/Dependency%20Versions/Grails%20BOM.html
     dependencyVersions = [
+            'grailsGradlePlugin'      : [version: grailsGradlePluginVersion,
+                                        group  : 'org.grails',
+                                        names  : ['grails-gradle-plugin'],
+                                        modules: ['']
+            ],
             'fieldsPlugin'           : [version: fieldsPluginVersion,
                                         group  : 'org.grails.plugins',
                                         names  : ['fields'],

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ gradleNexusPluginVersion=2.3.1
 gradleNexusPublishPluginVersion=1.3.0
 gradleExtraConfigurationsPluginVersion=10.0.1
 gradleLicensePluginVersion=0.16.1
+grailsGradlePluginVersion=7.0.0-SNAPSHOT
 groovyVersion=4.0.23
 gspVersion=7.0.0-SNAPSHOT
 hamcrestVersion=3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@ commonsIOVersion=2.17.0
 datastoreVersion=9.0.0-SNAPSHOT
 directoryWatcherVersion=0.18.0
 expectitCoreVersion=0.9.0
-fieldsPluginVersion=6.0.0-SNAPSHOT
 gdocEngineVersion=1.0.1
 gradleNexusPluginVersion=2.3.1
 gradleNexusPublishPluginVersion=1.3.0

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -45,27 +45,6 @@ publishing {
                                     if (sub.name == 'grails-dependencies') {
                                         mkp.type 'pom'
                                     }
-
-                                    if (sub.name == 'grails-bootstrap') {
-                                        mkp.exclusions {
-                                            mkp.exclusion {
-                                                mkp.groupId 'jline'
-                                                mkp.artifactId 'jline'
-                                            }
-                                            mkp.exclusion {
-                                                mkp.groupId 'org.fusesource.jansi'
-                                                mkp.artifactId 'jansi'
-                                            }
-                                            mkp.exclusion {
-                                                mkp.groupId 'net.java.dev.jna'
-                                                mkp.artifactId 'jna'
-                                            }
-                                            mkp.exclusion {
-                                                mkp.groupId 'org.apache.groovy'
-                                                mkp.artifactId 'groovy-ant'
-                                            }
-                                        }
-                                    }
                                 }
                             }
 

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -71,11 +71,7 @@ publishing {
                                     artifactId = artifactId.replace("gorm.", "")
                                 }
                                 mkp.dependency {
-                                    if(artifactId == 'grails-gradle-plugin') {
-                                        mkp.groupId 'org.grails'
-                                    } else {
-                                        mkp.groupId 'org.grails.plugins'
-                                    }
+                                    mkp.groupId 'org.grails.plugins'
                                     mkp.artifactId artifactId
                                     String versionValue = plugin.value
                                     if (!isBuildSnapshot && versionValue.endsWith("-SNAPSHOT")) {

--- a/grails-bom/plugins.properties
+++ b/grails-bom/plugins.properties
@@ -1,11 +1,12 @@
+cache=8.0.0-SNAPSHOT
+fieldsPluginVersion=6.0.0-SNAPSHOT
+geb=5.0.0-SNAPSHOT
 gorm.hibernate5=9.0.0-SNAPSHOT
 gorm.mongodb=9.0.0-SNAPSHOT
 gorm.neo4j=8.1.0
-cache=8.0.0-SNAPSHOT
 rxjava=1.1.1
 rxjava2=2.0.0
 scaffolding=6.0.0-SNAPSHOT
-geb=5.0.0-SNAPSHOT
 views-json=4.0.0-SNAPSHOT
 views-json-templates=4.0.0-SNAPSHOT
 views-markup=4.0.0-SNAPSHOT

--- a/grails-bom/plugins.properties
+++ b/grails-bom/plugins.properties
@@ -1,7 +1,6 @@
 gorm.hibernate5=9.0.0-SNAPSHOT
 gorm.mongodb=9.0.0-SNAPSHOT
 gorm.neo4j=8.1.0
-grails-gradle-plugin=7.0.0-SNAPSHOT
 cache=8.0.0-SNAPSHOT
 rxjava=1.1.1
 rxjava2=2.0.0


### PR DESCRIPTION
Makes grails-gradle-plugin a dependency and not a plugin
Removes exclusions no longer needed due to the dependencies should not have been dependencies in the first place.