### PR TITLE
go back to org.fusesource.jansi:jansi:1:18 with jline:jline:2.14.6 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1536M -XX:MaxMetaspaceSize=1024M
 
-# Generated on Mon Oct 21 14:36:55 PDT 2024 by: ./gradlew :grails-bom:syncProps
+# Generated on Tue Oct 22 16:16:30 EDT 2024 by: ./gradlew :grails-bom:syncProps
 # Only version value modifications allowed after this point. Do not insert or change version names. 
 ant.version=1.10.15
 asciidoctorj.version=3.0.0
@@ -43,7 +43,7 @@ groovy.version=4.0.23
 gsp.version=7.0.0-SNAPSHOT
 h2.version=2.3.232
 jackson.version=2.18.0
-jansi.version=2.4.1
+jansi.version=1.18
 javaparser-core.version=3.26.2
 jline.version=2.14.6
 jna.version=5.15.0


### PR DESCRIPTION
https://mvnrepository.com/artifact/jline/jline/2.14.6 is not compatible with https://mvnrepository.com/artifact/org.fusesource.jansi/jansi/2.4.1

https://mvnrepository.com/artifact/org.fusesource.jansi/jansi/1.18 is the latest compatible version.  

Reverses https://github.com/grails/grails-core/pull/13474 which triggered this issue and resolves error on https://github.com/grails/grails-core/issues/13752 until full rewrite can occur.

I would add a comment, but that version list is auto generated now and it would get lost on regen.  