### PR TITLE
fix: Add Artifactory repository for `grails-bom` snapshots

### DIFF
--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -109,6 +109,19 @@ dependencies {
 }
 
 publishing {
+
+    if (isBuildSnapshot) {
+        repositories {
+            maven {
+                credentials {
+                    username = findProperty('artifactoryPublishUsername') ?: System.getenv('ARTIFACTORY_USERNAME') ?: ''
+                    password = findProperty('artifactoryPublishPassword') ?: System.getenv('ARTIFACTORY_PASSWORD') ?: ''
+                }
+                url = 'https://repo.grails.org/grails/libs-snapshots-local'
+            }
+        }
+    }
+
     publications {
         maven(MavenPublication) {
             pom.withXml {


### PR DESCRIPTION
This repository was previously added in the root `build.gradle` file.

Probably fixes #13800 