### PR TITLE
matrix the build on java 17, 21 and 23 w/ ubuntu, windows and macOS using liberica

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,11 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-
+    - name: "☕️ Setup JDK"
+      uses: actions/setup-java@v4
+      with:
+        distribution: liberica
+        java-version: 17
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: ${{ matrix.java }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
@@ -47,7 +47,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,10 +13,11 @@ jobs:
   build:
     permissions:
       contents: read  #  to fetch code (actions/checkout)
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [17]
+        java: [17, 21, 23]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
       - name: "🗄️ Cache local Maven repository"
         uses: actions/cache@v4
@@ -121,7 +121,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
@@ -97,7 +97,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/retry-release.yml
+++ b/.github/workflows/retry-release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/sdkman.yml
+++ b/.github/workflows/sdkman.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4

--- a/build.gradle
+++ b/build.gradle
@@ -464,7 +464,7 @@ subprojects { subproject ->
         }
     }
 
-    java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+    java.sourceCompatibility = JavaVersion.VERSION_17
 
     if (!isTestSuite) {
         tasks.register('installToHomeDist', Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -464,7 +464,9 @@ subprojects { subproject ->
         }
     }
 
-    java.sourceCompatibility = JavaVersion.VERSION_17
+    compileJava {
+        options.release = 17
+    }
 
     if (!isTestSuite) {
         tasks.register('installToHomeDist', Copy) {


### PR DESCRIPTION
The windows GitHub runners are slower, but at least they run in parallel.   It's ironic given that MS owns GitHub, you would think they would make them the fastest.  

I don't think we want to go down these paths, but in researching the speed difference:

- pay for larger instances: https://github.com/grails/grails-core/actions/runners
- extreme measures:  https://github.com/astral-sh/uv/pull/3522/files


This PR uses Gradle Release Flag instead of Java Toolchain so the github workflow can control the version of Java.  `sourceCompatibility `is deprecated and marked for removal in Gradle 9.  https://docs.gradle.org/current/userguide/building_java_projects.html#sec:compiling_with_release

```
    compileJava.options.release = 17
```
