### PR TITLE
Filter order values should not be fixed and should be relative to requirements of Spring Boot.

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/org/grails/config/http/GrailsFilters.java
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/config/http/GrailsFilters.java
@@ -1,5 +1,3 @@
-package org.grails.config.http;
-
 /* Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +13,14 @@ package org.grails.config.http;
  * limitations under the License.
  */
 
+package org.grails.config.http;
+
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 
 /**
  * Stores the default order numbers of all Grails filters for use in configuration.
  * These filters are run prior to the Spring Security Filter Chain which is at DEFAULT_FILTER_ORDER
+ * @since 7.0
  */
 public enum GrailsFilters {
 

--- a/grails-plugin-controllers/src/main/groovy/org/grails/config/http/GrailsFilters.java
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/config/http/GrailsFilters.java
@@ -1,0 +1,48 @@
+package org.grails.config.http;
+
+/* Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+
+/**
+ * Stores the default order numbers of all Grails filters for use in configuration.
+ * These filters are run prior to the Spring Security Filter Chain which is at DEFAULT_FILTER_ORDER
+ */
+public enum GrailsFilters {
+
+    FIRST,
+    ASSET_PIPELINE_FILTER,
+    CHARACTER_ENCODING_FILTER,
+    HIDDEN_HTTP_METHOD_FILTER,
+    SITEMESH_FILTER,
+    GRAILS_WEB_REQUEST_FILTER,
+    LAST(SecurityProperties.DEFAULT_FILTER_ORDER - 10);
+
+    private static final int INTERVAL = 10;
+    private final int order;
+
+    GrailsFilters() {
+        this.order = SecurityProperties.DEFAULT_FILTER_ORDER - 100 + ordinal() * INTERVAL;
+    }
+    GrailsFilters(int order) {
+        this.order = order;
+    }
+
+    public int getOrder() {
+        return this.order;
+    }
+
+}

--- a/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
@@ -23,6 +23,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.grails.core.artefact.ControllerArtefactHandler
 import org.grails.plugins.web.servlet.context.BootStrapClassRunner
+import org.grails.config.http.GrailsFilters
 import org.grails.web.errors.GrailsExceptionResolver
 import org.grails.web.filters.HiddenHttpMethodFilter
 import org.grails.web.servlet.mvc.GrailsDispatcherServlet
@@ -32,7 +33,6 @@ import org.grails.web.servlet.view.CompositeViewResolver
 import org.springframework.beans.factory.support.AbstractBeanDefinition
 import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletRegistrationBean
 import org.springframework.boot.web.servlet.FilterRegistrationBean
-import org.springframework.boot.web.servlet.filter.OrderedFilter
 import org.springframework.context.ApplicationContext
 import org.springframework.util.ClassUtils
 import org.springframework.web.filter.CharacterEncodingFilter
@@ -93,19 +93,19 @@ class ControllersGrailsPlugin extends Plugin {
                 forceEncoding = filtersForceEncoding
             }
             urlPatterns = catchAllMapping
-            order = OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER + 10
+            order = GrailsFilters.CHARACTER_ENCODING_FILTER.order
         }
 
         hiddenHttpMethodFilter(FilterRegistrationBean) {
             filter = bean(HiddenHttpMethodFilter)
             urlPatterns = catchAllMapping
-            order = OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER + 20
+            order = GrailsFilters.HIDDEN_HTTP_METHOD_FILTER.order
         }
 
         grailsWebRequestFilter(FilterRegistrationBean) {
             filter = bean(GrailsWebRequestFilter)
             urlPatterns = catchAllMapping
-            order = OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER + 30
+            order = GrailsFilters.GRAILS_WEB_REQUEST_FILTER.order
             dispatcherTypes = EnumSet.of(
                     DispatcherType.FORWARD,
                     DispatcherType.INCLUDE,


### PR DESCRIPTION
Fixes #13797

This will evolve, but it is good to get the process started.

It was place in grails-controllers because that is where the used filters are instantiated.  The other possible location is grails-bootstrap.    These are the only 2 locations that depend on spring boot autoconfigure.   This needs to be based on spring boot autoconfigure in case at some point Spring decides to change the default value (A situation like this broke the Grails Spring Security Core plugin which was previously dependent on fixed numerical values that became outdated )

Asset pipeline [PR](https://github.com/bertramdev/asset-pipeline/pull/356) should be merged after this is accepted.
Sitemesh plugin will be updated after this is accepted. 