### PR TITLE
Spring Boot 3.4.0-RC1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -75,6 +75,6 @@ profiles-web.version=7.0.1-SNAPSHOT
 profiles-web-plugin.version=7.0.1-SNAPSHOT
 spock.version=2.3-groovy-4.0
 spotbugs-annotations.version=4.8.6
-spring-boot.version=3.3.5
+spring-boot.version=3.4.0-RC1
 springloaded.version=1.2.8.RELEASE
 views-json-testing-support.version=4.0.0-SNAPSHOT


### PR DESCRIPTION
We should be already be testing against and using Spring Boot 3.4.0 as it will be released before Grails 7.