### PR TITLE
Allow version resolution for api dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,7 +296,7 @@ subprojects { subproject ->
     if (subproject.name in ['grails-dependencies', 'grails-bom']) return
 
     dependencies {
-        implementation platform(project(':grails-bom'))
+        api platform(project(':grails-bom'))
     }
 
     if (subproject.name =~ /^(grails-web|grails-plugin-|grails-test-suite|grails-test)/) {


### PR DESCRIPTION
This should add the bom to the poms which will eliminate transitive version failures.