### PR TITLE
Remove circular transitive gsp dependency

### DIFF
--- a/grails-web-common/build.gradle
+++ b/grails-web-common/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     }
     api project(":grails-databinding")
     api project(":grails-encoder")
-    api "org.grails:grails-gsp"
+    compileOnly "org.grails:grails-gsp"
 
     api "org.apache.groovy:groovy-templates"
     compileOnly "jakarta.servlet:jakarta.servlet-api"

--- a/grails-web-databinding/build.gradle
+++ b/grails-web-databinding/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     api project(":grails-databinding")
     api project(":grails-web-common")
+    testRuntimeOnly "org.grails:grails-gsp"
 }

--- a/grails-web-url-mappings/build.gradle
+++ b/grails-web-url-mappings/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api project(":grails-web-common")
+    compileOnly "org.grails:grails-gsp"
 
     api("org.grails:grails-datastore-gorm-validation")
 


### PR DESCRIPTION
Can't roll back `grails-web-taglib` to `groovy:4.0.23` because

`grails-web-taglib` depends on `grails-web-common` which depends on `org.grails:grails-gsp` which depends on `org.apache.groovy:groovy:4.0.24-SNAPSHOT`