### PR TITLE
Move GrailsFilters configuration from grails-spring to grails-web-common module so that grails-spring to is not required for grails-boot. 

### DIFF
--- a/grails-bootstrap/build.gradle
+++ b/grails-bootstrap/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // when used by grails-gradle-plugin
     // see: https://docs.gradle.org/current/userguide/compatibility.html#groovy
     implementation "org.springframework:spring-context"
-    api "org.springframework.boot:spring-boot-autoconfigure"
+    implementation "org.springframework.boot:spring-boot-autoconfigure"
 
 
     compileOnly "org.codehaus.groovy:groovy:$GroovySystem.version"

--- a/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersAutoConfiguration.java
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersAutoConfiguration.java
@@ -3,7 +3,7 @@ package org.grails.plugins.web.controllers;
 import grails.config.Settings;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
-import org.grails.spring.config.http.GrailsFilters;
+import org.grails.web.config.http.GrailsFilters;
 import org.grails.web.filters.HiddenHttpMethodFilter;
 import org.grails.web.servlet.mvc.GrailsWebRequestFilter;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +16,6 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.filter.OrderedCharacterEncodingFilter;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.util.EnumSet;

--- a/grails-web-common/build.gradle
+++ b/grails-web-common/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     compileOnly "jakarta.servlet:jakarta.servlet-api"
     testCompileOnly "org.springframework:spring-test"
 
+    compileOnly "org.springframework.boot:spring-boot-autoconfigure"
     api "org.springframework:spring-webmvc"
     api "org.springframework:spring-context-support"
     implementation "com.github.ben-manes.caffeine:caffeine"

--- a/grails-web-common/src/main/groovy/org/grails/web/config/http/GrailsFilters.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/config/http/GrailsFilters.java
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package org.grails.spring.config.http;
+package org.grails.web.config.http;
 
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 


### PR DESCRIPTION
Fixes #13854 (See for discussion)