### PR TITLE
Continue ControllersAutoConfiguration Migration

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersAutoConfiguration.java
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersAutoConfiguration.java
@@ -3,6 +3,7 @@ package org.grails.plugins.web.controllers;
 import grails.config.Settings;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
+import jakarta.servlet.MultipartConfigElement;
 import org.grails.web.config.http.GrailsFilters;
 import org.grails.web.filters.HiddenHttpMethodFilter;
 import org.grails.web.servlet.mvc.GrailsWebRequestFilter;
@@ -33,13 +34,25 @@ public class ControllersAutoConfiguration {
     private boolean filtersForceEncoding;
 
     @Value("${" + Settings.RESOURCES_CACHE_PERIOD + ":0}")
-    int resourcesCachePeriod;
+    private int resourcesCachePeriod;
 
     @Value("${" + Settings.RESOURCES_ENABLED + ":true}")
-    boolean resourcesEnabled;
+    private boolean resourcesEnabled;
 
-    @Value("${" + Settings.RESOURCES_PATTERN + ":"+Settings.DEFAULT_RESOURCE_PATTERN+"}")
-    String resourcesPattern;
+    @Value("${" + Settings.RESOURCES_PATTERN + ":" + Settings.DEFAULT_RESOURCE_PATTERN + "}")
+    private String resourcesPattern;
+
+    @Value("${" + Settings.CONTROLLERS_UPLOAD_LOCATION + ":#{null}}")
+    private String uploadTmpDir;
+
+    @Value("${" + Settings.CONTROLLERS_UPLOAD_MAX_FILE_SIZE + ":128000}")
+    private long maxFileSize;
+
+    @Value("${" + Settings.CONTROLLERS_UPLOAD_MAX_REQUEST_SIZE + ":128000}")
+    private long maxRequestSize;
+
+    @Value("${" + Settings.CONTROLLERS_UPLOAD_FILE_SIZE_THRESHOLD + ":0}")
+    private int fileSizeThreshold;
 
     @Bean
     @ConditionalOnMissingBean(CharacterEncodingFilter.class)
@@ -80,7 +93,15 @@ public class ControllersAutoConfiguration {
     }
 
     @Bean
-    GrailsWebMvcConfigurer webMvcConfig() {
+    public MultipartConfigElement multipartConfigElement() {
+        if (uploadTmpDir == null) {
+            uploadTmpDir = System.getProperty("java.io.tmpdir");
+        }
+        return new MultipartConfigElement(uploadTmpDir, maxFileSize, maxRequestSize, fileSizeThreshold);
+    }
+
+    @Bean
+    public GrailsWebMvcConfigurer webMvcConfig() {
         return new GrailsWebMvcConfigurer(resourcesCachePeriod, resourcesEnabled, resourcesPattern);
     }
 

--- a/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
@@ -23,16 +23,12 @@ import groovy.util.logging.Slf4j
 import org.grails.core.artefact.ControllerArtefactHandler
 import org.grails.plugins.web.servlet.context.BootStrapClassRunner
 import org.grails.web.errors.GrailsExceptionResolver
-import org.grails.web.servlet.mvc.GrailsDispatcherServlet
 import org.grails.web.servlet.mvc.TokenResponseActionResultTransformer
 import org.grails.web.servlet.view.CompositeViewResolver
 import org.springframework.beans.factory.support.AbstractBeanDefinition
-import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletRegistrationBean
 import org.springframework.context.ApplicationContext
-import org.springframework.util.ClassUtils
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
-import jakarta.servlet.MultipartConfigElement
 
 /**
  * Handles the configuration of controllers for Grails.
@@ -57,8 +53,6 @@ class ControllersGrailsPlugin extends Plugin {
         def config = application.config
 
         boolean useJsessionId = config.getProperty(Settings.GRAILS_VIEWS_ENABLE_JSESSIONID, Boolean, false)
-        boolean isTomcat = ClassUtils.isPresent("org.apache.catalina.startup.Tomcat", application.classLoader)
-        String grailsServletPath = config.getProperty(Settings.WEB_SERVLET_PATH, isTomcat ? Settings.DEFAULT_TOMCAT_SERVLET_PATH : Settings.DEFAULT_WEB_SERVLET_PATH)
 
         if (!Boolean.parseBoolean(System.getProperty(Settings.SETTING_SKIP_BOOTSTRAP))) {
             bootStrapClassRunner(BootStrapClassRunner)
@@ -79,14 +73,6 @@ class ControllersGrailsPlugin extends Plugin {
         // allow @Controller annotated beans
         annotationHandlerMapping(RequestMappingHandlerMapping, interceptorsClosure)
         annotationHandlerAdapter(RequestMappingHandlerAdapter)
-
-        // add the dispatcher servlet
-        dispatcherServlet(GrailsDispatcherServlet)
-        dispatcherServletRegistration(DispatcherServletRegistrationBean, ref("dispatcherServlet"), grailsServletPath) {
-            loadOnStartup = 2
-            asyncSupported = true
-            multipartConfig = ref('multipartConfigElement')
-        }
 
         for (controller in application.getArtefacts(ControllerArtefactHandler.TYPE)) {
             log.debug "Configuring controller $controller.fullName"

--- a/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
@@ -57,10 +57,6 @@ class ControllersGrailsPlugin extends Plugin {
         def config = application.config
 
         boolean useJsessionId = config.getProperty(Settings.GRAILS_VIEWS_ENABLE_JSESSIONID, Boolean, false)
-        String uploadTmpDir = config.getProperty(Settings.CONTROLLERS_UPLOAD_LOCATION, System.getProperty("java.io.tmpdir"))
-        long maxFileSize = config.getProperty(Settings.CONTROLLERS_UPLOAD_MAX_FILE_SIZE, Long, 128000L)
-        long maxRequestSize = config.getProperty(Settings.CONTROLLERS_UPLOAD_MAX_REQUEST_SIZE, Long, 128000L)
-        int fileSizeThreashold = config.getProperty(Settings.CONTROLLERS_UPLOAD_FILE_SIZE_THRESHOLD, Integer, 0)
         boolean isTomcat = ClassUtils.isPresent("org.apache.catalina.startup.Tomcat", application.classLoader)
         String grailsServletPath = config.getProperty(Settings.WEB_SERVLET_PATH, isTomcat ? Settings.DEFAULT_TOMCAT_SERVLET_PATH : Settings.DEFAULT_WEB_SERVLET_PATH)
 
@@ -76,8 +72,6 @@ class ControllersGrailsPlugin extends Plugin {
 
         "${CompositeViewResolver.BEAN_NAME}"(CompositeViewResolver)
 
-        multipartConfigElement(MultipartConfigElement, uploadTmpDir, maxFileSize, maxRequestSize, fileSizeThreashold)
-
         def handlerInterceptors = springConfig.containsBean("localeChangeInterceptor") ? [ref("localeChangeInterceptor")] : []
         def interceptorsClosure = {
             interceptors = handlerInterceptors
@@ -91,7 +85,7 @@ class ControllersGrailsPlugin extends Plugin {
         dispatcherServletRegistration(DispatcherServletRegistrationBean, ref("dispatcherServlet"), grailsServletPath) {
             loadOnStartup = 2
             asyncSupported = true
-            multipartConfig = multipartConfigElement
+            multipartConfig = ref('multipartConfigElement')
         }
 
         for (controller in application.getArtefacts(ControllerArtefactHandler.TYPE)) {


### PR DESCRIPTION
Fixes
```
Overriding bean definition for bean 'dispatcherServlet' with a different definition: replacing [Root bean: class=null; scope=; abstract=false; lazyInit=null; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; fallback=false; factoryBeanName=org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration$DispatcherServletConfiguration; factoryMethodName=dispatcherServlet; initMethodNames=null; destroyMethodNames=[(inferred)]; defined in class path resource [org/springframework/boot/autoconfigure/web/servlet/DispatcherServletAutoConfiguration$DispatcherServletConfiguration.class]] with [Generic bean: class=org.grails.web.servlet.mvc.GrailsDispatcherServlet; scope=singleton; abstract=false; lazyInit=false; autowireMode=0; dependencyCheck=0; autowireCandidate=true; primary=false; fallback=false; factoryBeanName=null; factoryMethodName=null; initMethodNames=null; destroyMethodNames=null]
Overriding bean definition for bean 'multipartConfigElement' with a different definition: replacing [Root bean: class=null; scope=; abstract=false; lazyInit=null; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; fallback=false; factoryBeanName=org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration; factoryMethodName=multipartConfigElement; initMethodNames=null; destroyMethodNames=[(inferred)]; defined in class path resource [org/springframework/boot/autoconfigure/web/servlet/MultipartAutoConfiguration.class]] with [Generic bean: class=jakarta.servlet.MultipartConfigElement; scope=singleton; abstract=false; lazyInit=false; autowireMode=0; dependencyCheck=0; autowireCandidate=true; primary=false; fallback=false; factoryBeanName=null; factoryMethodName=null; initMethodNames=null; destroyMethodNames=null]
```