### PR TITLE
Don't set layout if none is specified

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -139,7 +139,7 @@ trait ResponseRenderer extends WebAttributes {
         else {
             renderMarkupInternal webRequest, closure, response
         }
-        setLayout webRequest.currentRequest, false, layoutArg
+        setLayout webRequest.currentRequest, layoutArg
     }
 
     private void renderJsonInternal(HttpServletResponse response, @DelegatesTo(value = StreamingJsonBuilder.StreamingJsonDelegate.class, strategy = Closure.DELEGATE_FIRST) Closure callable) {
@@ -163,7 +163,7 @@ trait ResponseRenderer extends WebAttributes {
         applyContentType response, argMap, body
         handleStatusArgument argMap, webRequest, response
         render body
-        setLayout webRequest.currentRequest, false, layoutArg
+        setLayout webRequest.currentRequest, layoutArg
     }
 
     /**
@@ -207,7 +207,7 @@ trait ResponseRenderer extends WebAttributes {
         handleStatusArgument argMap, webRequest, response
         applyContentType response, argMap, writable
         renderWritable writable, response
-        setLayout webRequest.currentRequest, false, layoutArg
+        setLayout webRequest.currentRequest, layoutArg
         webRequest.renderView = false
     }
 
@@ -235,7 +235,7 @@ trait ResponseRenderer extends WebAttributes {
                 CharSequence text = (textArg instanceof CharSequence) ? ((CharSequence)textArg) : textArg.toString()
                 render text
             }
-            setLayout webRequest.currentRequest, false, layoutArg
+            setLayout webRequest.currentRequest, layoutArg
         }
         else if (argMap.containsKey(ARGUMENT_VIEW)) {
             String viewName = argMap[ARGUMENT_VIEW].toString()
@@ -263,7 +263,7 @@ trait ResponseRenderer extends WebAttributes {
             }
 
             ((GroovyObject)this).setProperty "modelAndView", new ModelAndView(viewUri, model)
-            setLayout webRequest.currentRequest, true, layoutArg
+            setLayout webRequest.currentRequest, layoutArg
         }
         else if (argMap.containsKey(ARGUMENT_TEMPLATE)) {
             applyContentType response, argMap, null, false
@@ -300,7 +300,7 @@ trait ResponseRenderer extends WebAttributes {
                 // if automatic decoration occurred unwrap, since this is a partial
 
                 if (renderWithLayout) {
-                    setLayout webRequest.currentRequest, false, layoutArg
+                    setLayout webRequest.currentRequest, layoutArg
                 }
 
 
@@ -532,7 +532,7 @@ trait ResponseRenderer extends WebAttributes {
         renderArgument instanceof GPathResult ? APPLICATION_XML : defaultEncoding
     }
 
-    private void setLayout(HttpServletRequest request, boolean renderView, String layout) {
+    private void setLayout(HttpServletRequest request, String layout) {
         if (layout == null || request.getAttribute(WebUtils.LAYOUT_ATTRIBUTE) != null) {
             // layout has been set already
             return

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -139,7 +139,7 @@ trait ResponseRenderer extends WebAttributes {
         else {
             renderMarkupInternal webRequest, closure, response
         }
-        applySiteMeshLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+        setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
     }
 
     private void renderJsonInternal(HttpServletResponse response, @DelegatesTo(value = StreamingJsonBuilder.StreamingJsonDelegate.class, strategy = Closure.DELEGATE_FIRST) Closure callable) {
@@ -163,7 +163,7 @@ trait ResponseRenderer extends WebAttributes {
         applyContentType response, argMap, body
         handleStatusArgument argMap, webRequest, response
         render body
-        applySiteMeshLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+        setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
     }
 
     /**
@@ -207,7 +207,7 @@ trait ResponseRenderer extends WebAttributes {
         handleStatusArgument argMap, webRequest, response
         applyContentType response, argMap, writable
         renderWritable writable, response
-        applySiteMeshLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+        setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
         webRequest.renderView = false
     }
 
@@ -235,7 +235,7 @@ trait ResponseRenderer extends WebAttributes {
                 CharSequence text = (textArg instanceof CharSequence) ? ((CharSequence)textArg) : textArg.toString()
                 render text
             }
-            applySiteMeshLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+            setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
         }
         else if (argMap.containsKey(ARGUMENT_VIEW)) {
             String viewName = argMap[ARGUMENT_VIEW].toString()
@@ -263,7 +263,7 @@ trait ResponseRenderer extends WebAttributes {
             }
 
             ((GroovyObject)this).setProperty "modelAndView", new ModelAndView(viewUri, model)
-            applySiteMeshLayout webRequest.currentRequest, true, explicitSiteMeshLayout
+            setLayout webRequest.currentRequest, true, explicitSiteMeshLayout
         }
         else if (argMap.containsKey(ARGUMENT_TEMPLATE)) {
             applyContentType response, argMap, null, false
@@ -300,7 +300,7 @@ trait ResponseRenderer extends WebAttributes {
                 // if automatic decoration occurred unwrap, since this is a partial
 
                 if (renderWithLayout) {
-                    applySiteMeshLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+                    setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
                 }
 
 
@@ -532,13 +532,13 @@ trait ResponseRenderer extends WebAttributes {
         renderArgument instanceof GPathResult ? APPLICATION_XML : defaultEncoding
     }
 
-    private void applySiteMeshLayout(HttpServletRequest request, boolean renderView, String explicitSiteMeshLayout) {
-        if (explicitSiteMeshLayout == null && request.getAttribute(WebUtils.LAYOUT_ATTRIBUTE) != null) {
+    private void setLayout(HttpServletRequest request, boolean renderView, String layout) {
+        if (layout == null && request.getAttribute(WebUtils.LAYOUT_ATTRIBUTE) != null) {
             // layout has been set already
             return
         }
-        if (explicitSiteMeshLayout != null) {
-            request.setAttribute WebUtils.LAYOUT_ATTRIBUTE, explicitSiteMeshLayout
+        if (layout != null) {
+            request.setAttribute WebUtils.LAYOUT_ATTRIBUTE, layout
         }
     }
 

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -533,13 +533,12 @@ trait ResponseRenderer extends WebAttributes {
     }
 
     private void applySiteMeshLayout(HttpServletRequest request, boolean renderView, String explicitSiteMeshLayout) {
-        if(explicitSiteMeshLayout == null && request.getAttribute(WebUtils.LAYOUT_ATTRIBUTE) != null) {
+        if (explicitSiteMeshLayout == null && request.getAttribute(WebUtils.LAYOUT_ATTRIBUTE) != null) {
             // layout has been set already
             return
         }
-        String siteMeshLayout = explicitSiteMeshLayout != null ? explicitSiteMeshLayout : (renderView ? null : WebUtils.NONE_LAYOUT)
-        if(siteMeshLayout != null) {
-            request.setAttribute WebUtils.LAYOUT_ATTRIBUTE, siteMeshLayout
+        if (explicitSiteMeshLayout != null) {
+            request.setAttribute WebUtils.LAYOUT_ATTRIBUTE, explicitSiteMeshLayout
         }
     }
 

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -533,13 +533,11 @@ trait ResponseRenderer extends WebAttributes {
     }
 
     private void setLayout(HttpServletRequest request, boolean renderView, String layout) {
-        if (layout == null && request.getAttribute(WebUtils.LAYOUT_ATTRIBUTE) != null) {
+        if (layout == null || request.getAttribute(WebUtils.LAYOUT_ATTRIBUTE) != null) {
             // layout has been set already
             return
         }
-        if (layout != null) {
-            request.setAttribute WebUtils.LAYOUT_ATTRIBUTE, layout
-        }
+        request.setAttribute WebUtils.LAYOUT_ATTRIBUTE, layout
     }
 
     private String getContextPath(GrailsWebRequest webRequest, Map argMap) {

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -127,7 +127,7 @@ trait ResponseRenderer extends WebAttributes {
     void render(Map argMap, @DelegatesTo(strategy = Closure.DELEGATE_FIRST) Closure closure) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
-        String explicitSiteMeshLayout = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
+        String layoutArg = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
 
         applyContentType response, argMap, closure
         handleStatusArgument argMap, webRequest, response
@@ -139,7 +139,7 @@ trait ResponseRenderer extends WebAttributes {
         else {
             renderMarkupInternal webRequest, closure, response
         }
-        setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+        setLayout webRequest.currentRequest, false, layoutArg
     }
 
     private void renderJsonInternal(HttpServletResponse response, @DelegatesTo(value = StreamingJsonBuilder.StreamingJsonDelegate.class, strategy = Closure.DELEGATE_FIRST) Closure callable) {
@@ -158,12 +158,12 @@ trait ResponseRenderer extends WebAttributes {
     void render(Map argMap, CharSequence body) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
-        String explicitSiteMeshLayout = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
+        String layoutArg = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
 
         applyContentType response, argMap, body
         handleStatusArgument argMap, webRequest, response
         render body
-        setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+        setLayout webRequest.currentRequest, false, layoutArg
     }
 
     /**
@@ -202,12 +202,12 @@ trait ResponseRenderer extends WebAttributes {
     void render(Map argMap, Writable writable) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
-        String explicitSiteMeshLayout = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
+        String layoutArg = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
 
         handleStatusArgument argMap, webRequest, response
         applyContentType response, argMap, writable
         renderWritable writable, response
-        setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+        setLayout webRequest.currentRequest, false, layoutArg
         webRequest.renderView = false
     }
 
@@ -220,7 +220,7 @@ trait ResponseRenderer extends WebAttributes {
     void render(Map argMap) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
-        String explicitSiteMeshLayout = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
+        String layoutArg = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
         boolean statusSet = handleStatusArgument(argMap, webRequest, response)
 
 
@@ -235,7 +235,7 @@ trait ResponseRenderer extends WebAttributes {
                 CharSequence text = (textArg instanceof CharSequence) ? ((CharSequence)textArg) : textArg.toString()
                 render text
             }
-            setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+            setLayout webRequest.currentRequest, false, layoutArg
         }
         else if (argMap.containsKey(ARGUMENT_VIEW)) {
             String viewName = argMap[ARGUMENT_VIEW].toString()
@@ -263,7 +263,7 @@ trait ResponseRenderer extends WebAttributes {
             }
 
             ((GroovyObject)this).setProperty "modelAndView", new ModelAndView(viewUri, model)
-            setLayout webRequest.currentRequest, true, explicitSiteMeshLayout
+            setLayout webRequest.currentRequest, true, layoutArg
         }
         else if (argMap.containsKey(ARGUMENT_TEMPLATE)) {
             applyContentType response, argMap, null, false
@@ -296,11 +296,11 @@ trait ResponseRenderer extends WebAttributes {
                 }
 
 
-                boolean renderWithLayout = (explicitSiteMeshLayout || webRequest.getCurrentRequest().getAttribute(WebUtils.LAYOUT_ATTRIBUTE))
+                boolean renderWithLayout = (layoutArg || webRequest.getCurrentRequest().getAttribute(WebUtils.LAYOUT_ATTRIBUTE))
                 // if automatic decoration occurred unwrap, since this is a partial
 
                 if (renderWithLayout) {
-                    setLayout webRequest.currentRequest, false, explicitSiteMeshLayout
+                    setLayout webRequest.currentRequest, false, layoutArg
                 }
 
 

--- a/grails-web-common/src/main/groovy/org/grails/web/util/WebUtils.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/util/WebUtils.java
@@ -61,7 +61,6 @@ public class WebUtils extends org.springframework.web.util.WebUtils {
     public static final String DISPATCH_ACTION_PARAMETER = "_action_";
     public static final String SEND_ALLOW_HEADER_FOR_INVALID_HTTP_METHOD = "grails.http.invalid.method.allow.header";
     public static final String LAYOUT_ATTRIBUTE = "org.grails.layout.name";
-    public static final String NONE_LAYOUT = "_none_";
     public static final String RENDERING_VIEW = "org.grails.rendering.view";
     public static final String GRAILS_DISPATCH_EXTENSION = ".dispatch";
     public static final String GRAILS_SERVLET_PATH = "/grails";


### PR DESCRIPTION
Currently if no layout is specified, __none__ is set.  Since there is no concept of a none layout in Sitemesh 3, it attempts to find a layout named __none__.

Before 7 is final, more time will need to be spent perfecting layout resolution.   There is not clear separation of concerns.

The following question needs to be addressed prior to RC1

Should layout resolution be specific to controllers?  currently (and prior) this trait is applied to Controllers, RestControllers, and Interceptors.  I am not sure if RestControllers or Interceptors should be so tightly coupled to SiteMesh.

Perhaps all this layout logic should be removed and done directly inside Controller.

