### PR TITLE
remove dbconsole setting. use spring.h2.console.enabled instead

### DIFF
--- a/grails-core/src/main/groovy/grails/config/Settings.groovy
+++ b/grails-core/src/main/groovy/grails/config/Settings.groovy
@@ -139,11 +139,6 @@ interface Settings {
     String FILTER_FORCE_ENCODING = 'grails.filter.forceEncoding'
 
     /**
-     * Whether the H2 dbconsole is enabled or not
-     */
-    String DBCONSOLE_ENABLED = 'grails.dbconsole.enabled'
-
-    /**
      * The converter to use for creating URL tokens in URL mapping. Defaults to camel case.
      */
     String WEB_URL_CONVERTER = "grails.web.url.converter"


### PR DESCRIPTION
this reference to `grails.dbconsole.enabled` is confusing and should be removed.

It has been superseded by `spring.h2.console.enabled` and the docs already point to this configuration. 