### PR TITLE
Allow LinkGenerator to be overridden by autoconfiguration

### DIFF
--- a/grails-plugin-url-mappings/src/main/groovy/org/grails/plugins/web/mapping/UrlMappingsAutoConfiguration.java
+++ b/grails-plugin-url-mappings/src/main/groovy/org/grails/plugins/web/mapping/UrlMappingsAutoConfiguration.java
@@ -47,6 +47,7 @@ public class UrlMappingsAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(name = LinkGenerator.BEAN_NAME)
     public LinkGenerator grailsLinkGenerator() {
         if (cacheUrls == null) {
             cacheUrls = !Environment.isDevelopmentMode() && !Environment.getCurrent().isReloadEnabled();

--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/LinkGenerator.java
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/LinkGenerator.java
@@ -28,6 +28,7 @@ import java.util.Set;
  */
 public interface LinkGenerator {
 
+    String BEAN_NAME = "grailsLinkGenerator";
     String ATTRIBUTE_CONTROLLER = "controller";
     String ATTRIBUTE_RESOURCE = "resource";
     String ATTRIBUTE_ACTION = "action";


### PR DESCRIPTION
We should switch the asset plugin to autoconfiguration with this change (https://github.com/bertramdev/asset-pipeline/commit/fecac5c8fc9db4a0e9e11d56c9ad46e5b6ac6214#diff-5196ae3e10df42808b5a9addbe0a5fa15f8e72515238bd69057a32d43ac7a364)