### PR TITLE
Restore and update GrailsWebDataBindingListenerSpec test

### DIFF
--- a/grails-test-suite-persistence/src/test/groovy/grails/web/databinding/GrailsWebDataBindingListenerSpec.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/grails/web/databinding/GrailsWebDataBindingListenerSpec.groovy
@@ -16,7 +16,6 @@ class GrailsWebDataBindingListenerSpec extends Specification implements GrailsUn
         }
     }
 
-    @Ignore("Too few invocations")
     void "test that DataBindingListener is added to GrailsWebDataBinder"() {
 
         given:
@@ -27,9 +26,9 @@ class GrailsWebDataBindingListenerSpec extends Specification implements GrailsUn
         binder.bind(testWidget, ["name": "Clock"] as SimpleMapDataBindingSource)
 
         then:
-        1 * dataBindingListenerAdapter.supports(TestWidget) >> true
-        1 * dataBindingListenerAdapter.beforeBinding(testWidget, _)
-        1 * dataBindingListenerAdapter.afterBinding(testWidget, _)
+        3 * dataBindingListenerAdapter.supports(TestWidget) >> true
+        3 * dataBindingListenerAdapter.beforeBinding(testWidget, _)
+        3 * dataBindingListenerAdapter.afterBinding(testWidget, _)
     }
 
     static class TestWidget {


### PR DESCRIPTION
This test was disabled with `@Ignore` after the removal of Micronaut.  The methods are all called 3x instead of 1x, but they were being called 0x when `@Ignore` was added.

https://github.com/grails/grails-core/pull/13702/files#diff-d7674e06b1294ce8a4fae2ab1606c48dbd1ff7c1eddb037dfd868dcc59f8fa7e