### PR TITLE
handle properties version lookup in grails-bom

### DIFF
--- a/grails-shell/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 original authors
+ * Copyright 2014-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,12 +96,9 @@ class GrailsDependencyVersions implements DependencyManagement {
      *
      * @return the version with lookup from properties when required
      */
-    String versionLookup(String version){
-        if (version?.startsWith('${') && version?.endsWith('}')) {
-            return versionProperties.get(version.substring(2, version.length()-1))
-        }
-
-        return version
+    String versionLookup(String version) {
+        version?.startsWith('${') && version?.endsWith('}') ?
+                versionProperties[version[2..-2]] : version
     }
 
     protected void addDependency(String group, String artifactId, String version) {

--- a/grails-shell/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
@@ -68,10 +68,40 @@ class GrailsDependencyVersions implements DependencyManagement {
 
     @CompileDynamic
     void addDependencyManagement(GPathResult pom) {
-        pom.dependencyManagement.dependencies.dependency.each { dep ->
-            addDependency(dep.groupId.text(), dep.artifactId.text(), dep.version.text())
-        }
         versionProperties = pom.properties.'*'.collectEntries { [(it.name()): it.text()] }
+        pom.dependencyManagement.dependencies.dependency.each { dep ->
+            addDependency(dep.groupId.text(), dep.artifactId.text(), versionLookup(dep.version.text()))
+        }
+    }
+
+    /**
+     * Handles properties version lookup in grails-bom
+     *
+     *   <properties>
+     *    <ant.version>1.10.15</ant.version>
+     *   </properties>
+     *
+     *   <dependencyManagement>
+     *    <dependencies>
+     *     <dependency>
+     *      <groupId>org.apache.ant</groupId>
+     *      <artifactId>ant</artifactId>
+     *      <version>${ant.version}</version>
+     *     </dependency>
+     *    </dependencies>
+     *   </dependencyManagement>
+     *
+     * @param version
+     *            either the version or the version to lookup
+     *
+     * @return the version with lookup from properties when required
+     */
+    String versionLookup(String version){
+        if (version?.startsWith('${') && version?.endsWith('}')) {
+            return versionProperties.get(version.substring(2, version.length()-1))
+        }
+
+        return version
     }
 
     protected void addDependency(String group, String artifactId, String version) {


### PR DESCRIPTION
test with .`/gradlew assemble`
unzip build/distributions/grails-7.0.0-SNAPSHOT.zip
bin/grails 

Handles properties version lookup in grails-bom

https://repo.grails.org/ui/repos/tree/PomView/libs-snapshots-local/org/grails/grails-bom/7.0.0-SNAPSHOT/grails-bom-7.0.0-20241229.020850-191.pom

${profiles-angular.version} was coming from grails-bom and `org.grails.cli.boot.GrailsDependencyVersions` needed to be updated to handle version lookup

```
<properties>
     <profiles-angular.version>10.0.1</profiles-angular.versio>
</properties>
<dependencyManagement>
     <dependencies>
          <dependency>
               <groupId>org.grails.profiles</groupId>
               <artifactId>angular</artifactId>
               <version>${profiles-angular.version}</version>
          </dependency>
     </dependencies>
</dependencyManagement>
```