### PR TITLE
Ensure the section path shows when it fails to generate

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/DocPublisher.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/DocPublisher.groovy
@@ -496,9 +496,14 @@ class DocPublisher {
             varsCopy.sponsorLogo = injectPath(sponsorLogo, varsCopy.path)
         }
 
-        new File("${targetDir}/${section.name}.html").withWriter(encoding) { writer ->
-            varsCopy.content = accumulatedContent.toString()
-            layoutTemplate.make(varsCopy).writeTo(writer)
+        try {
+            new File("${targetDir}/${section.name}.html").withWriter(encoding) { writer ->
+                varsCopy.content = accumulatedContent.toString()
+                layoutTemplate.make(varsCopy).writeTo(writer)
+            }
+        }
+        catch(e) {
+            throw new IllegalStateException("Unable to generate section ${targetDir}/${section.name}.html", e)
         }
 
         return varsCopy.content


### PR DESCRIPTION
I'm working on the gsp project clean-up with common-build and running into a null pointer.  I need the details of where this exception is happening ...