### PR TITLE
Remove grails gradle plugin usage since the plugins are not full grails apps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,7 +260,7 @@ subprojects { subproject ->
                                     uri('https://repo.grails.org/grails/plugins3-snapshots-local') :
                                     uri('https://repo.grails.org/grails/libs-snapshots-local')
                         } else {
-                            url 'https://maven.pkg.github.com/grails/grails-core'
+                            url('https://maven.pkg.github.com/grails/grails-core')
                         }
                     }
                 }

--- a/grails-async/plugin/build.gradle
+++ b/grails-async/plugin/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-    }
-    dependencies {
-        classpath "org.grails:grails-gradle-plugin:${project['grails-gradle-plugin.version']}"
-    }
-}
-
-apply plugin: 'org.grails.grails-web'
-apply plugin: 'org.grails.grails-plugin'
-
 dependencies {
     implementation platform(project(':grails-bom'))
 

--- a/grails-docs/src/main/groovy/grails/doc/asciidoc/AsciiDocEngine.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/asciidoc/AsciiDocEngine.groovy
@@ -25,12 +25,12 @@ class AsciiDocEngine extends DocEngine {
     ]
     @Override
     String render(String content, RenderContext context) {
+        Attributes attrs = Attributes.builder().build()
+        attrs.setAttributes(attributes)
+
         def optionsBuilder = Options.builder()
             .standalone(false)
-            .attributes(Attributes.builder()
-                .imagesDir(attributes['imagesdir'])
-                .sourceHighlighter(attributes[ 'source-highlighter'])
-                .icons('icons').build())
+            .attributes(attrs)
 
         if (attributes.containsKey('safe')) {
             optionsBuilder.safe(SafeMode.valueOf(attributes.get('safe').toString()))

--- a/grails-events/plugin/build.gradle
+++ b/grails-events/plugin/build.gradle
@@ -1,19 +1,8 @@
-buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-    }
-    dependencies {
-        classpath "org.grails:grails-gradle-plugin:${project['grails-gradle-plugin.version']}"
-    }
-}
-
 plugins {
     id 'groovy'
     id 'java'
     id 'java-library'
 }
-
-apply plugin: 'org.grails.grails-plugin'
 
 dependencies {
     implementation platform(project(':grails-bom'))

--- a/grails-plugin-converters/build.gradle
+++ b/grails-plugin-converters/build.gradle
@@ -1,20 +1,8 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-
-buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-    }
-    dependencies {
-        classpath "org.grails:grails-gradle-plugin:${project['grails-gradle-plugin.version']}"
-    }
-}
-
 group = 'org.grails.plugins'
 version = projectVersion
 
 apply plugin: 'groovy'
 apply plugin: 'java-library'
-apply plugin: 'org.grails.grails-plugin'
 
 dependencies {
     implementation platform(project(':grails-bom'))


### PR DESCRIPTION
Grails Plugins that do not provide views (need the view compiler) or do not run independently have no need for the grails gradle plugins.  It's a better design to have a separate test project that imports the plugin to show the functionality.  

Another way to put this: the gradle plugin seems to only impact the build of the plugin and not what's exported.  If you only export the code via gradle & test externally it's not needed.  

Going forward, this can lead to a huge amount of cleanup since we aren't including the grails gradle plugin, which is then including grails-core again, and many other side effects.  It eliminates a key circular dependency that can cause unexpected behaviors and greatly simplifies our build files.  

It also helps us decide what plugins to apply.  For example, by not applying the grails gradle plugin, the dependency plugin doesn't get applied which gives us consistent resolution of dependencies.  

Finally, it's overhead we don't need in our build process.