### PR TITLE
Fixing issue with rxjava2/3 based Promise implementations not handling null

### DIFF
--- a/grails-async/rxjava2/src/main/groovy/org/grails/async/factory/rxjava2/RxPromise.groovy
+++ b/grails-async/rxjava2/src/main/groovy/org/grails/async/factory/rxjava2/RxPromise.groovy
@@ -41,9 +41,10 @@ class RxPromise<T>  implements Promise<T> {
     protected boolean finished = false
 
     RxPromise(RxPromiseFactory promiseFactory, Closure callable, Scheduler scheduler) {
+
         this(promiseFactory, Single.create( { SingleEmitter<? super T> singleSubscriber ->
             try {
-                singleSubscriber.onSuccess((T)callable.call())
+                singleSubscriber.onSuccess((T)runCallable(callable))
             } catch (Throwable t) {
                 singleSubscriber.onError(t)
             }
@@ -156,6 +157,15 @@ class RxPromise<T>  implements Promise<T> {
             else {
                 throw e
             }
+        }
+    }
+
+    static Object runCallable(Closure callable) {
+        Object rtn = callable.call()
+        if(rtn == null) {
+            return Void
+        } else {
+            return rtn
         }
     }
 }

--- a/grails-async/rxjava2/src/test/groovy/org/grails/async/factory/rxjava2/RxPromiseSpec.groovy
+++ b/grails-async/rxjava2/src/test/groovy/org/grails/async/factory/rxjava2/RxPromiseSpec.groovy
@@ -56,9 +56,8 @@ class RxPromiseSpec extends Specification {
 
     void 'Test promise null handling'() {
 
-        when: 'a promise map is created'
+        when: 'a null promise result is created'
         def promise = Promises.createPromise {
-            sleep 1000
             return null
         }
         def result = promise.get()

--- a/grails-async/rxjava2/src/test/groovy/org/grails/async/factory/rxjava2/RxPromiseSpec.groovy
+++ b/grails-async/rxjava2/src/test/groovy/org/grails/async/factory/rxjava2/RxPromiseSpec.groovy
@@ -54,6 +54,19 @@ class RxPromiseSpec extends Specification {
             result == [one: 1, two: 2, four: 4]
     }
 
+    void 'Test promise null handling'() {
+
+        when: 'a promise map is created'
+        def promise = Promises.createPromise {
+            sleep 1000
+            return null
+        }
+        def result = promise.get()
+
+        then: 'result is void'
+        result == Void
+    }
+
     void 'Test promise list handling'() {
 
         when: 'a promise list is created from two promises'

--- a/grails-async/rxjava3/src/main/groovy/org/grails/async/factory/rxjava3/RxPromise.groovy
+++ b/grails-async/rxjava3/src/main/groovy/org/grails/async/factory/rxjava3/RxPromise.groovy
@@ -41,7 +41,7 @@ class RxPromise<T>  implements Promise<T> {
     RxPromise(RxPromiseFactory promiseFactory, Closure callable, Scheduler scheduler) {
         this(promiseFactory, Single.create( { SingleEmitter<? super T> singleSubscriber ->
             try {
-                singleSubscriber.onSuccess((T)callable.call())
+                singleSubscriber.onSuccess((T)runCallable(callable))
             } catch (Throwable t) {
                 singleSubscriber.onError(t)
             }
@@ -154,6 +154,15 @@ class RxPromise<T>  implements Promise<T> {
             else {
                 throw e
             }
+        }
+    }
+
+    static Object runCallable(Closure callable) {
+        Object rtn = callable.call()
+        if(rtn == null) {
+            return Void
+        } else {
+            return rtn
         }
     }
 }

--- a/grails-async/rxjava3/src/test/groovy/org/grails/async/factory/rxjava3/RxPromiseSpec.groovy
+++ b/grails-async/rxjava3/src/test/groovy/org/grails/async/factory/rxjava3/RxPromiseSpec.groovy
@@ -43,9 +43,8 @@ class RxPromiseSpec extends Specification {
 
     void 'Test promise null handling'() {
 
-        when: 'a promise map is created'
+        when: 'a null promise result is created'
         def promise = Promises.createPromise {
-            sleep 1000
             return null
         }
         def result = promise.get()

--- a/grails-async/rxjava3/src/test/groovy/org/grails/async/factory/rxjava3/RxPromiseSpec.groovy
+++ b/grails-async/rxjava3/src/test/groovy/org/grails/async/factory/rxjava3/RxPromiseSpec.groovy
@@ -41,6 +41,19 @@ class RxPromiseSpec extends Specification {
 
     }
 
+    void 'Test promise null handling'() {
+
+        when: 'a promise map is created'
+        def promise = Promises.createPromise {
+            sleep 1000
+            return null
+        }
+        def result = promise.get()
+
+        then: 'result is void'
+        result == Void
+    }
+
     void 'Test promise map handling'() {
 
         when: 'a promise map is created'


### PR DESCRIPTION
It can be often the case that a Promise is used for the purposes of asynchronous operations in an isolated thread / persistence interceptor context. These async operations may not even care about a return type because they may be kicking off other error handling behaviors. In the case of the rxjava based implementations, rxjava gets angry when a return is null based and throws several exceptions: 

Example: 
```bash
RxPromiseSpec > Test promise null handling FAILED
    java.lang.NullPointerException: onSuccess called with null. Null values are generally not allowed in 2.x operators and sources.
        at io.reactivex.internal.operators.single.SingleCreate$Emitter.onSuccess(SingleCreate.java:65)
        at org.grails.async.factory.rxjava2.RxPromise$_closure1.doCall(RxPromise.groovy:47)
        at groovy.lang.Closure.call(Closure.java:433)
        at io.reactivex.internal.operators.single.SingleCreate.subscribeActual(SingleCreate.java:39)
        at io.reactivex.Single.subscribe(Single.java:3666)
        at io.reactivex.internal.operators.single.SingleSubscribeOn$SubscribeOnObserver.run(SingleSubscribeOn.java:89)
        at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:608)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)

```


This PR resolves this by translating null to a Void object type which allows this to pass through and behave like other Promise implementations.