### PR TITLE
Add `grails-web-taglib` to test dependencies

### DIFF
--- a/grails-test-examples/async-events-pubsub-demo/build.gradle
+++ b/grails-test-examples/async-events-pubsub-demo/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-logging'
     implementation 'org.springframework.boot:spring-boot-starter-tomcat'
 
+    compileOnly 'org.grails:grails-web-taglib'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.fusesource.jansi:jansi'
     runtimeOnly 'com.zaxxer:HikariCP'

--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(':grails-async-plugin')
     testImplementation "org.grails.plugins:gsp"
     testImplementation "org.grails:grails-gorm-testing-support"
+    testImplementation "org.grails:grails-web-taglib"
     testImplementation "org.grails:grails-web-testing-support"
 
     testImplementation "com.fasterxml.jackson.core:jackson-databind"

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
     testImplementation "org.grails.plugins:converters"
     testImplementation "org.grails:grails-datastore-gorm-hibernate5"
+    testImplementation "org.grails:grails-web-taglib"
     testImplementation "org.grails:grails-web-testing-support"
     testImplementation "org.grails.plugins:gsp"
     testImplementation project(':grails-async-plugin')


### PR DESCRIPTION
This is a temporary fix to get the tests working while we sort out the right dependency scopes in `grails-gsp`.