### PR TITLE
Enhance `PollingConditions` usage in tests

### DIFF
--- a/grails-async/core/src/test/groovy/grails/async/FutureTaskPromiseFactorySpec.groovy
+++ b/grails-async/core/src/test/groovy/grails/async/FutureTaskPromiseFactorySpec.groovy
@@ -52,9 +52,9 @@ class FutureTaskPromiseFactorySpec extends Specification {
             list.onComplete { List l -> result = l }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result
-                result == [2, 4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result
+                assert result == [2, 4]
             }
 
         when: 'a promise list is created from two closures'
@@ -62,8 +62,8 @@ class FutureTaskPromiseFactorySpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [4, 8]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [4, 8]
             }
     }
 
@@ -92,9 +92,9 @@ class FutureTaskPromiseFactorySpec extends Specification {
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
             thrown(ExecutionException)
-            new PollingConditions(timeout: 5).eventually {
-                !result
-                error
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !result
+                assert error
             }
     }
 

--- a/grails-async/core/src/test/groovy/grails/async/PromiseListSpec.groovy
+++ b/grails-async/core/src/test/groovy/grails/async/PromiseListSpec.groovy
@@ -37,8 +37,8 @@ class PromiseListSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'then the result from onComplete is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [1, 2, 3]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [1, 2, 3]
             }
     }
 
@@ -53,8 +53,8 @@ class PromiseListSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'then the result from onComplete is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [1, 2, 3]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [1, 2, 3]
             }
     }
 

--- a/grails-async/core/src/test/groovy/grails/async/PromiseMapSpec.groovy
+++ b/grails-async/core/src/test/groovy/grails/async/PromiseMapSpec.groovy
@@ -33,11 +33,11 @@ class PromiseMapSpec extends Specification {
             map.onComplete { result = it }
 
         then: 'an appropriately populated map is returned to the onComplete event'
-            new PollingConditions(timeout: 5).eventually {
-                result
-                result['one'] == 1
-                result['four'] == 4
-                result['eight'] == 8
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result
+                assert result['one'] == 1
+                assert result['four'] == 4
+                assert result['eight'] == 8
             }
     }
     
@@ -52,11 +52,11 @@ class PromiseMapSpec extends Specification {
             map.onComplete { result = it }
 
         then: 'an appropriately populated map is returned to the onComplete event'
-            new PollingConditions(timeout: 5).eventually {
-                result
-                result['one'] == 1
-                result['four'] == 4
-                result['eight'] == 8
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result
+                assert result['one'] == 1
+                assert result['four'] == 4
+                assert result['eight'] == 8
             }
     }
 
@@ -69,13 +69,14 @@ class PromiseMapSpec extends Specification {
             map['eight'] = { 4 * 2 }
             def result = null
             map.onComplete { result = it }
-            sleep 300
 
         then: 'an appropriately populated map is returned to the onComplete event'
-            result
-            result['one'] == 1
-            result['four'] == 4
-            result['eight'] == 8
+            new PollingConditions(timeout: 5, delay: 0.2, initialDelay: 0.3).eventually {
+                assert result
+                assert result['one'] == 1
+                assert result['four'] == 4
+                assert result['eight'] == 8
+            }
     }
 
     void 'Test that a PromiseMap triggers onError for an exception and ignores onComplete'() {
@@ -89,12 +90,13 @@ class PromiseMapSpec extends Specification {
             Throwable err = null
             map.onComplete { result = it }
             map.onError { err = it }
-            sleep 300
 
         then: 'An appropriately populated map is returned to the onComplete event'
-            !result
-            err
-            err.message == 'java.lang.RuntimeException: bad'
+            new PollingConditions(timeout: 5, delay: 0.2, initialDelay: 0.3).eventually {
+                assert !result
+                assert err
+                assert err.message == 'java.lang.RuntimeException: bad'
+            }
     }
 
     @PendingFeature(reason = '''

--- a/grails-async/core/src/test/groovy/grails/async/PromiseSpec.groovy
+++ b/grails-async/core/src/test/groovy/grails/async/PromiseSpec.groovy
@@ -68,11 +68,11 @@ class PromiseSpec extends Specification {
 
         when: 'a promise list is created from two promises'
             def p1 = Promises.createPromise {
-                sleep 200
+                sleep 200 // simulate long running task
                 1 + 1
             }
             def p2 = Promises.createPromise {
-                sleep 200
+                sleep 200 // simulate long running task
                 2 + 2
             }
             def list = Promises.createPromise(p1, p2)
@@ -80,8 +80,8 @@ class PromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [2, 4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [2, 4]
             }
     }
 
@@ -95,8 +95,8 @@ class PromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [2, 4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [2, 4]
             }
 
         when: 'a promise list is created from two closures'
@@ -104,8 +104,8 @@ class PromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [6, 8]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [6, 8]
             }
     }
 
@@ -119,9 +119,9 @@ class PromiseSpec extends Specification {
             promise.onError { hasError = true }
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                result == 2
-                hasError == false
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 2
+                assert hasError == false
             }
     }
 
@@ -135,10 +135,10 @@ class PromiseSpec extends Specification {
             promise.onError { error = it }
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                !result
-                error
-                error.message.contains('bad')
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !result
+                assert error
+                assert error.message.contains('bad')
             }
     }
 

--- a/grails-async/core/src/test/groovy/grails/async/SynchronousPromiseFactorySpec.groovy
+++ b/grails-async/core/src/test/groovy/grails/async/SynchronousPromiseFactorySpec.groovy
@@ -66,8 +66,8 @@ class SynchronousPromiseFactorySpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [2, 4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [2, 4]
             }
 
         when: 'a promise list is created from two closures'
@@ -75,8 +75,8 @@ class SynchronousPromiseFactorySpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [6, 8]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [6, 8]
             }
     }
 
@@ -90,9 +90,9 @@ class SynchronousPromiseFactorySpec extends Specification {
             promise.onError { hasError = true }
 
         then: 'The onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                result == 2
-                hasError == false
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 2
+                assert hasError == false
             }
     }
 
@@ -106,10 +106,10 @@ class SynchronousPromiseFactorySpec extends Specification {
             promise.onError { error = it }
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                !result
-                error
-                error.message == 'bad'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !result
+                assert error
+                assert error.message == 'bad'
             }
     }
 

--- a/grails-async/gpars/src/test/groovy/grails/async/GparsPromiseSpec.groovy
+++ b/grails-async/gpars/src/test/groovy/grails/async/GparsPromiseSpec.groovy
@@ -80,8 +80,8 @@ class GparsPromiseSpec extends Specification {
             promiseList.onComplete { List v -> result = v }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [2, 4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [2, 4]
             }
 
         when: 'a promise list is created from two closures'
@@ -90,8 +90,8 @@ class GparsPromiseSpec extends Specification {
             promiseList.onComplete { List v -> result = v }
 
         then: 'The result is correct'
-            new PollingConditions(timeout: 5) {
-                result == [2,4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [2,4]
             }
     }
 
@@ -105,9 +105,9 @@ class GparsPromiseSpec extends Specification {
             promise.onError { hasError = true }
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                result == 2
-                hasError == false
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 2
+                assert hasError == false
             }
     }
 
@@ -121,10 +121,10 @@ class GparsPromiseSpec extends Specification {
             promise.onError { error = it }
 
         then: 'the onError handler is invoked and the onComplete handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                !result
-                error
-                error.message == 'bad'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !result
+                assert error
+                assert error.message == 'bad'
             }
     }
 

--- a/grails-async/rxjava/src/test/groovy/org/grails/async/factory/rxjava/RxJavaPromiseListSpec.groovy
+++ b/grails-async/rxjava/src/test/groovy/org/grails/async/factory/rxjava/RxJavaPromiseListSpec.groovy
@@ -21,8 +21,8 @@ class RxJavaPromiseListSpec extends Specification{
             list.onComplete { result = it }
 
         then: 'then the result from onComplete is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [1,2,3]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [1,2,3]
             }
     }
 
@@ -37,8 +37,8 @@ class RxJavaPromiseListSpec extends Specification{
             list.onComplete { result = it }
 
         then: 'then the result from onComplete is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [1,2,3]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [1,2,3]
             }
     }
 

--- a/grails-async/rxjava/src/test/groovy/org/grails/async/factory/rxjava/RxJavaPromiseMapSpec.groovy
+++ b/grails-async/rxjava/src/test/groovy/org/grails/async/factory/rxjava/RxJavaPromiseMapSpec.groovy
@@ -18,11 +18,11 @@ class RxJavaPromiseMapSpec extends Specification{
             map.onComplete { result = it }
 
         then: 'an appropriately populated map is returned to the onComplete event'
-            new PollingConditions(timeout: 5).eventually {
-                result
-                result['one'] == 1
-                result['four'] == 4
-                result['eight'] == 8
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result
+                assert result['one'] == 1
+                assert result['four'] == 4
+                assert result['eight'] == 8
             }
     }
 
@@ -37,11 +37,11 @@ class RxJavaPromiseMapSpec extends Specification{
             map.onComplete { result = it }
 
         then: 'an appropriately populated map is returned to the onComplete event'
-            new PollingConditions(timeout: 5).eventually {
-                result
-                result['one'] == 1
-                result['four'] == 4
-                result['eight'] == 8
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result
+                assert result['one'] == 1
+                assert result['four'] == 4
+                assert result['eight'] == 8
             }
     }
 
@@ -56,11 +56,11 @@ class RxJavaPromiseMapSpec extends Specification{
             map.onComplete { result = it }
 
         then: 'an appropriately populated map is returned to the onComplete event'
-            new PollingConditions(timeout: 5).eventually {
-                result
-                result['one'] == 1
-                result['four'] == 4
-                result['eight'] == 8
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result
+                assert result['one'] == 1
+                assert result['four'] == 4
+                assert result['eight'] == 8
             }
     }
 
@@ -79,10 +79,10 @@ class RxJavaPromiseMapSpec extends Specification{
         map.onError { error = it }
 
         then: 'an appropriately populated map is returned to the onComplete event'
-            new PollingConditions(timeout: 5).eventually {
-                !result
-                error
-                error.message == 'bad'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !result
+                assert error
+                assert error.message == 'bad'
             }
     }
 

--- a/grails-async/rxjava/src/test/groovy/org/grails/async/factory/rxjava/RxJavaPromiseSpec.groovy
+++ b/grails-async/rxjava/src/test/groovy/org/grails/async/factory/rxjava/RxJavaPromiseSpec.groovy
@@ -62,8 +62,8 @@ class RxJavaPromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'The result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [2,4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [2,4]
             }
 
         when: 'a promise list is created from two closures'
@@ -71,8 +71,8 @@ class RxJavaPromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [4,8]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [4,8]
             }
     }
 
@@ -86,9 +86,9 @@ class RxJavaPromiseSpec extends Specification {
             promise.onError { hasError = true }
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                result == 2
-                hasError == false
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 2
+                assert hasError == false
             }
     }
 
@@ -102,10 +102,10 @@ class RxJavaPromiseSpec extends Specification {
             promise.onError { error = it }
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                !result
-                error
-                error.message == 'bad'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !result
+                assert error
+                assert error.message == 'bad'
             }
     }
 

--- a/grails-async/rxjava2/src/test/groovy/org/grails/async/factory/rxjava2/RxPromiseListSpec.groovy
+++ b/grails-async/rxjava2/src/test/groovy/org/grails/async/factory/rxjava2/RxPromiseListSpec.groovy
@@ -20,8 +20,8 @@ class RxPromiseListSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'then the result from onComplete is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [1,2,3]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [1,2,3]
             }
     }
 
@@ -36,8 +36,8 @@ class RxPromiseListSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'then the result from onComplete is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [1,2,3]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [1,2,3]
             }
     }
 

--- a/grails-async/rxjava2/src/test/groovy/org/grails/async/factory/rxjava2/RxPromiseSpec.groovy
+++ b/grails-async/rxjava2/src/test/groovy/org/grails/async/factory/rxjava2/RxPromiseSpec.groovy
@@ -76,8 +76,8 @@ class RxPromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [2,4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [2,4]
             }
 
         when: 'a promise list is created from two closures'
@@ -85,8 +85,8 @@ class RxPromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [4,8]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [4,8]
             }
     }
 
@@ -100,9 +100,9 @@ class RxPromiseSpec extends Specification {
             promise.onError { hasError = true }
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                result == 2
-                hasError == false
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 2
+                assert hasError == false
             }
     }
 
@@ -116,10 +116,10 @@ class RxPromiseSpec extends Specification {
             promise.onError { error = it }
 
         then: 'the onComplete handler is ignored and the onError handler is invoked'
-            new PollingConditions(timeout: 5).eventually {
-                !result
-                error
-                error.message == 'bad'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !result
+                assert error
+                assert error.message == 'bad'
             }
     }
 

--- a/grails-async/rxjava3/src/test/groovy/org/grails/async/factory/rxjava3/RxPromiseListSpec.groovy
+++ b/grails-async/rxjava3/src/test/groovy/org/grails/async/factory/rxjava3/RxPromiseListSpec.groovy
@@ -17,8 +17,8 @@ class RxPromiseListSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'then the result from onComplete is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [1,2,3]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [1,2,3]
             }
     }
 
@@ -33,8 +33,8 @@ class RxPromiseListSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'then the result from onComplete is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [1,2,3]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [1,2,3]
             }
     }
 

--- a/grails-async/rxjava3/src/test/groovy/org/grails/async/factory/rxjava3/RxPromiseSpec.groovy
+++ b/grails-async/rxjava3/src/test/groovy/org/grails/async/factory/rxjava3/RxPromiseSpec.groovy
@@ -73,8 +73,8 @@ class RxPromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [2,4]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [2,4]
             }
 
         when: 'a promise list is created from two closures'
@@ -82,8 +82,8 @@ class RxPromiseSpec extends Specification {
             list.onComplete { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == [4,8]
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == [4,8]
             }
     }
 
@@ -97,9 +97,9 @@ class RxPromiseSpec extends Specification {
             promise.onError { hasError = true }
 
         then: 'the onComplete handler is invoked and the onError handler is ignored'
-            new PollingConditions(timeout: 5).eventually {
-                result == 2
-                hasError == false
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 2
+                assert hasError == false
             }
     }
 
@@ -113,10 +113,10 @@ class RxPromiseSpec extends Specification {
             promise.onError { error = it }
 
         then: 'the onComplete handler is ignored and the onError handler is invoked'
-            new PollingConditions(timeout: 5).eventually {
-                !result
-                error
-                error.message == 'bad'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !result
+                assert error
+                assert error.message == 'bad'
             }
     }
 

--- a/grails-core/src/test/groovy/grails/boot/DevelopmentModeWatchSpec.groovy
+++ b/grails-core/src/test/groovy/grails/boot/DevelopmentModeWatchSpec.groovy
@@ -24,7 +24,6 @@ class DevelopmentModeWatchSpec extends Specification {
         GrailsApp app = new GrailsApp(GrailsTestConfigurationClass.class)
         ConfigurableApplicationContext context = app.run()
         WatchedResourcesGrailsPlugin plugin = context.getBean('grailsPluginManager').pluginList[0].plugin.instance
-        def pollingCondition = new PollingConditions(timeout: 10)
 
         when:
         File watchedFile = new File('testWatchedFile.properties')
@@ -32,7 +31,7 @@ class DevelopmentModeWatchSpec extends Specification {
         watchedFile.write 'foo.bar=baz'
 
         then:
-        pollingCondition.eventually {
+        new PollingConditions(timeout: 10).eventually {
             assert plugin.fileIsChanged.endsWith('testWatchedFile.properties')
         }
 

--- a/grails-events/gpars/src/test/groovy/org/grails/events/gpars/ActorEventBusSpec.groovy
+++ b/grails-events/gpars/src/test/groovy/org/grails/events/gpars/ActorEventBusSpec.groovy
@@ -18,8 +18,8 @@ class ActorEventBusSpec extends Specification {
             eventBus.notify('test', 'bar')
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == 'foo bar'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 'foo bar'
             }
     }
 
@@ -36,8 +36,8 @@ class ActorEventBusSpec extends Specification {
         eventBus.notify('test', 'bar', 'baz')
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == 'foo [bar, baz]'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 'foo [bar, baz]'
             }
     }
 
@@ -54,8 +54,8 @@ class ActorEventBusSpec extends Specification {
             eventBus.notify('test', 'bar', 'baz')
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == 'foo bar baz'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 'foo bar baz'
             }
     }
 
@@ -72,8 +72,8 @@ class ActorEventBusSpec extends Specification {
         eventBus.sendAndReceive('test', 'bar') { result = it }
 
         then: 'the result is correct'
-            new PollingConditions(timeout: 5).eventually {
-                result == 'foo bar'
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result == 'foo bar'
             }
     }
 
@@ -92,8 +92,8 @@ class ActorEventBusSpec extends Specification {
             eventBus.sendAndReceive('test', 'bar') { result = it }
 
         then: 'the result is a throwable'
-            new PollingConditions(timeout: 5).eventually {
-                result instanceof Throwable
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert result instanceof Throwable
             }
     }
 

--- a/grails-events/rxjava/src/test/groovy/org/grails/events/rxjava/PublishSubscribeSpringSpec.groovy
+++ b/grails-events/rxjava/src/test/groovy/org/grails/events/rxjava/PublishSubscribeSpringSpec.groovy
@@ -35,22 +35,22 @@ class PublishSubscribeSpringSpec extends Specification {
             publisher.sum(1, 2)
 
         then: 'the subscriber is notified'
-            new PollingConditions(timeout: 5).eventually {
-                !subscriber.error
-                subscriber.total == 3
-                subscriber.events.size() == 1
-                subscriber.events[0].parameters == [a:1,b:2]
-                subscriber.transactionalInvoked
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !subscriber.error
+                assert subscriber.total == 3
+                assert subscriber.events.size() == 1
+                assert subscriber.events[0].parameters == [a:1,b:2]
+                assert subscriber.transactionalInvoked
             }
 
         when: 'we invoke a method on the publisher with the wrong type for the subscriber'
             publisher.wrongType()
 
         then: 'the subscriber is not notified'
-            new PollingConditions(timeout: 5).eventually {
-                !subscriber.error
-                subscriber.total == 3
-                subscriber.events.size() == 2
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert !subscriber.error
+                assert subscriber.total == 3
+                assert subscriber.events.size() == 2
             }
 
         when: 'we invoke a method on the publisher that throws an exception'
@@ -59,10 +59,10 @@ class PublishSubscribeSpringSpec extends Specification {
         then: 'an exception is thrown'
             def e = thrown(RuntimeException)
             e.message == 'bad'
-            new PollingConditions(timeout: 5).eventually {
-                subscriber.error == e
-                subscriber.events.size() == 3
-                subscriber.total == 3
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert subscriber.error == e
+                assert subscriber.events.size() == 3
+                assert subscriber.total == 3
             }
     }
 }

--- a/grails-events/transform/src/test/groovy/grails/events/annotation/PublishSubscribeSpringSpec.groovy
+++ b/grails-events/transform/src/test/groovy/grails/events/annotation/PublishSubscribeSpringSpec.groovy
@@ -53,11 +53,11 @@ class PublishSubscribeSpringSpec extends Specification {
 
         then: 'an exception should be thrown and the subscriber should receive the event'
             def e = thrown(RuntimeException)
-            new PollingConditions(timeout: 5).eventually {
-                e.message == 'bad'
-                subscriber.error == e
-                subscriber.events.size() == 3
-                subscriber.total == 3
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert e.message == 'bad'
+                assert subscriber.error == e
+                assert subscriber.events.size() == 3
+                assert subscriber.total == 3
             }
     }
 }

--- a/grails-test-examples/async-events-pubsub-demo/src/integration-test/groovy/pubsub/demo/PubSubSpec.groovy
+++ b/grails-test-examples/async-events-pubsub-demo/src/integration-test/groovy/pubsub/demo/PubSubSpec.groovy
@@ -24,8 +24,8 @@ class PubSubSpec extends Specification {
             sumService.sum(1, 2)
 
         then: 'the subscriber should receive the events'
-            new PollingConditions(timeout: 5).eventually {
-                totalService.accumulatedTotal == 6
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert totalService.accumulatedTotal == 6
             }
     }
 
@@ -36,9 +36,9 @@ class PubSubSpec extends Specification {
             bookService.saveBook('The Stand')
 
         then: 'no event is fired'
-            new PollingConditions(initialDelay: 0.5).eventually {
-                bookSubscriber.newBooks == []
-                bookSubscriber.insertEvents.empty
+            new PollingConditions(initialDelay: 0.5, timeout: 5, delay: 0.2).eventually {
+                assert bookSubscriber.newBooks == []
+                assert bookSubscriber.insertEvents.empty
             }
     }
 
@@ -48,9 +48,9 @@ class PubSubSpec extends Specification {
             bookService.saveBook('The Stand')
 
         then: 'the event is fired and received'
-            new PollingConditions(timeout: 5).eventually {
-                bookSubscriber.newBooks == ['The Stand']
-                bookSubscriber.insertEvents.size() == 1
+            new PollingConditions(timeout: 5, delay: 0.2).eventually {
+                assert bookSubscriber.newBooks == ['The Stand']
+                assert bookSubscriber.insertEvents.size() == 1
             }
     }
 


### PR DESCRIPTION
- Use the `assert` keyword in `PollingConditions` conditions, as recommended in the [API docs](https://spockframework.org/spock/javadoc/2.3/spock/util/concurrent/PollingConditions.html) and [documentation](https://spockframework.org/spock/docs/2.3/all_in_one.html#_polling_conditions).
- Increase the delay for `PollingConditions` from the default 100ms to 200ms. This adjustment tries to address flakiness observed in CI environments, providing more stability for tests.