### PR TITLE
remove graalvm dependencies only required by asset-pipeline gradle plugin

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
-java=17.0.13-librca
-gradle=8.12
+java=17.0.14-librca
+gradle=8.12.1
 

--- a/dependabot/build.gradle
+++ b/dependabot/build.gradle
@@ -1,4 +1,4 @@
-// Generated on Fri Jan 17 12:13:55 EST 2025 by: ./gradlew :grails-bom:dependabotBuild
+// Generated on Fri Jan 31 16:17:36 PST 2025 by: ./gradlew :grails-bom:dependabotBuild
 plugins {
     id 'java-library'
 }
@@ -17,9 +17,6 @@ dependencies {
     api "io.methvin:directory-watcher:${project['directory-watcher.version']}"
     api "org.xhtmlrenderer:flying-saucer-pdf-openpdf:${project['flying-saucer-pdf-openpdf.version']}"
     api "org.gebish:geb-spock:${project['geb-spock.version']}"
-    api "org.graalvm.sdk:graal-sdk:${project['graal-sdk.version']}"
-    api "org.graalvm.js:js:${project['graal-sdk.version']}"
-    api "org.graalvm.js:js-scriptengine:${project['graal-sdk.version']}"
     api "org.grails:grails-datastore-gorm-hibernate5:${project['grails-datastore-gorm-hibernate5.version']}"
     api "org.grails:grails-datastore-gorm-mongodb:${project['grails-datastore-gorm-mongodb.version']}"
     api "org.grails:grails-datastore-async:${project['grails-datastore.version']}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ preventSnapshotPublish=false
 # https://github.com/grails/grails-gradle-plugin/issues/222
 slf4jPreventExclusion=true
 
-# Generated on Thu Jan 16 10:23:54 EST 2025 by: ./gradlew :grails-bom:syncProps
+# Generated on Sun Feb 02 19:37:49 PST 2025 by: ./gradlew :grails-bom:syncProps
 # Only version value modifications allowed after this point. Do not insert or change version names. 
 ant.version=1.10.15
 asciidoctorj.version=3.0.0
@@ -44,7 +44,6 @@ commons-text.version=1.12.0
 directory-watcher.version=0.18.0
 flying-saucer-pdf-openpdf.version=9.4.0
 geb-spock.version=7.0
-graal-sdk.version=24.1.1
 grails-datastore.version=9.0.0-SNAPSHOT
 grails-datastore-gorm-hibernate5.version=9.0.0-SNAPSHOT
 grails-datastore-gorm-mongodb.version=9.0.0-SNAPSHOT

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -43,8 +43,6 @@ ext {
         org.asciidoctor:asciidoctorj::
         org.fusesource.jansi:jansi::
         org.gebish:geb-spock::
-        org.graalvm.sdk:graal-sdk::
-        org.graalvm.js:js:,scriptengine::graal-sdk
         org.grails.plugins:gsp::
         org.grails:grails-datastore-gorm-hibernate5::
         org.grails:grails-datastore-gorm-mongodb::


### PR DESCRIPTION
These should only be resolved during build process or bootRun by the asset pipeline gradle plugin.

Setting the version of graalvm outside of the asset pipeline plugin results in missing dependencies and unexpected behavior. 

Allows:
https://github.com/bertramdev/asset-pipeline/pull/370