### PR TITLE
set liquibase.version to prevent override from spring-boot-dependencies

### DIFF
--- a/dependabot/build.gradle
+++ b/dependabot/build.gradle
@@ -1,4 +1,4 @@
-// Generated on Mon Feb 03 21:04:18 EST 2025 by: ./gradlew :grails-bom:dependabotBuild
+// Generated on Wed Feb 05 18:23:24 EST 2025 by: ./gradlew :grails-bom:dependabotBuild
 plugins {
     id 'java-library'
 }
@@ -46,6 +46,9 @@ dependencies {
     api "net.java.dev.jna:jna:${project['jna.version']}"
     api "org.webjars.npm:jquery:${project['jquery.version']}"
     api "org.jsoup:jsoup:${project['jsoup.version']}"
+    api "org.liquibase:liquibase-cdi:${project['liquibase.version']}"
+    api "org.liquibase:liquibase-core:${project['liquibase.version']}"
+    api "org.liquibase.ext:liquibase-hibernate5:${project['liquibase.version']}"
     api "org.mongodb:bson:${project['mongodb.version']}"
     api "org.mongodb:bson-record-codec:${project['mongodb.version']}"
     api "org.mongodb:mongodb-driver-core:${project['mongodb.version']}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ preventSnapshotPublish=false
 # https://github.com/grails/grails-gradle-plugin/issues/222
 slf4jPreventExclusion=true
 
-# Generated on Mon Feb 03 21:04:24 EST 2025 by: ./gradlew :grails-bom:syncProps
+# Generated on Wed Feb 05 18:23:13 EST 2025 by: ./gradlew :grails-bom:syncProps
 # Only version value modifications allowed after this point. Do not insert or change version names. 
 ant.version=1.10.15
 asciidoctorj.version=3.0.0
@@ -59,6 +59,7 @@ jline.version=2.14.6
 jna.version=5.16.0
 jquery.version=3.7.1
 jsoup.version=1.18.3
+liquibase.version=4.27.0
 mongodb.version=5.3.1
 objenesis.version=3.4
 plugins-cache.version=8.0.0-SNAPSHOT

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -50,6 +50,8 @@ ext {
         org.grails:views-json-testing-support::
         org.grails.profiles:base,plugin,profile,web,rest-api,web-plugin,rest-api-plugin,react,vue,angular:::profiles
         org.jsoup:jsoup::
+        org.liquibase:liquibase-cdi,liquibase-core:::liquibase
+        org.liquibase.ext:liquibase-hibernate5:::liquibase
         org.mongodb:bson:,record-codec::mongodb
         org.mongodb:mongodb-driver:core,sync::mongodb
         org.objenesis:objenesis::


### PR DESCRIPTION
[Spring boot 3.4.x](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/3.4.2/spring-boot-dependencies-3.4.2.pom) updated to `liquibase-core` 4.29.2 which is not compatible with the current version of `org.liquibase.ext:liquibase-hibernate5` 4.27.0

This overrides the version in grails-bom


```
Grails application running at http://localhost:0 in environment: development
Error |
Command execution error: Could not initialize class com.datical.liquibase.ext.config.ExtendedLiquibaseCommandLineConfiguration

> Task :dbmGenerateChangelog FAILED
6 actionable tasks: 5 executed, 1 up-to-date
<=============> 100% EXECUTING [11s]
> IDLE

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':dbmGenerateChangelog'.
```