### PR TITLE
change gradle-tool-api dependency scope to api & pull from repo.grails.org/core

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -140,7 +140,7 @@ class GrailsCreateStartScripts extends CreateStartScripts {
                 installedFile = "dist/$artifact.file.name"
             }
             installedFile
-        } + "lib/org.gradle/gradle-tooling-api/jars/gradle-tooling-api-${project.findProperty('gradleToolingApiVersion')}.jar".toString() // This is compileOnly, so it needs to be added manually
+        }
         generator.scriptRelPath = "bin/${unixScript.name}"
         generator.generateUnixScript(unixScript)
         generator.generateWindowsScript(windowsScript)

--- a/grails-shell/build.gradle
+++ b/grails-shell/build.gradle
@@ -4,10 +4,6 @@ mainClassName = "org.grails.cli.GrailsCli"
 
 repositories {
     mavenCentral()
-    maven {
-        url = 'https://repo.gradle.org/gradle/libs-releases'
-        description = 'Needed for Gradle Tooling API'
-    }
 }
 
 dependencies {
@@ -32,7 +28,7 @@ dependencies {
     api "org.fusesource.jansi:jansi"
     api "jline:jline"
 
-    compileOnly "org.gradle:gradle-tooling-api:$gradleToolingApiVersion"
+    api "org.gradle:gradle-tooling-api:$gradleToolingApiVersion"
     compileOnly "org.springframework.boot:spring-boot"
     compileOnly "org.springframework.boot:spring-boot-loader-tools"
     compileOnly "org.springframework:spring-web"

--- a/grails-shell/build.gradle
+++ b/grails-shell/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     api "org.apache.ant:ant"
     api "org.fusesource.jansi:jansi"
     api "jline:jline"
-
     api "org.gradle:gradle-tooling-api:$gradleToolingApiVersion"
+    
     compileOnly "org.springframework.boot:spring-boot"
     compileOnly "org.springframework.boot:spring-boot-loader-tools"
     compileOnly "org.springframework:spring-web"


### PR DESCRIPTION
https://repo.grails.org/core now includes a remote repository for https://repo.gradle.org/gradle/libs-releases/ so that we can pull gradle-tool-api from repo.grails.org/core instead of needing to add an extra repository to all projects.

gradle-tool-api is currently required by
- grails-shell build
- grails (grails-shell CLI) command during execution
- grails-shell CLI during execution from IntelliJ -> Run Grails Command

resolves:  https://github.com/grails/grails-core/issues/13958

reverses:
https://github.com/grails/grails-core/pull/13919/files
https://github.com/grails/grails-core/pull/13762/files