### PR TITLE
chore: remove obsolete `grails.factories` file

### DIFF
--- a/grails-plugin-services/src/main/resources/META-INF/grails.factories
+++ b/grails-plugin-services/src/main/resources/META-INF/grails.factories
@@ -1,1 +1,0 @@
-grails.compiler.traits.TraitInjector=grails.compiler.traits.ServiceTraitInjector


### PR DESCRIPTION
Remove the `grails.factories` file in `grails-plugin-services` which referenced a class that was removed in commit db298e21c06a93776d36a3c5b766f71298f54e0d.