### PR TITLE
Update test projects to set hibernate-ehcache dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,8 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1536M -XX:MaxMetaspaceSize=1024M
 
 # libraries only specific to test apps, these should not be exposed
+hibernateVersion=5.6.15.Final
+jbossTransactionApiVersion=2.0.0.Final
 micronautVersion=4.6.5
 micronautSerdeJacksonVersion=2.11.0
 springSecurityCoreVersion=7.0.0-SNAPSHOT

--- a/grails-test-examples/gorm/build.gradle
+++ b/grails-test-examples/gorm/build.gradle
@@ -27,6 +27,13 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
+    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
+    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails"

--- a/grails-test-examples/hyphenated/build.gradle
+++ b/grails-test-examples/hyphenated/build.gradle
@@ -27,6 +27,13 @@ dependencies {
     implementation "org.grails:grails-web-boot"
 
     implementation "org.grails.plugins:hibernate5"
+    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
+    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
     implementation "org.grails.plugins:cache"
 
     runtimeOnly "org.grails.plugins:scaffolding"


### PR DESCRIPTION
While excluding hibernate-core (javax) and including jboss-transaction-api