### PR TITLE
Change closure parameter name to parentName so it is distinct from class field name

### DIFF
--- a/grails-shell/src/main/groovy/org/grails/cli/profile/AbstractProfile.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/profile/AbstractProfile.groovy
@@ -349,10 +349,10 @@ abstract class AbstractProfile implements Profile {
 
     @Override
     public Iterable<Profile> getExtends() {
-        return parentNames.collect() { String name ->
-            def parent = profileRepository.getProfile(name, true)
+        return parentNames.collect() { String parentName ->
+            def parent = profileRepository.getProfile(parentName, true)
             if(parent == null) {
-                throw new IllegalStateException("Profile [$name] declares an invalid dependency on parent profile [$name]")
+                throw new IllegalStateException("Profile [$name] declares an invalid dependency on parent profile [$parentName]")
             }
             return parent
         }


### PR DESCRIPTION
Change closure parameter `name` to `parentName` so it is distinct from class field `name`

Exception now communicates the correct relationship between child and parent profiles
It was displaying the parent profile name twice