### PR TITLE
add type 'pom' and scope 'import' for grails-bom and jackson-bom

### DIFF
--- a/dependabot/build.gradle
+++ b/dependabot/build.gradle
@@ -1,4 +1,4 @@
-// Generated on Wed Feb 05 18:23:24 EST 2025 by: ./gradlew :grails-bom:dependabotBuild
+// Generated on Mon Mar 03 17:24:14 EST 2025 by: ./gradlew :grails-bom:dependabotBuild
 plugins {
     id 'java-library'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ preventSnapshotPublish=true
 # https://github.com/grails/grails-gradle-plugin/issues/222
 slf4jPreventExclusion=true
 
-# Generated on Wed Feb 05 18:23:13 EST 2025 by: ./gradlew :grails-bom:syncProps
+# Generated on Mon Mar 03 17:23:04 EST 2025 by: ./gradlew :grails-bom:syncProps
 # Only version value modifications allowed after this point. Do not insert or change version names. 
 ant.version=1.10.15
 asciidoctorj.version=3.0.0

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -23,7 +23,6 @@ ext {
     dependenciesOverview = """\
         com.bertramlabs.plugins:asset-pipeline-grails::
         com.bertramlabs.plugins:asset-pipeline-gradle::
-        com.fasterxml.jackson:jackson-bom:::jackson
         com.github.javaparser:javaparser-core::
         com.h2database:h2::
         commons-codec:commons-codec::
@@ -36,7 +35,6 @@ ext {
         net.java.dev.jna:jna::
         org.apache.ant:ant:,junit:
         org.apache.commons:commons-text::
-        org.apache.groovy:groovy:bom:::
         org.asciidoctor:asciidoctorj::
         org.fusesource.jansi:jansi::
         org.gebish:geb-spock::
@@ -128,6 +126,23 @@ publishing {
 
                 def dpm = root.appendNode('dependencyManagement')
                 def deps = dpm.appendNode('dependencies')
+
+                appendNodes(deps.appendNode('dependency'), [
+                        groupId: 'org.apache.groovy',
+                        artifactId: 'groovy:bom',
+                        version: '${groovy.version}',
+                        type: 'pom',
+                        scope: 'import'
+                ])
+
+                appendNodes(deps.appendNode('dependency'), [
+                        groupId: 'com.fasterxml.jackson',
+                        artifactId: 'jackson-bom',
+                        version: '${jackson.version}',
+                        type: 'pom',
+                        scope: 'import'
+                ])
+
                 appendNodes(deps.appendNode('dependency'), [
                     groupId: 'org.springframework.boot',
                     artifactId: 'spring-boot-dependencies',

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -167,7 +167,9 @@ publishing {
                 allDependencies.collect { def m = it.subMap('groupId', 'artifactId', 'version')
                     m + [version: "\${${m.version}}"]
                 }.each {
-                    appendNodes(deps.appendNode('dependency'), it)
+                    if(it.artifactId !in ['groovy-bom', 'jackson-bom']) {
+                        appendNodes(deps.appendNode('dependency'), it)
+                    }
                 }
             }
         }

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -99,6 +99,8 @@ allDependencies.each {
 
 dependencies {
     api platform("org.springframework.boot:spring-boot-dependencies:${project['spring-boot.version']}")
+    api platform("org.apache.groovy:groovy-bom:${project['groovy.version']}")
+    api platform("com.fasterxml.jackson:jackson-bom:${project['jackson.version']}")
 
     constraints {
         allDependencies.each {

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -23,6 +23,7 @@ ext {
     dependenciesOverview = """\
         com.bertramlabs.plugins:asset-pipeline-grails::
         com.bertramlabs.plugins:asset-pipeline-gradle::
+        com.fasterxml.jackson:jackson-bom:::jackson
         com.github.javaparser:javaparser-core::
         com.h2database:h2::
         commons-codec:commons-codec::
@@ -35,6 +36,7 @@ ext {
         net.java.dev.jna:jna::
         org.apache.ant:ant:,junit:
         org.apache.commons:commons-text::
+        org.apache.groovy:groovy:bom:::
         org.asciidoctor:asciidoctorj::
         org.fusesource.jansi:jansi::
         org.gebish:geb-spock::

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -129,7 +129,7 @@ publishing {
 
                 appendNodes(deps.appendNode('dependency'), [
                         groupId: 'org.apache.groovy',
-                        artifactId: 'groovy:bom',
+                        artifactId: 'groovy-bom',
                         version: '${groovy.version}',
                         type: 'pom',
                         scope: 'import'


### PR DESCRIPTION
These two BOMs were missing:

```
<type>pom</type>
<scope>import</scope>
```

Now they have type and scope and appear before spring-boot-dependencies

```
<dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>org.apache.groovy</groupId>
        <artifactId>groovy-bom</artifactId>
        <version>${groovy.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
      <dependency>
        <groupId>com.fasterxml.jackson</groupId>
        <artifactId>jackson-bom</artifactId>
        <version>${jackson.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
      <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-dependencies</artifactId>
        <version>${spring-boot.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
....
</dependencyManagement>
```

this resolves the following on groovydoc task when spring-boot-dependencies is using a different Groovy Version.

`Caused by: groovy.lang.GroovyRuntimeException: Conflicting module versions. Module [groovy-xml is loaded in version 4.0.25 and you are trying to load version 4.0.24`