### PR TITLE
Optimize the performance of the Shell CLI by reducing the length of t…

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -7,9 +7,9 @@ apply plugin: GrailsBuildPlugin
 
 List<Configuration> libsConfigurations = []
 subprojects { subproject ->
-    if (subproject.name in ['grails-shell', 'grails-core']) {
+    if (subproject.name == 'grails-shell') {
         libsConfigurations << configurations.create("${subproject.name}-libs") {
-            extendsFrom configurations.compileClasspath, configurations.runtimeClasspath
+            extendsFrom configurations.runtimeClasspath
         }
     }
 }
@@ -40,38 +40,6 @@ tasks.register('configurePopulateDependencies') {
                 if (!projectNames.contains(dependency.name)) {
                     populateDependencies.into("$dependency.group/$dependency.name/jars") {
                         from artifact.file // this will trigger the actual download if necessary
-                        def sourceJar = sourceArtifacts[dependency]
-                        if (sourceJar) {
-                            from sourceJar.file
-                        }
-                        def javadocJar = javadocArtifacts[dependency]
-                        if (javadocJar) {
-                            from javadocJar.file
-                        }
-                    }
-
-                    populateDependencies.into("$dependency.group/$dependency.name/jars") {
-                        from artifact.file // this will trigger the actual download if necessary
-                        def sourceJar = sourceArtifacts[dependency]
-                        if (sourceJar) {
-                            from sourceJar.file
-                        }
-                        def javadocJar = javadocArtifacts[dependency]
-                        if (javadocJar) {
-                            from javadocJar.file
-                        }
-                    }
-
-                    populateDependencies.into("$dependency.group/$dependency.name") {
-                        def pomFile = pomArtifacts[dependency]
-                        if (pomFile) {
-                            from pomFile.file
-                        }
-                    }
-
-                    populateDependencies.from("${metadata}/${dependency.group}/${dependency.name}/${dependency.version}") {
-                        include "**/*ivy.xml"
-                        eachFile { it.path = "$dependency.group/$dependency.name/ivy-${dependency.version}.xml" }
                     }
                 }
             }

--- a/grails-shell/build.gradle
+++ b/grails-shell/build.gradle
@@ -6,6 +6,43 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    // This is a workaround that can optimize the performance of the Shell CLI by reducing the length of the CLASSPATH,
+    // while also solving the problem of the length limit of command line parameters in the Windows environment
+    // This can be removed when we solve the dependencies of grails-bootstrap, grails-shell
+    runtimeClasspath {
+        exclude group: 'commons-codec', module: 'commons-codec'
+        exclude group: 'com.github.ben-manes.caffeine', module: 'caffeine'
+        exclude group: 'jakarta.annotation', module: 'jakarta.annotation-api'
+        exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
+        exclude group: 'javax.annotation', module: 'javax.annotation-api'
+        exclude group: 'javax.inject', module: 'javax.inject'
+        exclude group: 'javax.persistence', module: 'javax.persistence-api'
+        exclude group: 'javax.transaction', module: 'javax.transaction-api'
+        exclude group: 'junit', module: 'junit'
+        exclude group: 'io.micrometer', module: 'micrometer-observation'
+        exclude group: 'io.micrometer', module: 'micrometer-commons'
+        exclude group: 'org.checkerframework', module: 'checker-qual'
+        exclude group: 'org.apache.ant', module: 'ant-antlr'
+        exclude group: 'org.apache.ant', module: 'ant-junit'
+        exclude group: 'org.apache.commons', module: 'commons-compress'
+        exclude group: 'org.apache.groovy', module: 'groovy-groovydoc'
+        exclude group: 'org.apache.groovy', module: 'groovy-jmx'
+        exclude group: 'org.codehaus.plexus', module: 'plexus-classworlds'
+        exclude group: 'org.codehaus.plexus', module: 'plexus-component-annotations'
+        exclude group: 'org.codehaus.plexus', module: 'plexus-sec-dispatcher'
+        exclude group: 'org.hamcrest', module: 'hamcrest'
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+        exclude group: 'org.javassist', module: 'javassist'
+        exclude group: 'org.springframework', module: 'spring-aop'
+        exclude group: 'org.springframework', module: 'spring-expression'
+        exclude group: 'org.springframework', module: 'spring-jcl'
+        exclude group: 'org.springframework', module: 'spring-tx'
+        exclude group: 'org.springframework', module: 'spring-web'
+        exclude group: 'org.springframework.boot', module: 'spring-boot-autoconfigure'
+    }
+}
+
 dependencies {
     // compile grails-shell with the Groovy version provided by Gradle
     // to ensure build compatibility with Gradle, currently Groovy 3.0.x


### PR DESCRIPTION
…he CLASSPATH

* Excludes runtime dependencies of grails-shell
* Only include dependencies of grails-shell in the final distribution, no sources, javadocs, ivy files

Fixes gh-14029