### PR TITLE
fix: ensure correct application class is used in integration tests

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/config/GrailsAutoConfiguration.groovy
+++ b/grails-core/src/main/groovy/grails/boot/config/GrailsAutoConfiguration.groovy
@@ -24,6 +24,7 @@ import org.grails.compiler.injection.AbstractGrailsArtefactTransformer
 import org.grails.spring.aop.autoproxy.GroovyAwareAspectJAwareAdvisorAutoProxyCreator
 import org.grails.spring.aop.autoproxy.GroovyAwareInfrastructureAdvisorAutoProxyCreator
 import org.springframework.aop.config.AopConfigUtils
+import org.springframework.boot.SpringBootConfiguration
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.context.annotation.Bean
@@ -39,6 +40,7 @@ import java.lang.reflect.Field
  *
  */
 @CompileStatic
+@SpringBootConfiguration
 // WARNING: Never add logging to the source of this class, early initialization causes problems
 class GrailsAutoConfiguration implements GrailsApplicationClass, ApplicationContextAware {
 

--- a/grails-core/src/main/groovy/grails/boot/config/GrailsAutoConfiguration.groovy
+++ b/grails-core/src/main/groovy/grails/boot/config/GrailsAutoConfiguration.groovy
@@ -24,7 +24,6 @@ import org.grails.compiler.injection.AbstractGrailsArtefactTransformer
 import org.grails.spring.aop.autoproxy.GroovyAwareAspectJAwareAdvisorAutoProxyCreator
 import org.grails.spring.aop.autoproxy.GroovyAwareInfrastructureAdvisorAutoProxyCreator
 import org.springframework.aop.config.AopConfigUtils
-import org.springframework.boot.SpringBootConfiguration
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.context.annotation.Bean
@@ -40,7 +39,6 @@ import java.lang.reflect.Field
  *
  */
 @CompileStatic
-@SpringBootConfiguration
 // WARNING: Never add logging to the source of this class, early initialization causes problems
 class GrailsAutoConfiguration implements GrailsApplicationClass, ApplicationContextAware {
 

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 package org.grails.compiler.injection
+
 import grails.compiler.ast.AstTransformer
 import grails.compiler.ast.GrailsArtefactClassInjector
-import grails.core.GrailsApplication
 import grails.dev.Support
 import grails.io.ResourceUtils
 import grails.util.BuildSettings
@@ -30,20 +30,18 @@ import org.codehaus.groovy.ast.expr.ClassExpression
 import org.codehaus.groovy.ast.expr.ConstantExpression
 import org.codehaus.groovy.ast.expr.ListExpression
 import org.codehaus.groovy.ast.expr.MethodCallExpression
-import org.codehaus.groovy.ast.expr.PropertyExpression
 import org.codehaus.groovy.ast.stmt.BlockStatement
 import org.codehaus.groovy.ast.stmt.ExpressionStatement
 import org.codehaus.groovy.ast.stmt.ReturnStatement
 import org.codehaus.groovy.ast.stmt.Statement
-import org.codehaus.groovy.ast.tools.GeneralUtils
 import org.codehaus.groovy.classgen.GeneratorContext
 import org.codehaus.groovy.control.SourceUnit
 import org.grails.core.artefact.ApplicationArtefactHandler
 import org.grails.io.support.GrailsResourceUtils
 import org.grails.io.support.UrlResource
 import org.springframework.util.ClassUtils
-import static org.codehaus.groovy.ast.tools.GeneralUtils.*
 import java.lang.reflect.Modifier
+
 /**
  * Injector for the 'Application' class
  *
@@ -54,8 +52,12 @@ import java.lang.reflect.Modifier
 @AstTransformer
 class ApplicationClassInjector implements GrailsArtefactClassInjector {
 
-    public static final String EXCLUDE_MEMBER = "exclude"
-    public static final List<String> EXCLUDED_AUTO_CONFIGURE_CLASSES = ['org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration', 'org.springframework.boot.autoconfigure.reactor.ReactorAutoConfiguration', 'org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration']
+    public static final String EXCLUDE_MEMBER = 'exclude'
+    public static final List<String> EXCLUDED_AUTO_CONFIGURE_CLASSES = [
+            'org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration',
+            'org.springframework.boot.autoconfigure.reactor.ReactorAutoConfiguration',
+            'org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration'
+    ]
 
     ApplicationArtefactHandler applicationArtefactHandler = new ApplicationArtefactHandler()
 
@@ -136,8 +138,6 @@ class ApplicationClassInjector implements GrailsArtefactClassInjector {
             }
         }
     }
-
-
 
     @Override
     boolean shouldInject(URL url) {

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
@@ -118,7 +118,9 @@ class ApplicationClassInjector implements GrailsArtefactClassInjector {
                 }
 
                 // Add @SpringBootConfiguration so that the Application class is picked up by @SpringBootTest
-                addAnnotation('org.springframework.boot.SpringBootConfiguration', classNode)
+                addAnnotation('org.springframework.boot.SpringBootConfiguration', classNode).with {
+                    GrailsASTUtils.addExpressionToAnnotationMember(it, 'proxyBeanMethods', constX(false))
+                }
                 addAnnotation('org.springframework.web.servlet.config.annotation.EnableWebMvc', classNode, 'jakarta.servlet.ServletContext')
                 addAnnotation('org.springframework.boot.autoconfigure.EnableAutoConfiguration', classNode)?.with {
                     for (excludeClassName in EXCLUDED_AUTO_CONFIGURE_CLASSES) {

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
@@ -121,12 +121,8 @@ class ApplicationClassInjector implements GrailsArtefactClassInjector {
                 addAnnotation('org.springframework.boot.SpringBootConfiguration', classNode)
                 addAnnotation('org.springframework.web.servlet.config.annotation.EnableWebMvc', classNode, 'jakarta.servlet.ServletContext')
                 addAnnotation('org.springframework.boot.autoconfigure.EnableAutoConfiguration', classNode)?.with {
-                    def classLoader = getClass().classLoader
                     for (excludeClassName in EXCLUDED_AUTO_CONFIGURE_CLASSES) {
-                        if (ClassUtils.isPresent(excludeClassName, classLoader)) {
-                            def excludeClass = new ClassExpression(ClassHelper.make(classLoader.loadClass(excludeClassName)))
-                            GrailsASTUtils.addExpressionToAnnotationMember(it, EXCLUDE_MEMBER, excludeClass)
-                        }
+                        GrailsASTUtils.addExpressionToAnnotationMember(it, 'excludeName', constX(excludeClassName))
                     }
                 }
             }

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,16 +114,22 @@ class ApplicationClassInjector implements GrailsArtefactClassInjector {
                 }
 
                 def classLoader = getClass().classLoader
-                if(ClassUtils.isPresent('jakarta.servlet.ServletContext', classLoader)) {
-                    GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(classLoader.loadClass('org.springframework.web.servlet.config.annotation.EnableWebMvc')))
+                if (ClassUtils.isPresent('jakarta.servlet.ServletContext', classLoader)) {
+                    GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(
+                            classLoader.loadClass('org.springframework.web.servlet.config.annotation.EnableWebMvc')
+                    ))
                 }
-                if(ClassUtils.isPresent('org.springframework.boot.autoconfigure.EnableAutoConfiguration', classLoader) ) {
-                    def enableAutoConfigurationAnnotation = GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(classLoader.loadClass('org.springframework.boot.autoconfigure.EnableAutoConfiguration')))
-
-                    for(autoConfigureClassName in EXCLUDED_AUTO_CONFIGURE_CLASSES) {
-                        if(ClassUtils.isPresent(autoConfigureClassName, classLoader)) {
+                if (ClassUtils.isPresent('org.springframework.boot.autoconfigure.EnableAutoConfiguration', classLoader) ) {
+                    GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(
+                            classLoader.loadClass('org.springframework.boot.SpringBootConfiguration')
+                    ))
+                    def autoConfigAnn = GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(
+                            classLoader.loadClass('org.springframework.boot.autoconfigure.EnableAutoConfiguration')
+                    ))
+                    for (autoConfigureClassName in EXCLUDED_AUTO_CONFIGURE_CLASSES) {
+                        if (ClassUtils.isPresent(autoConfigureClassName, classLoader)) {
                             def autoConfigClassExpression = new ClassExpression(ClassHelper.make(classLoader.loadClass(autoConfigureClassName)))
-                            GrailsASTUtils.addExpressionToAnnotationMember(enableAutoConfigurationAnnotation, EXCLUDE_MEMBER, autoConfigClassExpression)
+                            GrailsASTUtils.addExpressionToAnnotationMember(autoConfigAnn, EXCLUDE_MEMBER, autoConfigClassExpression)
                         }
                     }
                 }

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
@@ -118,7 +118,7 @@ class ApplicationClassInjector implements GrailsArtefactClassInjector {
                 }
 
                 // Add @SpringBootConfiguration so that the Application class is picked up by @SpringBootTest
-                addAnnotation('org.springframework.boot.SpringBootConfiguration', classNode).with {
+                addAnnotation('org.springframework.boot.SpringBootConfiguration', classNode)?.with {
                     GrailsASTUtils.addExpressionToAnnotationMember(it, 'proxyBeanMethods', constX(false))
                 }
                 addAnnotation('org.springframework.web.servlet.config.annotation.EnableWebMvc', classNode, 'jakarta.servlet.ServletContext')

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
@@ -40,6 +40,7 @@ import org.grails.core.artefact.ApplicationArtefactHandler
 import org.grails.io.support.GrailsResourceUtils
 import org.grails.io.support.UrlResource
 import org.springframework.util.ClassUtils
+import static org.codehaus.groovy.ast.tools.GeneralUtils.*
 import java.lang.reflect.Modifier
 
 /**

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
@@ -23,6 +23,7 @@ import grails.util.BuildSettings
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.apache.groovy.ast.tools.AnnotatedNodeUtils
+import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.expr.ArgumentListExpression
@@ -116,23 +117,15 @@ class ApplicationClassInjector implements GrailsArtefactClassInjector {
                     }
                 }
 
-                def classLoader = getClass().classLoader
-                if (ClassUtils.isPresent('jakarta.servlet.ServletContext', classLoader)) {
-                    GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(
-                            classLoader.loadClass('org.springframework.web.servlet.config.annotation.EnableWebMvc')
-                    ))
-                }
-                if (ClassUtils.isPresent('org.springframework.boot.autoconfigure.EnableAutoConfiguration', classLoader) ) {
-                    GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(
-                            classLoader.loadClass('org.springframework.boot.SpringBootConfiguration')
-                    ))
-                    def autoConfigAnn = GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(
-                            classLoader.loadClass('org.springframework.boot.autoconfigure.EnableAutoConfiguration')
-                    ))
-                    for (autoConfigureClassName in EXCLUDED_AUTO_CONFIGURE_CLASSES) {
-                        if (ClassUtils.isPresent(autoConfigureClassName, classLoader)) {
-                            def autoConfigClassExpression = new ClassExpression(ClassHelper.make(classLoader.loadClass(autoConfigureClassName)))
-                            GrailsASTUtils.addExpressionToAnnotationMember(autoConfigAnn, EXCLUDE_MEMBER, autoConfigClassExpression)
+                // Add @SpringBootConfiguration so that the Application class is picked up by @SpringBootTest
+                addAnnotation('org.springframework.boot.SpringBootConfiguration', classNode)
+                addAnnotation('org.springframework.web.servlet.config.annotation.EnableWebMvc', classNode, 'jakarta.servlet.ServletContext')
+                addAnnotation('org.springframework.boot.autoconfigure.EnableAutoConfiguration', classNode)?.with {
+                    def classLoader = getClass().classLoader
+                    for (excludeClassName in EXCLUDED_AUTO_CONFIGURE_CLASSES) {
+                        if (ClassUtils.isPresent(excludeClassName, classLoader)) {
+                            def excludeClass = new ClassExpression(ClassHelper.make(classLoader.loadClass(excludeClassName)))
+                            GrailsASTUtils.addExpressionToAnnotationMember(it, EXCLUDE_MEMBER, excludeClass)
                         }
                     }
                 }
@@ -145,5 +138,15 @@ class ApplicationClassInjector implements GrailsArtefactClassInjector {
         if(url == null) return false
         def res = new UrlResource(url)
         return GrailsResourceUtils.isGrailsResource(res) && res.filename == "Application.groovy"
+    }
+
+    private AnnotationNode addAnnotation(String annotationClassName, ClassNode classNode, String conditionalClass = null) {
+        def classLoader = getClass().classLoader
+        if (ClassUtils.isPresent(conditionalClass ?: annotationClassName, classLoader)) {
+            return GrailsASTUtils.addAnnotationOrGetExisting(classNode, ClassHelper.make(
+                    classLoader.loadClass(annotationClassName)
+            ))
+        }
+        return null
     }
 }

--- a/grails-testing-support/src/main/groovy/org/grails/compiler/injection/testing/IntegrationTestMixinTransformation.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/compiler/injection/testing/IntegrationTestMixinTransformation.groovy
@@ -144,8 +144,13 @@ class IntegrationTestMixinTransformation implements ASTTransformation {
         if (servletApi != null) {
 
             if( GrailsASTUtils.findAnnotation(classNode, SpringBootTest) == null) {
-                AnnotationNode webIntegrationTestAnnotation = GrailsASTUtils.addAnnotationOrGetExisting(classNode, SpringBootTest)
-                webIntegrationTestAnnotation.addMember("webEnvironment", propX(classX(SpringBootTest.WebEnvironment.class), "RANDOM_PORT"))
+                GrailsASTUtils.addAnnotationOrGetExisting(
+                        classNode, SpringBootTest, [
+                                webEnvironment: propX(classX(SpringBootTest.WebEnvironment), 'RANDOM_PORT'),
+                                useMainMethod: propX(classX(SpringBootTest.UseMainMethod), 'ALWAYS')
+                        ] as Map<String,Object>
+                )
+
                 if(classNode.getProperty("serverPort") == null) {
 
                     def serverPortField = new FieldNode("serverPort", Modifier.PROTECTED, ClassHelper.Integer_TYPE, classNode, new ConstantExpression(8080))


### PR DESCRIPTION
- Add `@SpringBootConfiguration` to `Application` via `ApplicationClassInjector`
- Set `useMainMethod = ALWAYS` in `@SpringBootTest` via `@Integration`

Resolves gh-14012