### PR TITLE
remove --refresh-dependencies to avoid Premature end of Content-Length

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
           DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-        run: ./gradlew build assemble groovydoc -PskipFunctionalTests --continue --refresh-dependencies
+        run: ./gradlew build assemble groovydoc -PskipFunctionalTests --continue
   functional:
     name: "Functional Tests"
     needs: skip_check

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -142,4 +142,3 @@ jobs:
           ./gradlew build
           -PgroovyVersion=${{needs.build_groovy.outputs.groovyVersion}}
           -x groovydoc
-          --refresh-dependencies


### PR DESCRIPTION
to avoid Premature end of Content-Length delimited message body

```
> Could not get resource 'https://repo.grails.org/grails/core/org/grails/grails-async/7.0.0-SNAPSHOT/grails-async-7.0.0-20250313.020438-51.jar'.
                  > Premature end of Content-Length delimited message body (expected: 68,766; received: 12,994)
```

The theory behind this issue is that when we start a matrixed GitHub action it requests the dependencies over and over again from repo.grails.org (JFrog Artifactory) and it looks like a DOS attack from GitHub actions, which JFrog Artifactory is throttling/mitigating.

`--refresh-dependencies` was added to many GitHub workflows to force the workflow to pull the recently published `-SNAPSHOT` dependencies, which occurs often.  The replacement for this approach is to delete all recently used GitHub actions cache and then rerun the action.  
