### PR TITLE
Document removal of package-plugin command

### DIFF
--- a/UPGRADE7.md
+++ b/UPGRADE7.md
@@ -1,23 +1,24 @@
 # Common 7.0 Upgrade Gotchas - DRAFT -
 
 Experienced while upgrading modules for Grails 7
+
 - the following deprecated classes were removed, please use the suggested replacement
-  * grails.core.GrailsTagLibClass -> grails.core.gsp.GrailsTagLibClass
-  * org.grails.core.artefact.TagLibArtefactHandler -> org.grails.core.artefact.gsp.TagLibArtefactHandler
-  * org.grails.core.DefaultGrailsTagLibClass -> org.grails.core.gsp.DefaultGrailsTagLibClass 
+  - grails.core.GrailsTagLibClass -> grails.core.gsp.GrailsTagLibClass
+  - org.grails.core.artefact.TagLibArtefactHandler -> org.grails.core.artefact.gsp.TagLibArtefactHandler
+  - org.grails.core.DefaultGrailsTagLibClass -> org.grails.core.gsp.DefaultGrailsTagLibClass
 - h2 2.x is stricter about reserved words
-  - https://github.com/grails/gorm-hibernate5/pull/910/commits/c8de45df204966ccc228b46b94beeb2142ae0f59 
-- [GROOVY-10621](https://issues.apache.org/jira/browse/GROOVY-10621) 
-  - Primitive booleans will no longer generate the form of isProperty & getProperty.  They will only generate isProperty()
-- The amount of boilerplate required in gradle files has been reduced:  
-  - When `org.grails.grails-plugin` gradle plugin is applied, the bootJar task is disabled by default.  No more needing to explicitly set it to false!
-  - We no longer have a `micronaut-bom` and a `spring-bom`.  We only have the `spring-bom` now, which allows `grails-bom` to inherit from it and be applied as part of the Spring Dependency Management plugin.  This means versions do not need included for any library in the bom.  Override bom versions via gradle properties.
-  - The `grailsPublish` plugin returns and is no longer an internal only plugin.  It has been enhanced to work with some multi-project workflows.  Eliminate publishing boilerplate of the nexus-publish, maven-publish, & signing plugin by adopting it.
+  - https://github.com/grails/gorm-hibernate5/pull/910/commits/c8de45df204966ccc228b46b94beeb2142ae0f59
+- [GROOVY-10621](https://issues.apache.org/jira/browse/GROOVY-10621)
+  - Primitive booleans will no longer generate the form of isProperty & getProperty. They will only generate isProperty()
+- The amount of boilerplate required in gradle files has been reduced:
+  - When `org.grails.grails-plugin` gradle plugin is applied, the bootJar task is disabled by default. No more needing to explicitly set it to false!
+  - We no longer have a `micronaut-bom` and a `spring-bom`. We only have the `spring-bom` now, which allows `grails-bom` to inherit from it and be applied as part of the Spring Dependency Management plugin. This means versions do not need included for any library in the bom. Override bom versions via gradle properties.
+  - The `grailsPublish` plugin returns and is no longer an internal only plugin. It has been enhanced to work with some multi-project workflows. Eliminate publishing boilerplate of the nexus-publish, maven-publish, & signing plugin by adopting it.
 - Jar artifacts produced by Grails Plugins will no longer have the suffix `-plain`
   - https://github.com/grails/grails-gradle-plugin/pull/347
-- [GROOVY-5169](https://issues.apache.org/jira/browse/GROOVY-5169)  [GROOVY-10449](https://issues.apache.org/jira/browse/GROOVY-10449)
+- [GROOVY-5169](https://issues.apache.org/jira/browse/GROOVY-5169) [GROOVY-10449](https://issues.apache.org/jira/browse/GROOVY-10449)
   - Fields with a public modifier were not returned with MetaClassImpl#getProperties() in groovy 3, but are now.
-- Some older libraries may include an older version of groovy, but still be compatible with Groovy 4.  One example is `GPars`.  In your gradle file, you can force a dependency upgrade via this code:
+- Some older libraries may include an older version of groovy, but still be compatible with Groovy 4. One example is `GPars`. In your gradle file, you can force a dependency upgrade via this code:
 
         configurations.configureEach {
             resolutionStrategy.eachDependency { DependencyResolveDetails details ->
@@ -26,16 +27,17 @@ Experienced while upgrading modules for Grails 7
                 }
             }
         }
-- The `jakarta` package switch means that older libraries using `javax` will need to be updated to use the correct namespace.  The side effect of this change is most grails plugins will likely need updated to be compatible with Grails 7.
-- When migrating a new project to Grails 7, it's advised to generate a stock 7.0 app from [start.grails.org](https://start.grails.org) and compare the project with a grails app generated from the same grails version that your application uses.  This helps catch the dependency clean up that has occurred.  Including the additions of new dependencies.  Note: due to an issue with project resolution the `grails-bom` will need explicitly imported in buildSrc or any project that does not apply the grails gradle plugins (grails-plugin, grails-web, or grails-gsp).  By default, the grails gradle plugins (grails-plugin, grails-web, grails-gsp) will apply the bom automatically.
-- the gradle property `groovyVersion` is being replaced with the upstream spring property name `groovy.version`.  Please update your projects accordingly.
+
+- The `jakarta` package switch means that older libraries using `javax` will need to be updated to use the correct namespace. The side effect of this change is most grails plugins will likely need updated to be compatible with Grails 7.
+- When migrating a new project to Grails 7, it's advised to generate a stock 7.0 app from [start.grails.org](https://start.grails.org) and compare the project with a grails app generated from the same grails version that your application uses. This helps catch the dependency clean up that has occurred. Including the additions of new dependencies. Note: due to an issue with project resolution the `grails-bom` will need explicitly imported in buildSrc or any project that does not apply the grails gradle plugins (grails-plugin, grails-web, or grails-gsp). By default, the grails gradle plugins (grails-plugin, grails-web, grails-gsp) will apply the bom automatically.
+- the gradle property `groovyVersion` is being replaced with the upstream spring property name `groovy.version`. Please update your projects accordingly.
 - hibernate-ehcache
 
-    The `org.hibernate:hibernate-ehcache` library is no longer provided by the `org.grails.plugins:hibernate5` plugin. If
-    your application depends on `hibernate-ehcache`, you must now add it explicitly to your project dependencies.
-    
-    Since `hibernate-ehcache` brings in a conflicting `javax` version of `org.hibernate:hibernate-core`, it is
-    recommended to exclude `hibernate-core` from the `hibernate-ehcache` dependency to avoid conflicts:
+  The `org.hibernate:hibernate-ehcache` library is no longer provided by the `org.grails.plugins:hibernate5` plugin. If
+  your application depends on `hibernate-ehcache`, you must now add it explicitly to your project dependencies.
+
+  Since `hibernate-ehcache` brings in a conflicting `javax` version of `org.hibernate:hibernate-core`, it is
+  recommended to exclude `hibernate-core` from the `hibernate-ehcache` dependency to avoid conflicts:
 
       dependencies {
           implementation 'org.hibernate:hibernate-ehcache:5.6.15.Final', {
@@ -47,13 +49,21 @@ Experienced while upgrading modules for Grails 7
           }
       }
 
+- Command line changes:
+  - The `package-plugin` command has been removed since Grails 4.0.4
+    - For packaging plugins, use `./gradlew assemble` instead
+    - For building plugin JARs, use `./gradlew jar`
+    - This aligns with Gradle's standard build lifecycle tasks
+    - Previous documentation references to `grails package-plugin` should be updated to use these Gradle tasks
 
 ## NOTE: This document is a draft and the explanations are only highlights and will be expanded further prior to release of 7.0.
 
-## New Features 
-- [grails-gsp #551](https://github.com/grails/grails-gsp/issues/551) adopts a `formActionSubmit` tag to replace `actionSubmit`.  Dispatching actions via a parameter name on a form submit will be removed in a future version of grails.
+## New Features
+
+- [grails-gsp #551](https://github.com/grails/grails-gsp/issues/551) adopts a `formActionSubmit` tag to replace `actionSubmit`. Dispatching actions via a parameter name on a form submit will be removed in a future version of grails.
 
 ### Cool New Features
+
 - You can now @Scaffold Controllers and Services and virtually eliminate any boiler plate code.
 - Hello Exterminator, Good by bugs! Lot's of things started working... and working well! For instance, use of controller namespaces now work seemlessly.
 - Bootstrap 5.3.3 support. Saffolding and Fields tags now optionally support boostrap classes.
@@ -61,7 +71,7 @@ Experienced while upgrading modules for Grails 7
 - Lightweight, Removal of numerous dependencies.
 - grails-bom overhaul for keeping depedencies up to date and in sync.
 - g:form now automatically provides csrf protection when Spring Security CSRF is enabled.
-- Massive decoupling of dependencies and cleanup between modules.  SiteMesh dependencies are no longer compiled into controllers fused between numerous modules. SiteMesh isn't even required to use Grails!
+- Massive decoupling of dependencies and cleanup between modules. SiteMesh dependencies are no longer compiled into controllers fused between numerous modules. SiteMesh isn't even required to use Grails!
 - SiteMesh ahs been upgrade to SiteMesh 3!
 - Completely up to date modern stack that has been optimized for easier future transitions.
 - GSP can now be used OUTSIDE of Grails! see grails-boot


### PR DESCRIPTION
Documents the removal of `package-plugin` command and provides migration path in UPGRADE7.md

### Context
- The `package-plugin` command was removed in Grails 4.0.4
- Documentation needed updating to reflect this change and provide alternatives
- Issue #11613 reported missing command

### Changes
- Added section in UPGRADE7.md about removed command line tools
- Documents the replacement using Gradle standard tasks:
  - `./gradlew assemble` for packaging plugins
  - `./gradlew jar` for building plugin JARs
- Explains rationale for change (aligning with Gradle standards)

### Testing
- No functional testing needed as this is a documentation-only change
- Verified accuracy of Gradle commands for plugin packaging

### Additional Notes
- Part of ongoing documentation improvements for Grails 7.0
- Helps users migrate from older Grails versions using legacy commands
- Aligns with modern Gradle-based build practices

Fixes #11613 