### PR TITLE
Add support for HTTP 307/308 redirect status codes

### DIFF
--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectController.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectController.groovy
@@ -54,13 +54,11 @@ class RedirectController {
     }
 
     def toActionTemporaryRedirect() {
-        request.setAttribute('statusConfig', [tempRedirect: true])
-        redirect(action:'foo')
+        redirect(action:'foo', temporary:true)
     }
 
     def toActionPermanentRedirect() {
-        request.setAttribute('statusConfig', [tempRedirect: true])
-        redirect(action:'foo', permanent: true)
+        redirect(action:'foo', permanent:true, temporary:true)
     }
 
     def toRoot() {

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectController.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectController.groovy
@@ -53,6 +53,16 @@ class RedirectController {
         redirect(action:"${prefix}oo")
     }
 
+    def toActionTemporaryRedirect() {
+        request.setAttribute('statusConfig', [tempRedirect: true])
+        redirect(action:'foo')
+    }
+
+    def toActionPermanentRedirect() {
+        request.setAttribute('statusConfig', [tempRedirect: true])
+        redirect(action:'foo', permanent: true)
+    }
+
     def toRoot() {
         redirect(controller:'default')
     }

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectController.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectController.groovy
@@ -61,6 +61,14 @@ class RedirectController {
         redirect(action:'foo', permanent:true, temporary:true)
     }
 
+    def toActionMovedTemporary() {
+        redirect(action:'foo', moved:true)
+    }
+
+    def toActionMovedPermanent() {
+        redirect(action:'foo', permanent:true, moved:true)
+    }
+
     def toRoot() {
         redirect(controller:'default')
     }

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectController.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectController.groovy
@@ -54,19 +54,19 @@ class RedirectController {
     }
 
     def toActionTemporaryRedirect() {
-        redirect(action:'foo', temporary:true)
+        redirect(action:'foo', moved: false)
     }
 
     def toActionPermanentRedirect() {
-        redirect(action:'foo', permanent:true, temporary:true)
+        redirect(action:'foo', permanent:true, moved:false)
     }
 
     def toActionMovedTemporary() {
-        redirect(action:'foo', moved:true)
+        redirect(action:'foo')
     }
 
     def toActionMovedPermanent() {
-        redirect(action:'foo', permanent:true, moved:true)
+        redirect(action:'foo', permanent:true)
     }
 
     def toRoot() {

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectMethodTests.groovy
@@ -256,7 +256,7 @@ class RedirectMethodTests extends Specification implements UrlMappingsUnitTest<U
         when:
         def c = new RedirectController()
         webRequest.controllerName = 'redirect'
-        c.toActionTemporaryRedirect()
+        c.toActionMovedTemporary()
         
         then: "should use HTTP 307 Temporary Redirect"
         307 == response.status
@@ -267,7 +267,7 @@ class RedirectMethodTests extends Specification implements UrlMappingsUnitTest<U
         when:
         def c = new RedirectController() 
         webRequest.controllerName = 'redirect'
-        c.toActionPermanentRedirect()
+        c.toActionMovedPermanent()
         
         then: "should use HTTP 308 Permanent Redirect"
         308 == response.status

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectMethodTests.groovy
@@ -252,6 +252,28 @@ class RedirectMethodTests extends Specification implements UrlMappingsUnitTest<U
         "/little-brown-bottle/thankyou" ==  response.redirectedUrl
     }
 
+    void "test temporary redirect with status 307"() {
+        when:
+        def c = new RedirectController()
+        webRequest.controllerName = 'redirect'
+        c.toActionTemporaryRedirect()
+        
+        then:
+        307 == response.status
+        "/redirect/foo" == response.redirectedUrl
+    }
+
+    void "test permanent redirect with status 308"() {
+        when:
+        def c = new RedirectController() 
+        webRequest.controllerName = 'redirect'
+        c.toActionPermanentRedirect()
+        
+        then:
+        308 == response.status
+        "/redirect/foo" == response.redirectedUrl
+    }
+
     static class UrlMappings {
         static mappings = {
             "/"(controller:'default')

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectMethodTests.groovy
@@ -6,6 +6,7 @@ import grails.web.mapping.mvc.exceptions.CannotRedirectException
 import org.grails.web.util.GrailsApplicationAttributes
 import grails.artefact.Artefact
 import grails.web.mapping.mvc.RedirectEventListener
+import org.springframework.http.HttpStatus
 import spock.lang.Specification
 
 /**
@@ -252,25 +253,47 @@ class RedirectMethodTests extends Specification implements UrlMappingsUnitTest<U
         "/little-brown-bottle/thankyou" ==  response.redirectedUrl
     }
 
-    void "test temporary redirect with status 307"() {
+    void "test temporary redirect"() {
+        when:
+        def c = new RedirectController()
+        webRequest.controllerName = 'redirect'
+        c.toActionTemporaryRedirect()
+        
+        then: "should use HTTP 307 Temporary Redirect"
+        HttpStatus.TEMPORARY_REDIRECT.value() == response.status
+        "/redirect/foo" == response.redirectedUrl
+    }
+
+    void "test permanent redirect"() {
+        when:
+        def c = new RedirectController() 
+        webRequest.controllerName = 'redirect'
+        c.toActionPermanentRedirect()
+        
+        then: "should use HTTP 308 Permanent Redirect"
+        HttpStatus.PERMANENT_REDIRECT.value() == response.status
+        "/redirect/foo" == response.redirectedUrl
+    }
+
+    void "test moved temporary redirect"() {
         when:
         def c = new RedirectController()
         webRequest.controllerName = 'redirect'
         c.toActionMovedTemporary()
-        
-        then: "should use HTTP 307 Temporary Redirect"
-        307 == response.status
+
+        then: "should use HTTP 302 Moved Temporary"
+        HttpStatus.MOVED_TEMPORARILY.value() == response.status
         "/redirect/foo" == response.redirectedUrl
     }
 
-    void "test permanent redirect with status 308"() {
+    void "test moved permanent redirect"() {
         when:
-        def c = new RedirectController() 
+        def c = new RedirectController()
         webRequest.controllerName = 'redirect'
         c.toActionMovedPermanent()
-        
-        then: "should use HTTP 308 Permanent Redirect"
-        308 == response.status
+
+        then: "should use HTTP 301 Moved Permanent"
+        HttpStatus.MOVED_PERMANENTLY.value() == response.status
         "/redirect/foo" == response.redirectedUrl
     }
 

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RedirectMethodTests.groovy
@@ -258,7 +258,7 @@ class RedirectMethodTests extends Specification implements UrlMappingsUnitTest<U
         webRequest.controllerName = 'redirect'
         c.toActionTemporaryRedirect()
         
-        then:
+        then: "should use HTTP 307 Temporary Redirect"
         307 == response.status
         "/redirect/foo" == response.redirectedUrl
     }
@@ -269,7 +269,7 @@ class RedirectMethodTests extends Specification implements UrlMappingsUnitTest<U
         webRequest.controllerName = 'redirect'
         c.toActionPermanentRedirect()
         
-        then:
+        then: "should use HTTP 308 Permanent Redirect"
         308 == response.status
         "/redirect/foo" == response.redirectedUrl
     }

--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
@@ -39,7 +39,7 @@ class ResponseRedirector {
 
     public static final String ARGUMENT_PERMANENT = "permanent"
     public static final String ARGUMENT_ABSOLUTE = "absolute"
-    public static final String ARGUMENT_TEMPORARY = "temporary" // Add new constant
+    public static final String ARGUMENT_MOVED = "moved"  // Renamed from ARGUMENT_TEMPORARY
     public static final String GRAILS_REDIRECT_ISSUED = GrailsApplicationAttributes.REDIRECT_ISSUED
     private static final String BLANK = ""
     private static final String KEEP_PARAMS_WHEN_REDIRECT = 'keepParamsWhenRedirect'
@@ -105,50 +105,37 @@ class ResponseRedirector {
                 namedParameters.put(LinkGenerator.ATTRIBUTE_PARAMS, configuredParams + webRequest.originalParams)
             }
         }
-        redirectResponse(linkGenerator.getServerBaseURL(), linkGenerator.link(namedParameters), request, response, permanent, absolute, arguments)
+        redirectResponse(linkGenerator.getServerBaseURL(), linkGenerator.link(namedParameters), request, response, permanent, absolute)
     }
 
     /*
      * Redirects the response the the given URI
      */
-    private void redirectResponse(String serverBaseURL, String actualUri, HttpServletRequest request, HttpServletResponse response, boolean permanent, boolean absolute, Map arguments) {
-        if(log.isDebugEnabled()) {
-            log.debug "Method [redirect] forwarding request to [$actualUri]"
-            log.debug "Executing redirect with response [$response]"
-        }
-
-        String processedActualUri = processedUrl(actualUri, request)
-
-        String redirectURI
-        if (absolute) {
-            redirectURI = processedActualUri.contains("://") ? processedActualUri : serverBaseURL + processedActualUri
-        } else {
-            redirectURI = linkGenerator.contextPath + processedActualUri
-        }
-
-        String redirectUrl = useJessionId ? response.encodeRedirectURL(redirectURI) : redirectURI
-
-        // Update to use arguments instead of request attributes
-        boolean temporary = Boolean.TRUE == arguments.get(ARGUMENT_TEMPORARY)
-        int status
-        if (permanent) {
-            status = temporary ? HttpServletResponse.SC_PERMANENT_REDIRECT : HttpServletResponse.SC_MOVED_PERMANENTLY 
-        } else {
-            status = temporary ? HttpServletResponse.SC_TEMPORARY_REDIRECT : HttpServletResponse.SC_MOVED_TEMPORARILY
-        }
-
-        response.status = status
-        response.setHeader HttpHeaders.LOCATION, redirectUrl
-
-        if (redirectListeners) {
-            for (redirectEventListener in redirectListeners) {
-                redirectEventListener.responseRedirected redirectUrl
-            }
-        }
-
-        request.setAttribute GRAILS_REDIRECT_ISSUED, processedActualUri
+    protected void redirectResponse(String serverBaseURL, String actualUri, HttpServletRequest request, HttpServletResponse response, boolean permanent, boolean absolute) {
+        if(permanent == null) permanent = false
+        String url = absolute ? serverBaseURL + actualUri : actualUri
+        doRedirect(url, request, response, permanent)
     }
 
+    protected void doRedirect(String url, HttpServletRequest request, HttpServletResponse response, boolean permanent) {
+        boolean moved = establishMoved(request, permanent) 
+        int status
+        if (permanent) {
+            status = moved ? HttpServletResponse.SC_PERMANENT_REDIRECT : HttpServletResponse.SC_MOVED_PERMANENTLY
+        } else {
+            status = moved ? HttpServletResponse.SC_TEMPORARY_REDIRECT : HttpServletResponse.SC_MOVED_TEMPORARILY 
+        }
+        response.setStatus(status)
+        response.sendRedirect(url)
+    }
+
+    private boolean establishMoved(HttpServletRequest request, boolean permanent) {
+        def moved = arguments?.get(ARGUMENT_MOVED)
+        if (moved instanceof String) {
+            return Boolean.valueOf(moved)
+        }
+        return moved as boolean
+    }
 
     private String processedUrl(String link, HttpServletRequest request) {
         if (requestDataValueProcessor) {

--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
@@ -126,7 +126,16 @@ class ResponseRedirector {
         }
 
         String redirectUrl = useJessionId ? response.encodeRedirectURL(redirectURI) : redirectURI
-        int status = permanent ? HttpServletResponse.SC_MOVED_PERMANENTLY : HttpServletResponse.SC_MOVED_TEMPORARILY
+
+        // Add support for 307/308 status codes
+        Map statusConfig = request.getAttribute('statusConfig')
+        boolean tempRedirect = Boolean.valueOf(statusConfig?.tempRedirect)
+        int status
+        if (permanent) {
+            status = tempRedirect ? HttpServletResponse.SC_PERMANENT_REDIRECT : HttpServletResponse.SC_MOVED_PERMANENTLY 
+        } else {
+            status = tempRedirect ? HttpServletResponse.SC_TEMPORARY_REDIRECT : HttpServletResponse.SC_MOVED_TEMPORARILY
+        }
 
         response.status = status
         response.setHeader HttpHeaders.LOCATION, redirectUrl

--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
@@ -22,6 +22,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Commons
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.util.GrailsApplicationAttributes
+import org.springframework.http.HttpStatus
 import org.springframework.util.Assert
 import org.springframework.web.servlet.support.RequestDataValueProcessor
 
@@ -39,7 +40,7 @@ class ResponseRedirector {
 
     public static final String ARGUMENT_PERMANENT = "permanent"
     public static final String ARGUMENT_ABSOLUTE = "absolute"
-    public static final String ARGUMENT_MOVED = "moved"  // Renamed from ARGUMENT_TEMPORARY
+    public static final String ARGUMENT_MOVED = "moved"
     public static final String GRAILS_REDIRECT_ISSUED = GrailsApplicationAttributes.REDIRECT_ISSUED
     private static final String BLANK = ""
     private static final String KEEP_PARAMS_WHEN_REDIRECT = 'keepParamsWhenRedirect'
@@ -62,6 +63,19 @@ class ResponseRedirector {
         redirect(request, response, arguments)
     }
 
+    private static boolean getBooleanArgument(String argumentName, Map arguments, Boolean defaultValue = null) {
+        def argument = arguments.get(argumentName)
+        if (argument instanceof String) {
+            return Boolean.valueOf(argument)
+        }
+        else if(argument == null && defaultValue != null) {
+            return defaultValue
+        }
+        else {
+            return Boolean.TRUE == argument
+        }
+    }
+
     void redirect(HttpServletRequest request, HttpServletResponse response, Map arguments) {
         if (request.getAttribute(GRAILS_REDIRECT_ISSUED)) {
             throw new CannotRedirectException("Cannot issue a redirect(..) here. A previous call to redirect(..) has already redirected the response.")
@@ -71,27 +85,15 @@ class ResponseRedirector {
             throw new CannotRedirectException("Cannot issue a redirect(..) here. The response has already been committed either by another redirect or by directly writing to the response.")
         }
 
-        boolean permanent
-
-        def permanentArgument = arguments.get(ARGUMENT_PERMANENT)
-        if(permanentArgument instanceof String) {
-            permanent = Boolean.valueOf(permanentArgument)
-        } else {
-            permanent = Boolean.TRUE == permanentArgument
-        }
+        boolean permanent = getBooleanArgument(ARGUMENT_PERMANENT, arguments)
+        boolean moved = getBooleanArgument(ARGUMENT_MOVED, arguments, true)
 
         final Map namedParameters = new LinkedHashMap<>(arguments)
         // we generate a relative link with no context path so that the absolute can be calculated by combining the serverBaseURL
         // which includes the contextPath
         namedParameters.put LinkGenerator.ATTRIBUTE_CONTEXT_PATH, BLANK
 
-        boolean absolute
-        def absoluteArgument = arguments.get(ARGUMENT_ABSOLUTE)
-        if (absoluteArgument instanceof String) {
-            absolute = Boolean.valueOf(absoluteArgument)
-        } else {
-            absolute = (absoluteArgument == null) ? true : (Boolean.TRUE == absoluteArgument)
-        }
+        boolean absolute = getBooleanArgument(ARGUMENT_ABSOLUTE, arguments, true)
 
         // If the request parameters contain "keepParamsWhenRedirect = true", then we add the original params. The
         // new attribute can be used from UrlMappings to redirect from old URLs to new ones while keeping the params
@@ -105,36 +107,47 @@ class ResponseRedirector {
                 namedParameters.put(LinkGenerator.ATTRIBUTE_PARAMS, configuredParams + webRequest.originalParams)
             }
         }
-        redirectResponse(linkGenerator.getServerBaseURL(), linkGenerator.link(namedParameters), request, response, permanent, absolute)
+        redirectResponse(linkGenerator.getServerBaseURL(), linkGenerator.link(namedParameters), request, response, permanent, moved, absolute)
     }
 
     /*
      * Redirects the response the the given URI
      */
-    protected void redirectResponse(String serverBaseURL, String actualUri, HttpServletRequest request, HttpServletResponse response, boolean permanent, boolean absolute) {
-        if(permanent == null) permanent = false
-        String url = absolute ? serverBaseURL + actualUri : actualUri
-        doRedirect(url, request, response, permanent)
-    }
+    private void redirectResponse(String serverBaseURL, String actualUri, HttpServletRequest request, HttpServletResponse response, boolean permanent, boolean moved, boolean absolute) {
+        if(log.isDebugEnabled()) {
+            log.debug "Method [redirect] forwarding request to [$actualUri]"
+            log.debug "Executing redirect with response [$response]"
+        }
 
-    protected void doRedirect(String url, HttpServletRequest request, HttpServletResponse response, boolean permanent) {
-        boolean moved = establishMoved(request, permanent) 
-        int status
-        if (permanent) {
-            status = moved ? HttpServletResponse.SC_PERMANENT_REDIRECT : HttpServletResponse.SC_MOVED_PERMANENTLY
+        String processedActualUri = processedUrl(actualUri, request)
+
+        String redirectURI
+        if (absolute) {
+            redirectURI = processedActualUri.contains("://") ? processedActualUri : serverBaseURL + processedActualUri
         } else {
-            status = moved ? HttpServletResponse.SC_TEMPORARY_REDIRECT : HttpServletResponse.SC_MOVED_TEMPORARILY 
+            redirectURI = linkGenerator.contextPath + processedActualUri
         }
-        response.setStatus(status)
-        response.sendRedirect(url)
-    }
 
-    private boolean establishMoved(HttpServletRequest request, boolean permanent) {
-        def moved = arguments?.get(ARGUMENT_MOVED)
-        if (moved instanceof String) {
-            return Boolean.valueOf(moved)
+        String redirectUrl = useJessionId ? response.encodeRedirectURL(redirectURI) : redirectURI
+
+        int status
+        if(permanent) {
+            status = moved ? HttpStatus.MOVED_PERMANENTLY.value() : HttpStatus.PERMANENT_REDIRECT.value()
         }
-        return moved as boolean
+        else {
+            status = moved ? HttpStatus.MOVED_TEMPORARILY.value() : HttpStatus.TEMPORARY_REDIRECT.value()
+        }
+
+        response.status = status
+        response.setHeader HttpHeaders.LOCATION, redirectUrl
+
+        if (redirectListeners) {
+            for (redirectEventListener in redirectListeners) {
+                redirectEventListener.responseRedirected redirectUrl
+            }
+        }
+
+        request.setAttribute GRAILS_REDIRECT_ISSUED, processedActualUri
     }
 
     private String processedUrl(String link, HttpServletRequest request) {

--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
@@ -39,6 +39,7 @@ class ResponseRedirector {
 
     public static final String ARGUMENT_PERMANENT = "permanent"
     public static final String ARGUMENT_ABSOLUTE = "absolute"
+    public static final String ARGUMENT_TEMPORARY = "temporary" // Add new constant
     public static final String GRAILS_REDIRECT_ISSUED = GrailsApplicationAttributes.REDIRECT_ISSUED
     private static final String BLANK = ""
     private static final String KEEP_PARAMS_WHEN_REDIRECT = 'keepParamsWhenRedirect'
@@ -104,13 +105,13 @@ class ResponseRedirector {
                 namedParameters.put(LinkGenerator.ATTRIBUTE_PARAMS, configuredParams + webRequest.originalParams)
             }
         }
-        redirectResponse(linkGenerator.getServerBaseURL(), linkGenerator.link(namedParameters), request, response, permanent, absolute)
+        redirectResponse(linkGenerator.getServerBaseURL(), linkGenerator.link(namedParameters), request, response, permanent, absolute, arguments)
     }
 
     /*
      * Redirects the response the the given URI
      */
-    private void redirectResponse(String serverBaseURL, String actualUri, HttpServletRequest request, HttpServletResponse response, boolean permanent, boolean absolute) {
+    private void redirectResponse(String serverBaseURL, String actualUri, HttpServletRequest request, HttpServletResponse response, boolean permanent, boolean absolute, Map arguments) {
         if(log.isDebugEnabled()) {
             log.debug "Method [redirect] forwarding request to [$actualUri]"
             log.debug "Executing redirect with response [$response]"
@@ -127,14 +128,13 @@ class ResponseRedirector {
 
         String redirectUrl = useJessionId ? response.encodeRedirectURL(redirectURI) : redirectURI
 
-        // Add support for 307/308 status codes
-        Map statusConfig = request.getAttribute('statusConfig')
-        boolean tempRedirect = Boolean.valueOf(statusConfig?.tempRedirect)
+        // Update to use arguments instead of request attributes
+        boolean temporary = Boolean.TRUE == arguments.get(ARGUMENT_TEMPORARY)
         int status
         if (permanent) {
-            status = tempRedirect ? HttpServletResponse.SC_PERMANENT_REDIRECT : HttpServletResponse.SC_MOVED_PERMANENTLY 
+            status = temporary ? HttpServletResponse.SC_PERMANENT_REDIRECT : HttpServletResponse.SC_MOVED_PERMANENTLY 
         } else {
-            status = tempRedirect ? HttpServletResponse.SC_TEMPORARY_REDIRECT : HttpServletResponse.SC_MOVED_TEMPORARILY
+            status = temporary ? HttpServletResponse.SC_TEMPORARY_REDIRECT : HttpServletResponse.SC_MOVED_TEMPORARILY
         }
 
         response.status = status


### PR DESCRIPTION
Added support for HTTP 307/308 status codes in the ResponseRedirector by:

Fixes #11625 

1. Extending the redirect logic to check for a `tempRedirect` flag in the statusConfig
2. Using appropriate status codes based on permanent + tempRedirect flags:
   - permanent: false, tempRedirect: false -> 302 (default)
   - permanent: true, tempRedirect: false -> 301
   - permanent: false, tempRedirect: true -> 307
   - permanent: true, tempRedirect: true -> 308

3. Added test cases to verify both temporary (307) and permanent (308) redirect behavior

## Usage##
```groovy
**For 307 Temporary Redirect**
request.setAttribute('statusConfig', [tempRedirect: true])
redirect(action: 'foo')

**For 308 Permanent Redirect**
request.setAttribute('statusConfig', [tempRedirect: true])
redirect(action: 'foo', permanent: true)