### PR TITLE
Develocity and flaky tests fixes

### DIFF
--- a/grails-async/core/src/test/groovy/grails/async/FutureTaskPromiseFactorySpec.groovy
+++ b/grails-async/core/src/test/groovy/grails/async/FutureTaskPromiseFactorySpec.groovy
@@ -84,7 +84,13 @@ class FutureTaskPromiseFactorySpec extends Specification {
     void 'Test promise onError handling'() {
         
         when: 'a promise is executed with an onComplete handler'
-            def promise = Promises.createPromise { throw new RuntimeException('bad') }
+            def promise = Promises.createPromise {
+                // Sleep to give the get() method below a chance to wrap the exception,
+                // otherwise a RuntimeException will bubble up instead of an ExecutionException
+                // resulting in a flaky test.
+                sleep 50
+                throw new RuntimeException('bad')
+            }
             def result = null
             Throwable error = null
             promise.onComplete { result = it }

--- a/grails-async/gpars/src/test/groovy/grails/async/GparsPromiseSpec.groovy
+++ b/grails-async/gpars/src/test/groovy/grails/async/GparsPromiseSpec.groovy
@@ -49,7 +49,7 @@ class GparsPromiseSpec extends Specification {
         
         when: 'a promise that takes longer than the timeout'
             def p = Promises.createPromise {
-                sleep 200
+                sleep 1000
                 println 'completed op'
             }
             p.get(50, TimeUnit.MILLISECONDS)

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,14 +5,13 @@ plugins {
 
 def isCI = System.getenv().containsKey('CI')
 def isLocal = !isCI
-def isAuthenticated = System.getenv().containsKey('GRAILS_DEVELOCITY_ACCESS_KEY')
 
 develocity {
     server = 'https://ge.grails.org'
     buildScan {
         tag('grails')
         tag('grails-core')
-        publishing.onlyIf { isAuthenticated }
+        publishing.onlyIf { it.authenticated }
         uploadInBackground = isLocal
     }
 }
@@ -20,7 +19,7 @@ develocity {
 buildCache {
     local { enabled = isLocal }
     remote(develocity.buildCache) {
-        push = isCI && isAuthenticated
+        push = isCI
         enabled = true
     }
 }


### PR DESCRIPTION
The test was flaky in CI, so we pro-long the sleep. This will not affect the test time, just make sure that the promise is not completed before the `p.get` call times out.