### PR TITLE
CI, Build and Test updates

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '21', '23' ]
+        java: [ 17, 21, 23 ]
     runs-on: ubuntu-24.04
     steps:
       - name: "📥 Checkout repository"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,8 +31,6 @@ env:
 jobs:
   buildGradle:
     name: 'Build Gradle Plugins'
-    permissions:
-      contents: read  #  to fetch code (actions/checkout)
     strategy:
       fail-fast: false
       matrix:
@@ -57,8 +55,6 @@ jobs:
           --continue --stacktrace
   build:
     name: 'Build Grails-Core'
-    permissions:
-      contents: read  #  to fetch code (actions/checkout)
     strategy:
       fail-fast: false
       matrix:
@@ -86,8 +82,6 @@ jobs:
           -PskipHibernate5Tests
   functional:
     name: "Functional Tests"
-    permissions:
-      contents: read  #  to fetch code (actions/checkout)
     strategy:
       fail-fast: false
       matrix:
@@ -169,8 +163,6 @@ jobs:
   publishGradle:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ buildGradle ]
-    permissions:
-      contents: read # limit to read access
     runs-on: ubuntu-24.04
     steps:
       - name: "📥 Checkout repository"
@@ -197,8 +189,6 @@ jobs:
   publish:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ publishGradle, build, functional, hibernate5Functional, mongodbFunctional ]
-    permissions:
-      contents: read # limit to read access
     runs-on: ubuntu-24.04
     steps:
       - name: "📥 Checkout repository"
@@ -223,8 +213,6 @@ jobs:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ publish ]
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write # TODO: Comment why this is needed
     steps:
       - name: "📥 Checkout the repository"
         uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,8 @@ on:
       - '[3-9]+.[3-9]+.x'
   workflow_dispatch:
 env:
-  # to prevent throttling of the github api, include the github token in an environment variable since the build will check for it
+  # To prevent throttling of GitHub API usage, include the GitHub token as an environment variable
+  # as the build will use it when fetching git tags in CreateReleaseDropDown.groovy
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   buildGradle:
@@ -35,9 +36,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+        java: [ 17, 21 ]
+    runs-on: ubuntu-24.04
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4
@@ -52,7 +52,9 @@ jobs:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🔨 Build project"
         working-directory: 'grails-gradle'
-        run: ./gradlew build assemble --continue --stacktrace
+        run: >
+          ./gradlew build assemble
+          --continue --stacktrace
   build:
     name: 'Build Grails-Core'
     permissions:
@@ -60,8 +62,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21, 23]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [ 17, 21, 23 ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "📥 Checkout repository"
@@ -76,14 +78,12 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🔨 Build project"
-        id: build
         run: >
-          ./gradlew build 
-          assemble 
-          groovydoc 
-          --continue 
-          --stacktrace 
-          -PskipFunctionalTests -PskipMongodbTests -PskipHibernate5Tests
+          ./gradlew build assemble groovydoc
+          --continue --stacktrace
+          -PskipFunctionalTests
+          -PskipMongodbTests
+          -PskipHibernate5Tests
   functional:
     name: "Functional Tests"
     permissions:
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '17', '21', '23' ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4
@@ -105,12 +105,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔨 Functional Tests"
+      - name: "🏃 Run Functional Tests"
         run: >
-          ./gradlew 
-          build 
-          --stacktrace 
-          -PonlyFunctionalTests -PskipMongodbTests -PskipHibernate5Tests
+          ./gradlew bootJar check
+          --continue --stacktrace
+          -PonlyFunctionalTests
+          -PskipHibernate5Tests
+          -PskipMongodbTests
   mongodbFunctional:
     name: "Mongodb Functional Tests"
     runs-on: ubuntu-24.04
@@ -125,22 +126,20 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
           distribution: liberica
+          java-version: ${{ matrix.java }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
-      - name: "🔨 Run Build"
-        id: build
+      - name: "🏃 Run Functional Tests"
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          ./gradlew 
-          cleanTest 
-          build 
-          --continue 
-          -PonlyMongodbTests -PmongodbContainerVersion=${{ matrix.mongodb-version }}
+          ./gradlew bootJar cleanTest check
+          --continue --stacktrace
+          -PonlyMongodbTests
+          -PmongodbContainerVersion=${{ matrix.mongodb-version }}
   hibernate5Functional:
     name: "Hibernate5 Functional Tests"
     runs-on: ubuntu-24.04
@@ -154,23 +153,25 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
           distribution: liberica
+          java-version: ${{ matrix.java }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
-      - name: "🔨 Run Build"
-        id: build
+      - name: "🏃 Run Functional Tests"
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew cleanTest build --continue -PonlyHibernate5Tests
+        run: >
+          ./gradlew bootJar cleanTest check
+          --continue --stacktrace
+          -PonlyHibernate5Tests
   publishGradle:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ buildGradle ]
     permissions:
       contents: read # limit to read access
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4
@@ -184,7 +185,6 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "📤 Publish Gradle Snapshot Artifacts"
-        id: publish
         env:
           GRAILS_PUBLISH_RELEASE: 'false'
           MAVEN_PUBLISH_URL: ${{ secrets.GRAILS_NEXUS_PUBLISH_SNAPSHOT_URL }}
@@ -192,13 +192,14 @@ jobs:
           MAVEN_PUBLISH_PASSWORD: ${{ secrets.NEXUS_PW  }}
         working-directory: 'grails-gradle'
         run: >
-          ./gradlew publish -Dorg.gradle.internal.publish.checksums.insecure=true
+          ./gradlew publish
+          -Dorg.gradle.internal.publish.checksums.insecure=true
   publish:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
-    needs: [ publishGradle, build, functional, hibernate5Functional, mongodbFunctional]
+    needs: [ publishGradle, build, functional, hibernate5Functional, mongodbFunctional ]
     permissions:
       contents: read # limit to read access
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4
@@ -212,20 +213,18 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "📤 Publish Grails-Core Snapshot Artifacts"
-        id: publish
         env:
           GRAILS_PUBLISH_RELEASE: 'false'
           MAVEN_PUBLISH_URL: ${{ secrets.GRAILS_NEXUS_PUBLISH_SNAPSHOT_URL }}
           MAVEN_PUBLISH_USERNAME: ${{ secrets.NEXUS_USER }}
           MAVEN_PUBLISH_PASSWORD: ${{ secrets.NEXUS_PW  }}
-        run: >
-          ./gradlew publish
+        run: ./gradlew publish
   docs:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
-    needs: [publish]
-    runs-on: ubuntu-latest
+    needs: [ publish ]
+    runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: write # TODO: Comment why this is needed
     steps:
       - name: "📥 Checkout the repository"
         uses: actions/checkout@v4
@@ -242,15 +241,16 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          java-version: 17
           distribution: liberica
+          java-version: 17
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "🔨 Build Snapshot Documentation"
         run: >
-          ./gradlew grails-doc:build -PgithubBranch=${{ env.TARGET_BRANCH }}
+          ./gradlew grails-doc:build
+          -PgithubBranch=${{ env.TARGET_BRANCH }}
       - name: "📤 Upload Generated Docs to Workflow Result Page"
         uses: actions/upload-artifact@v4
         with:

--- a/gradle/hibernate5-test-config.gradle
+++ b/gradle/hibernate5-test-config.gradle
@@ -24,27 +24,15 @@ dependencies {
 
 tasks.withType(Test).configureEach {
     onlyIf {
-        if (project.hasProperty('onlyFunctionalTests')) {
-            return false
+        ![
+                'onlyFunctionalTests',
+                'skipHibernate5Tests',
+                'onlyMongodbTests',
+                'onlyCoreTests',
+                'skipTests'
+        ].find {
+            project.hasProperty(it)
         }
-
-        if (project.hasProperty('skipHibernate5Tests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyMongodbTests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyCoreTests')) {
-            return false
-        }
-
-        if(project.hasProperty('skipTests')) {
-            return false
-        }
-
-        true
     }
 
     useJUnitPlatform()

--- a/gradle/mongodb-forked-test-config.gradle
+++ b/gradle/mongodb-forked-test-config.gradle
@@ -28,27 +28,15 @@ tasks.named('compileTestGroovy', GroovyCompile) {
 
 tasks.withType(Test).configureEach {
     onlyIf {
-        if (project.hasProperty('onlyFunctionalTests')) {
-            return false
+        ![
+                'onlyFunctionalTests',
+                'onlyHibernate5Tests',
+                'skipMongodbTests',
+                'onlyCoreTests',
+                'skipTests'
+        ].find {
+            project.hasProperty(it)
         }
-
-        if (project.hasProperty('skipMongodbTests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyHibernate5Tests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyCoreTests')) {
-            return false
-        }
-
-        if(project.hasProperty('skipTests')) {
-            return false
-        }
-
-        true
     }
 
     useJUnitPlatform()

--- a/gradle/mongodb-test-config.gradle
+++ b/gradle/mongodb-test-config.gradle
@@ -28,27 +28,15 @@ tasks.named('compileTestGroovy', GroovyCompile) {
 
 tasks.withType(Test).configureEach {
     onlyIf {
-        if (project.hasProperty('onlyFunctionalTests')) {
-            return false
+        ![
+                'onlyFunctionalTests',
+                'onlyHibernate5Tests',
+                'skipMongodbTests',
+                'onlyCoreTests',
+                'skipTests'
+        ].find {
+            project.hasProperty(it)
         }
-
-        if (project.hasProperty('skipMongodbTests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyHibernate5Tests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyCoreTests')) {
-            return false
-        }
-
-        if(project.hasProperty('skipTests')) {
-            return false
-        }
-
-        true
     }
 
     useJUnitPlatform()

--- a/grails-data-graphql/examples/grails-docs-app/grails-app/conf/logback.xml
+++ b/grails-data-graphql/examples/grails-docs-app/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-data-graphql/examples/grails-docs-app/grails-app/conf/logback.xml
+++ b/grails-data-graphql/examples/grails-docs-app/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-data-graphql/examples/grails-tenant-app/grails-app/conf/logback.xml
+++ b/grails-data-graphql/examples/grails-tenant-app/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-data-graphql/examples/grails-tenant-app/grails-app/conf/logback.xml
+++ b/grails-data-graphql/examples/grails-tenant-app/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-data-graphql/examples/grails-test-app/grails-app/conf/logback.xml
+++ b/grails-data-graphql/examples/grails-test-app/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-data-graphql/examples/grails-test-app/grails-app/conf/logback.xml
+++ b/grails-data-graphql/examples/grails-test-app/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-data-neo4j/examples/grails3-neo4j-hibernate/grails-app/conf/logback.xml
+++ b/grails-data-neo4j/examples/grails3-neo4j-hibernate/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-data-neo4j/examples/grails3-neo4j-hibernate/grails-app/conf/logback.xml
+++ b/grails-data-neo4j/examples/grails3-neo4j-hibernate/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-data-neo4j/examples/grails3-neo4j/grails-app/conf/logback.xml
+++ b/grails-data-neo4j/examples/grails3-neo4j/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-data-neo4j/examples/grails3-neo4j/grails-app/conf/logback.xml
+++ b/grails-data-neo4j/examples/grails3-neo4j/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-data-neo4j/examples/test-data-service/grails-app/conf/logback.xml
+++ b/grails-data-neo4j/examples/test-data-service/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-data-neo4j/examples/test-data-service/grails-app/conf/logback.xml
+++ b/grails-data-neo4j/examples/test-data-service/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/resources/logback.xml
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/resources/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/resources/logback.xml
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/resources/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/CustomAutoTimestampSpec.groovy
+++ b/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/CustomAutoTimestampSpec.groovy
@@ -42,7 +42,7 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
             Date previousCreated = r.created
             Date previousModified = r.modified
             r.name = "Test 2"
-            sleep(50) // give the save a chance to set a different time
+            sleep(1) // give the save a chance to set a different time
             r.save(flush:true)
             session.clear()
             r = RecordCustom.get(r.id)
@@ -59,7 +59,7 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
         def now = new Date()
         r.created = new Date(now.time)
         r.modified = r.created
-        sleep(50) // give the save a chance to set a different time
+        sleep(1) // give the save a chance to set a different time
         r.save(flush:true, failOnError:true)
         session.clear()
         r = RecordCustom.get(r.id)
@@ -72,7 +72,7 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
         Date previousCreated = r.created
         Date previousModified = r.modified
         r.name = "Test 2"
-        sleep(50) // give the save a chance to set a different time
+        sleep(1) // give the save a chance to set a different time
         r.save(flush:true)
         session.clear()
         r = RecordCustom.get(r.id)
@@ -93,7 +93,7 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
         def now = new Date()
         r.created = new Date(now.time)
         r.modified = r.created
-        sleep(50) // give the save a chance to set a different time
+        sleep(1) // give the save a chance to set a different time
         r.save(flush:true, failOnError:true)
         session.clear()
         r = RecordCustom.get(r.id)
@@ -106,7 +106,7 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
         Date previousCreated = r.created
         Date previousModified = r.modified
         r.name = "Test 2"
-        sleep(50) // give the save a chance to set a different time
+        sleep(1) // give the save a chance to set a different time
         r.save(flush:true)
         session.clear()
         r = RecordCustom.get(r.id)

--- a/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/CustomAutoTimestampSpec.groovy
+++ b/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/CustomAutoTimestampSpec.groovy
@@ -22,15 +22,9 @@ import grails.gorm.annotation.AutoTimestamp
 import grails.gorm.tests.GormDatastoreSpec
 import grails.persistence.Entity
 import org.grails.datastore.gorm.events.AutoTimestampEventListener
-import spock.lang.IgnoreIf
-import spock.lang.Retry
-import spock.lang.Stepwise
 
 import static grails.gorm.annotation.AutoTimestamp.EventType.CREATED
 
-@Retry // this test is flaky on CI due to https://github.com/apache/grails-data-mapping/issues/1877
-@Stepwise
-@IgnoreIf( { os.windows } )
 class CustomAutoTimestampSpec extends GormDatastoreSpec {
 
     void "Test when the auto timestamp properties are customized, they are correctly set"() {
@@ -41,19 +35,21 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
             r = RecordCustom.get(r.id)
 
         then:"the custom lastUpdated and dateCreated are set"
-            r.modified != null && r.modified < new Date()
-            r.created != null && r.created < new Date()
+            r.modified != null
+            r.created != null
 
         when:"An entity is modified"
             Date previousCreated = r.created
             Date previousModified = r.modified
             r.name = "Test 2"
+            sleep(50) // give the save a chance to set a different time
             r.save(flush:true)
             session.clear()
             r = RecordCustom.get(r.id)
 
             then:"the custom lastUpdated property is updated and dateCreated is not"
-            r.modified != null && previousModified < r.modified
+            r.modified != null
+            previousModified.time < r.modified.time
             previousCreated.time == r.created.time
     }
 
@@ -63,24 +59,27 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
         def now = new Date()
         r.created = new Date(now.time)
         r.modified = r.created
+        sleep(50) // give the save a chance to set a different time
         r.save(flush:true, failOnError:true)
         session.clear()
         r = RecordCustom.get(r.id)
 
         then:"the custom lastUpdated and dateCreated are set"
-        now < r.modified
-        now < r.created
+        now.time < r.modified.time
+        now.time < r.created.time
 
         when:"An entity is modified"
         Date previousCreated = r.created
         Date previousModified = r.modified
         r.name = "Test 2"
+        sleep(50) // give the save a chance to set a different time
         r.save(flush:true)
         session.clear()
         r = RecordCustom.get(r.id)
 
         then:"the custom lastUpdated property is updated and dateCreated is not"
-        r.modified != null && previousModified < r.modified
+        r.modified != null
+        previousModified.time < r.modified.time
         previousCreated.time == r.created.time
     }
 
@@ -94,6 +93,7 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
         def now = new Date()
         r.created = new Date(now.time)
         r.modified = r.created
+        sleep(50) // give the save a chance to set a different time
         r.save(flush:true, failOnError:true)
         session.clear()
         r = RecordCustom.get(r.id)
@@ -106,16 +106,15 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
         Date previousCreated = r.created
         Date previousModified = r.modified
         r.name = "Test 2"
+        sleep(50) // give the save a chance to set a different time
         r.save(flush:true)
         session.clear()
         r = RecordCustom.get(r.id)
 
         then:"the custom lastUpdated property is updated and dateCreated is not"
-        r.modified != null && previousModified < r.modified
+        r.modified != null
+        previousModified.time < r.modified.time
         previousCreated.time == r.created.time
-
-        cleanup:
-        (RecordCustom.gormPersistentEntity.mappingContext.eventListeners.find { it.class == AutoTimestampEventListener} as AutoTimestampEventListener).insertOverwrite = true
     }
 
     @Override

--- a/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/CustomAutoTimestampSpec.groovy
+++ b/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/CustomAutoTimestampSpec.groovy
@@ -33,10 +33,13 @@ class CustomAutoTimestampSpec extends GormDatastoreSpec {
             r.save(flush:true, failOnError:true)
             session.clear()
             r = RecordCustom.get(r.id)
+            sleep(1) // give the date comparison below a chance diff
 
         then:"the custom lastUpdated and dateCreated are set"
             r.modified != null
             r.created != null
+            r.modified.time < new Date().time
+            r.created.time < new Date().time
 
         when:"An entity is modified"
             Date previousCreated = r.created

--- a/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/TckTestSuite.groovy
+++ b/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/TckTestSuite.groovy
@@ -21,14 +21,12 @@ package org.grails.datastore.gorm
 import grails.gorm.tck.NotInListSpec
 import org.junit.platform.suite.api.SelectClasses
 import org.junit.platform.suite.api.Suite
-import spock.lang.IgnoreIf
 
 /**
  * Use this class to run tck classes against the current implementation.
  *
  * @author graemerocher
  */
-@IgnoreIf({ os.windows }) // Fails on windows even though the NotInListSpec is in the TCK and runs
 @Suite
 @SelectClasses([NotInListSpec])
 class TckTestSuite {

--- a/grails-gradle/gradle.properties
+++ b/grails-gradle/gradle.properties
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This groovy version should be the version built with grails applications and NOT the one used by this project
-# since this project must use gradle's groovy version.  This property will be used to set up the test projects
-# like grails would be to ensure proper test coverage
-e2eGroovyVersion=4.0.24
+# This Groovy version should be the version used to build Grails applications and NOT the version used by this project,
+# since this project must use Gradle's Groovy version. This property will be used to set up the test projects
+# like Grails would, to ensure proper test coverage.
+e2eGroovyVersion=4.0.25
 
 org.gradle.caching=true
 org.gradle.daemon=true

--- a/grails-gradle/gradle/e2eTest.gradle
+++ b/grails-gradle/gradle/e2eTest.gradle
@@ -21,23 +21,14 @@ def e2eTest = sourceSets.create('e2eTest')
 def e2eTestTask = tasks.register('e2eTest', Test)
 e2eTestTask.configure { Test it ->
     it.onlyIf {
-        if(project.hasProperty('onlyFunctionalTests')) {
-            return false
+        ![
+                'onlyFunctionalTests',
+                'onlyHibernate5Tests',
+                'onlyMongodbTests',
+                'skipTests'
+        ].find {
+            project.hasProperty(it)
         }
-
-        if (project.hasProperty('onlyMongodbTests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyHibernate5Tests')) {
-            return false
-        }
-
-        if(project.hasProperty('skipTests')) {
-            return false
-        }
-
-        true
     }
     it.group = 'verification'
     it.testClassesDirs = sourceSets.e2eTest.output.classesDirs

--- a/grails-gradle/gradle/test-config.gradle
+++ b/grails-gradle/gradle/test-config.gradle
@@ -28,27 +28,15 @@ def java17moduleReflectionCompatibilityArguments = [
 
 tasks.withType(Test).configureEach {
     onlyIf {
-        if (project.hasProperty('onlyFunctionalTests')) {
-            return false
+        ![
+                'onlyFunctionalTests',
+                'onlyHibernate5Tests',
+                'onlyMongodbTests',
+                'skipCoreTests',
+                'skipTests'
+        ].find {
+            project.hasProperty(it)
         }
-
-        if (project.hasProperty('onlyMongodbTests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyHibernate5Tests')) {
-            return false
-        }
-
-        if (project.hasProperty('skipCoreTests')) {
-            return false
-        }
-
-        if (project.hasProperty('skipTests')) {
-            return false
-        }
-
-        true
     }
 
     useJUnitPlatform()

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/child-project-with-unrelated-parent/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/child-project-with-unrelated-parent/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -29,6 +30,7 @@ buildscript {
 }
 
 repositories {
+    mavenCentral()
     maven { url = 'https://repo.grails.org/grails/core' }
     maven { url = 'https://repository.apache.org/content/groups/snapshots' }
 }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/child-project-with-unrelated-parent/otherProject/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/child-project-with-unrelated-parent/otherProject/build.gradle
@@ -18,6 +18,7 @@
  */
 
 repositories {
+    mavenCentral()
     maven { url = 'https://repo.grails.org/grails/core' }
     maven { url = 'https://repository.apache.org/content/groups/snapshots' }
 }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-no-subproject-build-gradle-publish-all/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-no-subproject-build-gradle-publish-all/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -39,6 +40,7 @@ subprojects { project ->
     apply plugin: 'groovy'
 
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-no-subproject-build-gradle-publish-per-project/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-no-subproject-build-gradle-publish-per-project/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -39,6 +40,7 @@ subprojects { project ->
     apply plugin: 'groovy'
 
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-child-published/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-child-published/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-parent-published/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-parent-child-setup-per-project-parent-published/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-with-subproject-gradle/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/legacy-apply/multi-project-with-subproject-gradle/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
     }
 }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
     }
 }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/groovy-only-project/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -36,6 +37,7 @@ subprojects { project ->
     group = "org.grails.example"
 
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -39,6 +40,7 @@ subprojects { project ->
     apply plugin: 'groovy'
 
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/child-project-with-unrelated-parent/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/child-project-with-unrelated-parent/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -35,6 +36,7 @@ plugins {
 }
 
 repositories {
+    mavenCentral()
     maven { url = 'https://repo.grails.org/grails/core' }
     maven { url = 'https://repository.apache.org/content/groups/snapshots' }
 }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/child-project-with-unrelated-parent/otherProject/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/child-project-with-unrelated-parent/otherProject/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -34,6 +35,7 @@ plugins {
 }
 
 repositories {
+    mavenCentral()
     maven { url = 'https://repo.grails.org/grails/core' }
     maven { url = 'https://repository.apache.org/content/groups/snapshots' }
 }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-child-published/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-child-published/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -35,6 +36,7 @@ plugins {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-parent-published/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/multi-project-parent-child-setup-per-project-parent-published/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -43,6 +44,7 @@ dependencies {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/multi-project-with-subproject-gradle/build.gradle
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/plugins-block/multi-project-with-subproject-gradle/build.gradle
@@ -20,6 +20,7 @@
 buildscript {
     repositories {
         maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }
@@ -30,6 +31,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
     }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -184,13 +184,13 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         project.afterEvaluate {
             Task sourcesJarTask = taskContainer.findByName('sourcesJar')
             if (sourcesJarTask) {
-                project.rootProject.logger.lifecycle("Found sources jar task")
+                project.rootProject.logger.info('Found sources jar task')
                 sourcesJarTask.configure {
-                    project.rootProject.logger.lifecycle("Including ast in sources jar")
+                    project.rootProject.logger.info('Including ast in sources jar')
                     from sourceSets.ast.allSource
                 }
             } else {
-                project.rootProject.logger.lifecycle("No sources jar task found")
+                project.rootProject.logger.info('No sources jar task found')
             }
 
             Task javadocTask = taskContainer.findByName('javadoc')
@@ -199,7 +199,7 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
                     source += sourceSets.ast.allJava
                 }
             } else {
-                project.rootProject.logger.lifecycle("Warning - a javadocTask was not found, so the ast source will not be included in the javadoc task")
+                project.rootProject.logger.info('Warning - a javadocTask was not found, so the ast source will not be included in the javadoc task')
             }
 
             Task groovydocTask = taskContainer.findByName('groovydoc')
@@ -216,7 +216,7 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
                     source += sourceSets.ast.allJava
                 }
             } else {
-                project.rootProject.logger.lifecycle("Warning - a groovydocTask was not found, so the ast source will not be included in the groovydoc task")
+                project.rootProject.logger.info('Warning - a groovydocTask was not found, so the ast source will not be included in the groovydoc task')
             }
         }
     }

--- a/grails-gradle/settings.gradle
+++ b/grails-gradle/settings.gradle
@@ -24,14 +24,13 @@ plugins {
 
 def isCI = System.getenv().containsKey('CI')
 def isLocal = !isCI
-def isAuthenticated = System.getenv().containsKey('GRAILS_DEVELOCITY_ACCESS_KEY')
 
 develocity {
 	server = 'https://ge.grails.org'
 	buildScan {
 		tag('grails')
 		tag('grails-gradle-plugins')
-		publishing.onlyIf { isAuthenticated }
+		publishing.onlyIf { it.authenticated }
 		uploadInBackground = isLocal
 	}
 }
@@ -39,7 +38,7 @@ develocity {
 buildCache {
 	local { enabled = isLocal }
 	remote(develocity.buildCache) {
-		push = isCI && isAuthenticated
+		push = isCI
 		enabled = true
 	}
 }

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
@@ -55,18 +55,18 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
     }
 
     @PendingFeatureIf({
-        System.getenv('GITHUB_REF')
+        System.getenv().containsKey('CI')
         /*
-            FOR SOME REASON FAILS IN CI WITH:
-            output == '<form action="/books" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
-            |      |
-            |      false
-            |      6 differences (95% similarity)
-            |      <form action="(------)" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>
-            |      <form action="(/books)" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>
-            <form action="" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />
-            </form>
-         */
+        FOR SOME REASON FAILS (ONLY) IN CI WITH:
+        output == '<form action="/books" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
+        |      |
+        |      false
+        |      6 differences (95% similarity)
+        |      <form action="(------)" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>
+        |      <form action="(/books)" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>
+        <form action="" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />
+        </form>
+        */
     })
     def testFormNoNamespace() {
         expect:
@@ -291,6 +291,19 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
         ).toString() == '<form action="/con/action" method="post" id="formElementId" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
     }
 
+    @PendingFeatureIf({
+        System.getenv().containsKey('CI')
+        /*
+        FOR SOME REASON FAILS (ONLY) IN CI WITH:
+        tagLib.formActionSubmit([ controller: 'con', id: 'formElementId', value: 'Submit' ]).toString() == '<input type="submit" formaction="/con" value="Submit" id="formElementId" />'
+        |      |                                                                             |          |
+        |      <input type="submit" formaction="" value="Submit" id="formElementId" />       |          false
+        |                                                                                    |          4 differences (94% similarity)
+        |                                                                                    |          <input type="submit" formaction="(----)" value="Submit" id="formElementId" />
+        |                                                                                    |          <input type="submit" formaction="(/con)" value="Submit" id="formElementId" />
+        |                                                                                    <input type="submit" formaction="" value="Submit" id="formElementId" />
+        */
+    })
     def testFormActionSubmitWithController() {
         expect:
         tagLib.formActionSubmit([

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
@@ -25,8 +25,6 @@ import org.grails.buffer.FastStringWriter
 import org.grails.core.AbstractGrailsClass
 import org.grails.core.artefact.UrlMappingsArtefactHandler
 import org.grails.plugins.web.taglib.FormTagLib
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 /**
@@ -55,7 +53,6 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
 
     }
 
-    @IgnoreIf({ System.getenv('GITHUB_REF') })
     def testFormNoNamespace() {
         when:
         def template = '<g:form controller="books"></g:form>'
@@ -331,7 +328,6 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
         output == '<form action="/con/action" method="post" id="formElementId" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
     }
 
-    @Ignore // flaky test
     def testFormActionSubmitWithController() {
         when:
         String output = tagLib.formActionSubmit([controller: 'con', id: 'formElementId', value: 'Submit'])

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
@@ -25,20 +25,22 @@ import org.grails.buffer.FastStringWriter
 import org.grails.core.AbstractGrailsClass
 import org.grails.core.artefact.UrlMappingsArtefactHandler
 import org.grails.plugins.web.taglib.FormTagLib
+import spock.lang.Issue
+import spock.lang.PendingFeatureIf
+import spock.lang.Rollup
 import spock.lang.Specification
 
 /**
  * Tests for the FormTagLib.groovy file which contains tags to help with the                                         l
- * creation of HTML forms
+ * creation of HTML forms.
  *
- * Please note tests that require special config have been moved to FormTagLibWithConfigSpec you can test things
- * that require no special config here
+ * Please note tests that require special config have been moved to FormTagLibWithConfigSpec.
+ * You can test things that require no special config here.
  *
  * @author Graeme
  * @author rvanderwerf
  */
 class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib> {
-
 
     def setup() {
         tagLib.requestDataValueProcessor = new MockRequestDataValueProcessor()
@@ -46,102 +48,82 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
 
     def setupSpec() {
         def mappingsClosure = {
-            "/admin/books"(controller:'books', namespace:'admin')
-            "/books"(controller:'books')
+            '/admin/books'(controller: 'books', namespace: 'admin')
+            '/books'(controller: 'books')
         }
-        grailsApplication.addArtefact(UrlMappingsArtefactHandler.TYPE, new FormTagLibTests.MockGrailsUrlMappingsClass(mappingsClosure))
-
+        grailsApplication.addArtefact(UrlMappingsArtefactHandler.TYPE, new MockGrailsUrlMappingsClass(mappingsClosure))
     }
 
+    @PendingFeatureIf({
+        System.getenv('GITHUB_REF')
+        /*
+            FOR SOME REASON FAILS IN CI WITH:
+            output == '<form action="/books" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
+            |      |
+            |      false
+            |      6 differences (95% similarity)
+            |      <form action="(------)" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>
+            |      <form action="(/books)" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>
+            <form action="" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />
+            </form>
+         */
+    })
     def testFormNoNamespace() {
-        when:
-        def template = '<g:form controller="books"></g:form>'
-        String output = applyTemplate(template)
-
-        then:
-        output == '<form action="/books" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
-    }
-
-    private static final class MockGrailsUrlMappingsClass extends AbstractGrailsClass implements GrailsUrlMappingsClass {
-        Closure mappingClosure
-        public MockGrailsUrlMappingsClass(Closure mappingClosure) {
-            super(FormTagLibTests.class, "UrlMappings")
-            this.mappingClosure = mappingClosure
-        }
-        @Override
-        public Closure getMappingsClosure() {
-            return mappingClosure
-        }
-
-        @Override
-        public List getExcludePatterns() {
-            return null
-        }
+        expect:
+        applyTemplate('<g:form controller="books"></g:form>') ==
+                '<form action="/books" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
     }
 
     def testFormTagWithAlternativeMethod() {
+        given:
         unRegisterRequestDataValueProcessor()
-        when:
-        def template = '<g:form url="/foo/bar" method="delete"></g:form>'
 
-        then:
-        String output = ('<form action="/foo/bar" method="post" ><input type="hidden" name="_method" value="DELETE" id="_method" /></form>')
-         output == applyTemplate(template)
+        expect:
+        applyTemplate('<g:form url="/foo/bar" method="delete"></g:form>') ==
+                '<form action="/foo/bar" method="post" ><input type="hidden" name="_method" value="DELETE" id="_method" /></form>'
     }
 
     def testFormTagWithAlternativeMethodAndRequestDataValueProcessor() {
-        when:
-        def template = '<g:form url="/foo/bar" method="delete"></g:form>'
-        String output = applyTemplate(template)
-
-        then:
-        output == '<form action="/foo/bar" method="post" ><input type="hidden" name="_method" value="DELETE_PROCESSED_" id="_method" /><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
+        expect:
+        applyTemplate('<g:form url="/foo/bar" method="delete"></g:form>') ==
+                '<form action="/foo/bar" method="post" ><input type="hidden" name="_method" value="DELETE_PROCESSED_" id="_method" /><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
     }
 
-    // test for GRAILS-3865
+    @Issue('https://github.com/apache/grails-core/issues/6653')
     def testHiddenFieldWithZeroValue() {
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        def template = '<g:hiddenField name="index" value="${0}" />'
-        String output = applyTemplate('value="0"')
 
-        then:
-        output.contains('value="0"')
+        expect:
+        applyTemplate('<g:hiddenField name="index" value="${0}" />').contains('value="0"')
     }
 
     def testHiddenFieldWithZeroValueAndRequestDataValueProcessor() {
-        when:
-        def template = '<g:hiddenField name="index" value="${0}" />'
-        String output = applyTemplate(template)
-
-        then:
-        output.contains('value="0_PROCESSED_"')
+        expect:
+        applyTemplate('<g:hiddenField name="index" value="${0}" />').contains('value="0_PROCESSED_"')
     }
 
     def testFormTagWithStringURL() {
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        def template = '<g:form url="/foo/bar"></g:form>'
-        String output = applyTemplate(template)
 
-        then:
-        output == '<form action="/foo/bar" method="post" ></form>'
+        expect:
+        applyTemplate('<g:form url="/foo/bar"></g:form>') ==
+                '<form action="/foo/bar" method="post" ></form>'
     }
 
     def testFormTagWithStringURLAndRequestDataValueProcessor() {
-        when:
-        def template = '<g:form url="/foo/bar"></g:form>'
-        String output = applyTemplate(template)
-
-        then:
-        output == '<form action="/foo/bar" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
+        expect:
+        applyTemplate('<g:form url="/foo/bar"></g:form>') ==
+                '<form action="/foo/bar" method="post" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
     }
 
     def testFormTagWithTrueUseToken() {
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        def template = '<g:form url="/foo/bar" useToken="true"></g:form>'
-        String output = applyTemplate(template)
+
+        when:
+        String output = applyTemplate('<g:form url="/foo/bar" useToken="true"></g:form>')
 
         then:
         output.contains('<form action="/foo/bar" method="post" >')
@@ -149,8 +131,7 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
         output.contains('<input type="hidden" name="SYNCHRONIZER_URI" value="')
 
         when:
-        template = '<g:form url="/foo/bar" useToken="${2 * 3 == 6}"></g:form>'
-        output = applyTemplate(template)
+        output = applyTemplate('<g:form url="/foo/bar" useToken="${2 * 3 == 6}"></g:form>')
 
         then:
         output.contains('<form action="/foo/bar" method="post" >')
@@ -160,9 +141,7 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
 
     def testFormTagWithTrueUseTokenAndRequestDataValueProcessor() {
         when:
-
-        def template = '<g:form url="/foo/bar" useToken="true"></g:form>'
-        String output = applyTemplate(template)
+        String output = applyTemplate('<g:form url="/foo/bar" useToken="true"></g:form>')
 
         then:
         output.contains('<form action="/foo/bar" method="post" >')
@@ -171,8 +150,7 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
 
 
         when:
-        template = '<g:form url="/foo/bar" useToken="${2 * 3 == 6}"></g:form>'
-        output = applyTemplate(template)
+        output = applyTemplate('<g:form url="/foo/bar" useToken="${2 * 3 == 6}"></g:form>')
 
         then:
         output.contains('<form action="/foo/bar" method="post" >')
@@ -182,9 +160,7 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
 
     def testFormTagWithNonTrueUseToken() {
         when:
-
-        def template = '<g:form url="/foo/bar" useToken="false"></g:form>'
-        String output = applyTemplate(template)
+        String output = applyTemplate('<g:form url="/foo/bar" useToken="false"></g:form>')
 
         then:
         output.contains('<form action="/foo/bar" method="post" >')
@@ -192,8 +168,7 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
         !output.contains('SYNCHRONIZER_URI')
 
         when:
-        template = '<g:form url="/foo/bar" useToken="someNonTrueValue"></g:form>'
-        output = applyTemplate(template)
+        output = applyTemplate('<g:form url="/foo/bar" useToken="someNonTrueValue"></g:form>')
 
         then:
         output.contains('<form action="/foo/bar" method="post" >')
@@ -201,8 +176,7 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
         !output.contains('SYNCHRONIZER_URI')
 
         when:
-        template = '<g:form url="/foo/bar" useToken="${42 * 2112 == 3}"></g:form>'
-        output = applyTemplate(template)
+        output = applyTemplate('<g:form url="/foo/bar" useToken="${42 * 2112 == 3}"></g:form>')
 
         then:
         output.contains('<form action="/foo/bar" method="post" >')
@@ -210,331 +184,339 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
         !output.contains('SYNCHRONIZER_URI')
     }
 
-    def testTextFieldTag() {
-        when:
+    @Rollup
+    def testTextFieldTag(String template, Map model, String expectedOutput) {
+        given:
         unRegisterRequestDataValueProcessor()
-        def template = '<g:textField name="testField" value="1" />'
-        String output = applyTemplate(template,[value:"1"])
 
-        then:
-        output == '<input type="text" name="testField" value="1" id="testField" />'
+        expect:
+        applyTemplate(template, model) == expectedOutput
 
-        when:
-        template = '<g:textField name="testField" value="${value}" />'
-        output = applyTemplate(template,[value:/foo > " & < '/])
-
-        then:
-        output == '<input type="text" name="testField" value="foo &gt; &quot; &amp; &lt; &#39;" id="testField" />'
+        where:
+        template | model || expectedOutput
+        '<g:textField name="testField" value="1" />' | [value: '1'] ||
+                '<input type="text" name="testField" value="1" id="testField" />'
+        '<g:textField name="testField" value="${value}" />' | [value: /foo > " & < '/] ||
+                '<input type="text" name="testField" value="foo &gt; &quot; &amp; &lt; &#39;" id="testField" />'
     }
 
-    def testTextFieldTagWithRequestDataValueProcessor() {
+    @Rollup
+    def testTextFieldTagWithRequestDataValueProcessor(String template, Map model, String expectedOutput) {
+        expect:
+        applyTemplate(template, model) == expectedOutput
 
-        when:
-        String template = '<g:textField name="testField" value="1" />'
-        String output = applyTemplate(template)
-
-        then:
-        output == '<input type="text" name="testField" value="1_PROCESSED_" id="testField" />'
-
-        when:
-        template = '<g:textField name="testField" value="${value}" />'
-        output = applyTemplate(template, [value:/foo > " & < '/])
-
-        then:
-         output == '<input type="text" name="testField" value="foo &gt; &quot; &amp; &lt; &#39;_PROCESSED_" id="testField" />'
+        where:
+        template | model || expectedOutput
+        '<g:textField name="testField" value="1" />' | [:] ||
+                '<input type="text" name="testField" value="1_PROCESSED_" id="testField" />'
+        '<g:textField name="testField" value="${value}" />' | [value:/foo > " & < '/] ||
+                '<input type="text" name="testField" value="foo &gt; &quot; &amp; &lt; &#39;_PROCESSED_" id="testField" />'
     }
 
-    def testTextFieldTagWithNonBooleanAttributesAndNoConfig() {
-        when:
+    @Rollup
+    def testTextFieldTagWithNonBooleanAttributesAndNoConfig(String template, String expectedOutput) {
+        given:
         unRegisterRequestDataValueProcessor()
-        def template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" bogus="false" />'
-        String output = applyTemplate(template)
 
-        then:
-        output == '<input type="text" name="testField" value="1" bogus="false" id="testField" />'
+        expect:
+        applyTemplate(template) == expectedOutput
 
-        when:
-        template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true" bogus="true" />'
-        output = applyTemplate(template)
-
-        then:
-        output == '<input type="text" name="testField" value="1" bogus="true" disabled="disabled" checked="checked" readonly="readonly" required="required" id="testField" />'
+        where:
+        template || expectedOutput
+        '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" bogus="false" />' ||
+                '<input type="text" name="testField" value="1" bogus="false" id="testField" />'
+        '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true" bogus="true" />' ||
+                '<input type="text" name="testField" value="1" bogus="true" disabled="disabled" checked="checked" readonly="readonly" required="required" id="testField" />'
     }
 
 
     def testTextAreaWithBody() {
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        def template = '<g:textArea name="test">This is content</g:textArea>'
-        String output = applyTemplate(template)
 
-        then:
-        output == '<textarea name="test" id="test" >This is content</textarea>'
+        expect:
+        applyTemplate('<g:textArea name="test">This is content</g:textArea>') ==
+                '<textarea name="test" id="test" >This is content</textarea>'
     }
 
     def testTextAreaWithBodyAndRequestDataValueProcessor() {
-        when:
-        def template = '<g:textArea name="test">This is content</g:textArea>'
-        String output = applyTemplate(template)
-
-        then:
-        output == '<textarea name="test" id="test" >This is content_PROCESSED_</textarea>'
+        expect:
+        applyTemplate('<g:textArea name="test">This is content</g:textArea>') ==
+                '<textarea name="test" id="test" >This is content_PROCESSED_</textarea>'
     }
 
     def testPasswordTag() {
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        def template = '<g:passwordField name="myPassword" value="foo"/>'
-        String output = applyTemplate(template)
 
-        then:
-        output == '<input type="password" name="myPassword" value="foo" id="myPassword" />'
+        expect:
+        applyTemplate('<g:passwordField name="myPassword" value="foo"/>') ==
+                '<input type="password" name="myPassword" value="foo" id="myPassword" />'
     }
 
     def testPasswordTagWithRequestDataValueProcessor() {
-        when:
-        def template = '<g:passwordField name="myPassword" value="foo"/>'
-        String output = applyTemplate(template)
-
-        then:
-        output =='<input type="password" name="myPassword" value="foo_PROCESSED_" id="myPassword" />'
+        expect:
+        applyTemplate('<g:passwordField name="myPassword" value="foo"/>') ==
+                '<input type="password" name="myPassword" value="foo_PROCESSED_" id="myPassword" />'
     }
 
     def testFormWithURL() {
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.form(
-                new TreeMap([
-                        url: [controller: 'con', action: 'action'],
-                        id: 'formElementId'
-                ])
-        )
 
-        then:
-        output == '<form action="/con/action" method="post" id="formElementId" ></form>'
+        expect:
+        tagLib.form(
+                new TreeMap([
+                        url: [
+                                controller: 'con',
+                                action: 'action'
+                        ],
+                        id: 'formElementId'
+                ]),
+                null
+        ).toString() == '<form action="/con/action" method="post" id="formElementId" ></form>'
     }
 
     def testFormWithURLAndRequestDataValueProcessor() {
-
-        when:
-        String output = tagLib.form(
+        expect:
+        tagLib.form(
                 new TreeMap([
-                        url: [controller: 'con', action: 'action'],
+                        url: [
+                                controller: 'con',
+                                action: 'action'
+                        ],
                         id: 'formElementId'
-                ])
-        )
-
-        then:
-        output == '<form action="/con/action" method="post" id="formElementId" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
+                ]),
+                null
+        ).toString() == '<form action="/con/action" method="post" id="formElementId" ><input type="hidden" name="requestDataValueProcessorHiddenName" value="hiddenValue" />\n</form>'
     }
 
     def testFormActionSubmitWithController() {
-        when:
-        String output = tagLib.formActionSubmit([controller: 'con', id: 'formElementId', value: 'Submit'])
-
-        then:
-        output == '<input type="submit" formaction="/con" value="Submit" id="formElementId" />'
+        expect:
+        tagLib.formActionSubmit([
+                controller: 'con',
+                id: 'formElementId',
+                value: 'Submit'
+        ]).toString() ==
+                '<input type="submit" formaction="/con" value="Submit" id="formElementId" />'
     }
 
     def testFormActionSubmitWithControllerAndAction() {
-        when:
-        String output = tagLib.formActionSubmit([controller: 'con', action: 'act', id: 'formElementId', value: 'Submit'])
-
-        then:
-        output == '<input type="submit" formaction="/con/act" value="Submit" id="formElementId" />'
+        expect:
+        tagLib.formActionSubmit([
+                controller: 'con',
+                action: 'act',
+                id: 'formElementId',
+                value: 'Submit'
+        ]).toString() ==
+                '<input type="submit" formaction="/con/act" value="Submit" id="formElementId" />'
     }
 
     def testFormActionSubmitWithURLAndNoParams() {
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.formActionSubmit(new TreeMap([url: [controller: 'con', action:'action'], id: 'formElementId', value: 'Submit']))
 
-        then:
-        output == '<input type="submit" formaction="/con/action" id="formElementId" value="Submit" />'
+        expect:
+        tagLib.formActionSubmit(new TreeMap([
+                url: [
+                        controller: 'con',
+                        action: 'action'
+                ],
+                id: 'formElementId',
+                value: 'Submit'
+        ])).toString() ==
+                '<input type="submit" formaction="/con/action" id="formElementId" value="Submit" />'
     }
 
     def testFormActionSubmitWithAURLAndRequestDataValueProcessor() {
-        when:
-        String output = tagLib.formActionSubmit(
-            new TreeMap([
+        expect:
+        tagLib.formActionSubmit(new TreeMap([
                 url: [
                         controller: 'con',
-                        action:'action',
+                        action: 'action',
                         params: [
                             requestDataValueProcessorParamName: 'paramValue'
                         ]
                 ],
                 id: 'formElementId',
                 value: 'My Button'
-            ])
-        )
-
-        then:
-        output == '<input type="submit" formaction="/con/action" id="formElementId" value="My Button" />'
+        ])).toString() ==
+                '<input type="submit" formaction="/con/action" id="formElementId" value="My Button" />'
     }
 
     def testFormActionSubmitWithAURLAndWithoutRequestDataValueProcessor() {
         given:
         unRegisterRequestDataValueProcessor()
 
-        when:
-        String output = tagLib.formActionSubmit(
-            new TreeMap([
-                    url: [
-                            controller: 'con',
-                            action:'action',
-                            params: [
-                                    requestDataValueProcessorParamName: 'paramValue'
-                            ]
-                    ],
-                    id: 'formElementId',
-                    value: 'My Button'
-            ])
-        )
-
-        then:
-        output == '<input type="submit" formaction="/con/action?requestDataValueProcessorParamName=paramValue" id="formElementId" value="My Button" />'
+        expect:
+        tagLib.formActionSubmit(new TreeMap([
+                url: [
+                        controller: 'con',
+                        action: 'action',
+                        params: [
+                                requestDataValueProcessorParamName: 'paramValue'
+                        ]
+                ],
+                id: 'formElementId',
+                value: 'My Button'
+        ])).toString() ==
+                '<input type="submit" formaction="/con/action?requestDataValueProcessorParamName=paramValue" id="formElementId" value="My Button" />'
     }
 
     def testActionSubmitWithoutAction() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.actionSubmit(new TreeMap([value:'Edit']))
 
-        then:
-        output == '<input type="submit" name="_action_Edit" value="Edit" />'
+        expect:
+        tagLib.actionSubmit(new TreeMap([
+                value: 'Edit'
+        ])).toString() ==
+                '<input type="submit" name="_action_Edit" value="Edit" />'
     }
 
     def testActionSubmitWithoutActionAndWithRequestDataValueProcessor() {
-
-        when:
-        String output = tagLib.actionSubmit(new TreeMap([value:'Edit']))
-
-        then:
-        output == '<input type="submit" name="_action_Edit" value="Edit_PROCESSED_" />'
+        expect:
+        tagLib.actionSubmit(new TreeMap([
+                value: 'Edit'
+        ])).toString() ==
+                '<input type="submit" name="_action_Edit" value="Edit_PROCESSED_" />'
     }
 
     def testActionSubmitWithAction() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.actionSubmit(new TreeMap([action:'Edit', value:'Some label for editing']))
 
-        then:
-        output == '<input type="submit" name="_action_Edit" value="Some label for editing" />'
+        expect:
+        tagLib.actionSubmit(new TreeMap([
+                action: 'Edit',
+                value: 'Some label for editing'
+        ])).toString() ==
+                '<input type="submit" name="_action_Edit" value="Some label for editing" />'
     }
 
     def testActionSubmitWithActionAndRequestDataValueProcessor() {
-
-        when:
-        String output = tagLib.actionSubmit(new TreeMap([action:'Edit', value:'Some label for editing']))
-
-        then:
-        output == '<input type="submit" name="_action_Edit" value="Some label for editing_PROCESSED_" />'
+        expect:
+        tagLib.actionSubmit(new TreeMap([
+                action:'Edit',
+                value:'Some label for editing'
+        ])).toString() ==
+                '<input type="submit" name="_action_Edit" value="Some label for editing_PROCESSED_" />'
     }
 
     /**
      * GRAILS-454 - Make sure that the 'name' attribute is ignored.
      */
     def testActionSubmitWithName() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.actionSubmit(new TreeMap([action:'Edit', value:'Some label for editing', name:'customName']))
 
-        then:
-        output == '<input type="submit" name="_action_Edit" value="Some label for editing" />'
+        expect:
+        tagLib.actionSubmit(new TreeMap([
+                action: 'Edit',
+                value: 'Some label for editing',
+                name:'customName'
+        ])).toString() ==
+                '<input type="submit" name="_action_Edit" value="Some label for editing" />'
     }
 
     def testActionSubmitWithAdditionalAttributes() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.actionSubmit(new TreeMap([action:'Edit', value:'Some label for editing', style:'width: 200px;']))
 
-        then:
-        output == '<input type="submit" name="_action_Edit" value="Some label for editing" style="width: 200px;" />'
+        expect:
+        tagLib.actionSubmit(new TreeMap([
+                action: 'Edit',
+                value: 'Some label for editing',
+                style: 'width: 200px;'
+        ])).toString() ==
+                '<input type="submit" name="_action_Edit" value="Some label for editing" style="width: 200px;" />'
     }
 
     def testActionSubmitImageWithoutAction() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.actionSubmitImage(new TreeMap([src:'edit.gif', value:'Edit']))
 
-        then:
-        output == '<input type="image" name="_action_Edit" value="Edit" src="edit.gif" />'
+        expect:
+        tagLib.actionSubmitImage(new TreeMap([
+                src: 'edit.gif',
+                value: 'Edit'
+        ])).toString() ==
+                '<input type="image" name="_action_Edit" value="Edit" src="edit.gif" />'
     }
 
     def testActionSubmitImageWithoutActionAndWithRequestDataValueProcessor() {
-
-        when:
-        String output = tagLib.actionSubmitImage(new TreeMap([src:'edit.gif', value:'Edit']))
-
-        then:
-        output == '<input type="image" name="_action_Edit" value="Edit_PROCESSED_" src="edit.gif?requestDataValueProcessorParamName=paramValue" />'
+        expect:
+        tagLib.actionSubmitImage(new TreeMap([
+                src: 'edit.gif', value: 'Edit'
+        ])).toString() ==
+                '<input type="image" name="_action_Edit" value="Edit_PROCESSED_" src="edit.gif?requestDataValueProcessorParamName=paramValue" />'
     }
 
     def testActionSubmitImageWithAction() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.actionSubmitImage(new TreeMap([src:'edit.gif', action:'Edit', value:'Some label for editing']))
 
-        then:
-        output == '<input type="image" name="_action_Edit" value="Some label for editing" src="edit.gif" />'
+        expect:
+        tagLib.actionSubmitImage(new TreeMap([
+                src: 'edit.gif',
+                action: 'Edit',
+                value: 'Some label for editing'
+        ])).toString() ==
+                '<input type="image" name="_action_Edit" value="Some label for editing" src="edit.gif" />'
     }
 
     def testActionSubmitImageWithAdditionalAttributes() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.actionSubmitImage(new TreeMap([src:'edit.gif', action:'Edit', value:'Some label for editing', style:'border-line: 0px;']))
 
-        then:
-        output == '<input type="image" name="_action_Edit" value="Some label for editing" src="edit.gif" style="border-line: 0px;" />'
+        expect:
+        tagLib.actionSubmitImage(new TreeMap([
+                src: 'edit.gif',
+                action: 'Edit',
+                value: 'Some label for editing',
+                style:'border-line: 0px;'
+        ])).toString() ==
+                '<input type="image" name="_action_Edit" value="Some label for editing" src="edit.gif" style="border-line: 0px;" />'
     }
 
     def testHtmlEscapingTextAreaTag() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.textArea([name: "testField", value: "<b>some text</b>"])
 
-        then:
-        output == '<textarea name="testField" id="testField" >&lt;b&gt;some text&lt;/b&gt;</textarea>'
+        expect:
+        tagLib.textArea([name: 'testField', value: '<b>some text</b>'], null) ==
+                '<textarea name="testField" id="testField" >&lt;b&gt;some text&lt;/b&gt;</textarea>'
     }
 
     def testTextAreaTag() {
-
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.textArea([name: "testField", value: "1"])
 
-        then:
-        output == '<textarea name="testField" id="testField" >1</textarea>'
+        expect:
+        tagLib.textArea([name: 'testField', value: '1'], null).toString() ==
+                '<textarea name="testField" id="testField" >1</textarea>'
     }
 
-    def testPassingTheSameMapToTextField() {
+    @Rollup
+    def testPassingTheSameMapToTextField(Map attributes, String expectedOutput) {
         // GRAILS-8250
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        String output = tagLib.textField([name: 'A'])
 
-        then:
-        output == '<input type="text" name="A" value="" id="A" />'
+        expect:
+        tagLib.textField(attributes).toString() == expectedOutput
 
-        when:
-        output = tagLib.textField([name: 'B'])
-
-        then:
-        output == '<input type="text" name="B" value="" id="B" />'
+        where:
+        attributes  || expectedOutput
+        [name: 'A'] || '<input type="text" name="A" value="" id="A" />'
+        [name: 'B'] || '<input type="text" name="B" value="" id="B" />'
     }
 
     def testFieldImplDoesNotApplyAttributesFromPreviousInvocation() {
-        unRegisterRequestDataValueProcessor()
         // GRAILS-8250
+        given:
+        unRegisterRequestDataValueProcessor()
+
         when:
         def attrs = [:]
         def out = new FastStringWriter()
@@ -543,7 +525,7 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
         attrs.tagName = 'textField'
 
         then:
-        tagLib.fieldImpl out, attrs
+        tagLib.fieldImpl(out, attrs)
          '<input type="text" name="A" value="" id="A" />' == out.toString()
 
         when:
@@ -557,123 +539,54 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
          '<input type="text" name="B" value="" id="B" />' == out.toString()
     }
 
-    def testBooleanAttributes() {
+    @Rollup
+    def testBooleanAttributes(Map attribute, String expectedOutput) {
         // GRAILS-3468
-        // Test readonly for string as boolean true
-        when:
+        given:
         unRegisterRequestDataValueProcessor()
-        Map attributes = [name: 'myfield', value: '1', readonly: 'true']
-        String output = tagLib.textField(attributes)
 
-        then:
-        output == '<input type="text" name="myfield" value="1" readonly="readonly" id="myfield" />'
+        expect:
+        tagLib.textField(attribute + [name: 'myfield', value: '1']).toString() == expectedOutput
 
-        // Test readonly for string as boolean false
-        when:
-        attributes = [name: 'myfield', value: '1', readonly: 'false']
-        output = tagLib.textField(attributes)
-
-        then:
-         output == '<input type="text" name="myfield" value="1" id="myfield" />'
-
-        // Test readonly for real boolean true
-        when:
-        attributes = [name: 'myfield', value: '1', readonly: true]
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" readonly="readonly" id="myfield" />'
-
-        // Test readonly for real boolean false
-        when:
-        attributes = [name: 'myfield', value: '1', readonly: false]
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" id="myfield" />'
-
-        // Test readonly for its default value
-        when:
-        attributes = [name: 'myfield', value: '1', readonly: 'readonly']
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" readonly="readonly" id="myfield" />'
-
-        // Test readonly for a value different from the defined in the spec
-        when:
-        attributes = [name: 'myfield', value: '1', readonly: 'other value']
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" readonly="other value" id="myfield" />'
-
-        // Test readonly for null value
-        when:
-        attributes = [name: 'myfield', value: '1', readonly: null]
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" id="myfield" />'
-
-        // Test disabled for string as boolean true
-        when:
-        attributes = [name: 'myfield', value: '1', disabled: 'true']
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" disabled="disabled" id="myfield" />'
-
-        // Test disabled for string as boolean false
-        when:
-        attributes = [name: 'myfield', value: '1', disabled: 'false']
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" id="myfield" />'
-
-        // Test disabled for real boolean true
-        when:
-        attributes = [name: 'myfield', value: '1', disabled: true]
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" disabled="disabled" id="myfield" />'
-
-        // Test disabled for real boolean false
-        when:
-        attributes = [name: 'myfield', value: '1', disabled: false]
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" id="myfield" />'
-
-        // Test disabled for its default value
-        when:
-        attributes = [name: 'myfield', value: '1', disabled: 'disabled']
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" disabled="disabled" id="myfield" />'
-
-        // Test disabled for a value different from the defined in the spec
-        when:
-        attributes = [name: 'myfield', value: '1', disabled: 'other value']
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" disabled="other value" id="myfield" />'
-
-        // Test disabled for null value
-        when:
-        attributes = [name: 'myfield', value: '1', disabled: null]
-        output = tagLib.textField(attributes)
-
-        then:
-        output == '<input type="text" name="myfield" value="1" id="myfield" />'
+        where:
+        attribute              || expectedOutput
+        [readonly: 'true']     || '<input type="text" name="myfield" value="1" readonly="readonly" id="myfield" />'
+        [readonly: 'false']    || '<input type="text" name="myfield" value="1" id="myfield" />'
+        [readonly: true]       || '<input type="text" name="myfield" value="1" readonly="readonly" id="myfield" />'
+        [readonly: false]      || '<input type="text" name="myfield" value="1" id="myfield" />'
+        [readonly: 'readonly'] || '<input type="text" name="myfield" value="1" readonly="readonly" id="myfield" />'
+        [readonly: 'foo bar']  || '<input type="text" name="myfield" value="1" readonly="foo bar" id="myfield" />'
+        [readonly: null]       || '<input type="text" name="myfield" value="1" id="myfield" />'
+        [disabled: 'true']     || '<input type="text" name="myfield" value="1" disabled="disabled" id="myfield" />'
+        [disabled: 'false']    || '<input type="text" name="myfield" value="1" id="myfield" />'
+        [disabled: true]       || '<input type="text" name="myfield" value="1" disabled="disabled" id="myfield" />'
+        [disabled: false]      || '<input type="text" name="myfield" value="1" id="myfield" />'
+        [disabled: 'disabled'] || '<input type="text" name="myfield" value="1" disabled="disabled" id="myfield" />'
+        [disabled: 'foo bar']  || '<input type="text" name="myfield" value="1" disabled="foo bar" id="myfield" />'
+        [disabled: null]       || '<input type="text" name="myfield" value="1" id="myfield" />'
     }
 
     private void unRegisterRequestDataValueProcessor() {
         tagLib.requestDataValueProcessor = null
+    }
+
+    private static final class MockGrailsUrlMappingsClass extends AbstractGrailsClass implements GrailsUrlMappingsClass {
+
+        Closure mappingClosure
+
+        MockGrailsUrlMappingsClass(Closure mappingClosure) {
+            super(FormTagLibTests.class, 'UrlMappings')
+            this.mappingClosure = mappingClosure
+        }
+
+        @Override
+        Closure getMappingsClosure() {
+            return mappingClosure
+        }
+
+        @Override
+        List getExcludePatterns() {
+            return null
+        }
     }
 }

--- a/grails-test-examples/app1/grails-app/conf/logback.xml
+++ b/grails-test-examples/app1/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/app1/grails-app/conf/logback.xml
+++ b/grails-test-examples/app1/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/app2/grails-app/conf/logback.xml
+++ b/grails-test-examples/app2/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/app2/grails-app/conf/logback.xml
+++ b/grails-test-examples/app2/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/app3/grails-app/conf/logback.xml
+++ b/grails-test-examples/app3/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/app3/grails-app/conf/logback.xml
+++ b/grails-test-examples/app3/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/async-events-pubsub-demo/grails-app/conf/logback.xml
+++ b/grails-test-examples/async-events-pubsub-demo/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <withJansi>true</withJansi>

--- a/grails-test-examples/async-events-pubsub-demo/src/integration-test/resources/logback-test.xml
+++ b/grails-test-examples/async-events-pubsub-demo/src/integration-test/resources/logback-test.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <withJansi>true</withJansi>

--- a/grails-test-examples/cache/grails-app/conf/logback.xml
+++ b/grails-test-examples/cache/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/cache/grails-app/conf/logback.xml
+++ b/grails-test-examples/cache/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/datasources/grails-app/conf/logback.xml
+++ b/grails-test-examples/datasources/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/datasources/grails-app/conf/logback.xml
+++ b/grails-test-examples/datasources/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/demo33/grails-app/conf/logback.xml
+++ b/grails-test-examples/demo33/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/demo33/grails-app/conf/logback.xml
+++ b/grails-test-examples/demo33/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/InheritedConfigSpec.groovy
+++ b/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/InheritedConfigSpec.groovy
@@ -46,7 +46,7 @@ class InheritedConfigSpec extends SuperSpec {
         go '/serverName'
 
         then: 'the emitted hostname is correct'
-        $('p').text() == 'Server name: super.example.com'
+        pageSource.contains('Server name: super.example.com')
     }
 }
 
@@ -57,7 +57,7 @@ class NotInheritedConfigSpec extends NotSuperSpec {
         go '/serverName'
 
         then: 'the emitted hostname is correct'
-        $('p').text() != 'Server name: not.example.com'
+        !pageSource.contains('Server name: not.example.com')
     }
 }
 
@@ -73,7 +73,7 @@ class ChildPreferenceInheritedConfigSpec extends SuperSpec {
         go '/serverName'
 
         then: 'the emitted hostname is correct'
-        $('p').text() == 'Server name: child.example.com'
+        pageSource.contains('Server name: child.example.com')
 
         when:
         report('whatever')
@@ -81,7 +81,7 @@ class ChildPreferenceInheritedConfigSpec extends SuperSpec {
         then:
         // geb.test.GebTestManager: "Reporting has not been enabled on this GebTestManager yet report() was called"
         Throwable t = thrown(Exception)
-        t.message.contains("not been enabled")
+        t.message.contains('not been enabled')
     }
 }
 
@@ -101,7 +101,7 @@ class MultipleInheritanceSpec extends SuperSuperInheritedConfigSpec {
         go '/serverName'
 
         then: 'the emitted hostname is correct'
-        $('p').text() == 'Server name: super.example.com'
+        pageSource.contains('Server name: super.example.com')
         report('multi inheritance report')
     }
 }

--- a/grails-test-examples/gorm/grails-app/conf/logback.xml
+++ b/grails-test-examples/gorm/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/gorm/grails-app/conf/logback.xml
+++ b/grails-test-examples/gorm/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/gsp-sitemesh3/grails-app/conf/logback-spring.xml
+++ b/grails-test-examples/gsp-sitemesh3/grails-app/conf/logback-spring.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <withJansi>true</withJansi>

--- a/grails-test-examples/hibernate5/grails-data-service/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-data-service/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hibernate5/grails-database-per-tenant/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-database-per-tenant/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hibernate5/grails-hibernate-groovy-proxy/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-hibernate-groovy-proxy/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hibernate5/grails-hibernate/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-hibernate/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hibernate5/grails-schema-per-tenant/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-schema-per-tenant/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hibernate5/issue450/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/issue450/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hibernate5/issue450/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/issue450/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/hyphenated/grails-app/conf/logback.xml
+++ b/grails-test-examples/hyphenated/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/hyphenated/grails-app/conf/logback.xml
+++ b/grails-test-examples/hyphenated/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/issue-11102/grails-app/conf/logback.xml
+++ b/grails-test-examples/issue-11102/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/issue-11102/grails-app/conf/logback.xml
+++ b/grails-test-examples/issue-11102/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/issue-11767/grails-app/conf/logback.xml
+++ b/grails-test-examples/issue-11767/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <withJansi>true</withJansi>

--- a/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/logback.xml
+++ b/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/logback.xml
+++ b/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/issue-views-182/grails-app/conf/logback.xml
+++ b/grails-test-examples/issue-views-182/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/issue-views-182/grails-app/conf/logback.xml
+++ b/grails-test-examples/issue-views-182/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/micronaut/grails-app/conf/logback.xml
+++ b/grails-test-examples/micronaut/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/micronaut/grails-app/conf/logback.xml
+++ b/grails-test-examples/micronaut/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/mongodb/base/grails-app/conf/logback.xml
+++ b/grails-test-examples/mongodb/base/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/mongodb/database-per-tenant/build.gradle
+++ b/grails-test-examples/mongodb/database-per-tenant/build.gradle
@@ -22,6 +22,7 @@ group = 'examples.mongo.tenant'
 
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
+apply plugin: 'com.bertramlabs.asset-pipeline'
 
 dependencies {
 

--- a/grails-test-examples/mongodb/database-per-tenant/grails-app/conf/logback.xml
+++ b/grails-test-examples/mongodb/database-per-tenant/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/mongodb/gson-templates/build.gradle
+++ b/grails-test-examples/mongodb/gson-templates/build.gradle
@@ -22,6 +22,7 @@ group = 'examples'
 
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
+apply plugin: 'com.bertramlabs.asset-pipeline'
 
 dependencies {
     implementation platform(project(':grails-bom'))

--- a/grails-test-examples/mongodb/gson-templates/src/integration-test/resources/logback-test.xml
+++ b/grails-test-examples/mongodb/gson-templates/src/integration-test/resources/logback-test.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/mongodb/hibernate5/build.gradle
+++ b/grails-test-examples/mongodb/hibernate5/build.gradle
@@ -22,6 +22,7 @@ group = 'examples'
 
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
+apply plugin: 'com.bertramlabs.asset-pipeline'
 
 dependencies {
 

--- a/grails-test-examples/mongodb/hibernate5/grails-app/conf/logback.xml
+++ b/grails-test-examples/mongodb/hibernate5/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/mongodb/test-data-service/grails-app/conf/logback.xml
+++ b/grails-test-examples/mongodb/test-data-service/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/namespaces/grails-app/conf/logback.xml
+++ b/grails-test-examples/namespaces/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/namespaces/grails-app/conf/logback.xml
+++ b/grails-test-examples/namespaces/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/plugins/issue11005/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/issue11005/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/plugins/issue11005/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/issue11005/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/plugins/loadafter/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/loadafter/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/plugins/loadafter/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/loadafter/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/plugins/loadfirst/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/loadfirst/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/plugins/loadfirst/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/loadfirst/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/plugins/loadsecond/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/loadsecond/grails-app/conf/logback.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/plugins/loadsecond/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/loadsecond/grails-app/conf/logback.xml
@@ -27,7 +27,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>'%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex'</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
         </encoder>
     </appender>
 

--- a/grails-test-examples/views-functional-tests/src/integration-test/resources/logback-test.xml
+++ b/grails-test-examples/views-functional-tests/src/integration-test/resources/logback-test.xml
@@ -21,8 +21,8 @@
 -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-examples/views-functional-tests/src/test/resources/logback-test.xml
+++ b/grails-test-examples/views-functional-tests/src/test/resources/logback-test.xml
@@ -19,8 +19,8 @@
   -->
 <configuration>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -105,27 +105,15 @@ def isolatedTestPatterns = [
 isolatedTestPatterns.keySet().each { taskName ->
     tasks.register(taskName, Test).configure { Test tTask ->
         tTask.onlyIf {
-            if(project.hasProperty('onlyFunctionalTests')) {
-                return false
+            ![
+                    'onlyFunctionalTests',
+                    'onlyHibernate5Tests',
+                    'onlyMongodbTests',
+                    'skipCoreTests',
+                    'skipTests'
+            ].find {
+                project.hasProperty(it)
             }
-
-            if (project.hasProperty('onlyMongodbTests')) {
-                return false
-            }
-
-            if (project.hasProperty('onlyHibernate5Tests')) {
-                return false
-            }
-
-            if(project.hasProperty('skipCoreTests')) {
-                return false
-            }
-
-            if(project.hasProperty('skipTests')) {
-                return false
-            }
-
-            true
         }
         tTask.group = 'verification'
         tTask.filter.includePatterns = isolatedTestPatterns[taskName]
@@ -139,19 +127,13 @@ tasks.named('isolatedTestsTwo', Test).configure {
 
 tasks.withType(Test).configureEach {
     onlyIf {
-        if (project.hasProperty('onlyHibernate5Tests')) {
-            return false
+        ![
+                'onlyHibernate5Tests',
+                'onlyMongodbTests',
+                'skipCoreTests'
+        ].find {
+            project.hasProperty(it)
         }
-
-        if (project.hasProperty('onlyMongodbTests')) {
-            return false
-        }
-
-        if (project.hasProperty('skipCoreTests')) {
-            return false
-        }
-
-        return true
     }
 
     onlyIf {
@@ -166,27 +148,15 @@ tasks.withType(Test).configureEach {
 
 tasks.named('test', Test).configure {
     onlyIf {
-        if(project.hasProperty('onlyFunctionalTests')) {
-            return false
+        ![
+                'onlyFunctionalTests',
+                'onlyHibernate5Tests',
+                'onlyMongodbTests',
+                'skipCoreTests',
+                'skipTests'
+        ].find {
+            project.hasProperty(it)
         }
-
-        if (project.hasProperty('onlyMongodbTests')) {
-            return false
-        }
-
-        if (project.hasProperty('onlyHibernate5Tests')) {
-            return false
-        }
-
-        if(project.hasProperty('skipCoreTests')) {
-            return false
-        }
-
-        if(project.hasProperty('skipTests')) {
-            return false
-        }
-
-        true
     }
 
     filter.excludePatterns = isolatedTestPatterns.values().flatten()

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/GroovyPageUnitTestMixinWithCustomViewDirSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/GroovyPageUnitTestMixinWithCustomViewDirSpec.groovy
@@ -35,6 +35,6 @@ class GroovyPageUnitTestMixinWithCustomViewDirSpec extends Specification impleme
         def result = render(template: '/demo/myTemplate')
         
         then:
-        result == '\nthis is a custom template'
+        result.contains('this is a custom template')
     }
 }

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/GroovyPageUnitTestMixinWithCustomViewDirSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/GroovyPageUnitTestMixinWithCustomViewDirSpec.groovy
@@ -35,6 +35,6 @@ class GroovyPageUnitTestMixinWithCustomViewDirSpec extends Specification impleme
         def result = render(template: '/demo/myTemplate')
         
         then:
-        result.contains('this is a custom template')
+        result.trim() == 'this is a custom template'
     }
 }


### PR DESCRIPTION
- Stabilize flaky `CustomAutoTimestampSpec`
  - Address intermittent CI failures possibly caused by date values not incrementing as expected.
  - Enhance assertions by comparing `.time` values to reveal the actual millisecond differences.
  - Remove annotations that were added as a try to remedy the flakiness, to determine if they are warranted.
  - Omit cleanup of `insertOverwrite`, to determine if it is necessary for test stability.
  - Do one comparison per statement in `then` blocks.
- Fix `GroovyPageUnitTestMixinWithCustomViewDirSpec` on Windows
  - The test was failing on Windows due to line ending differences affecting string comparisons.
- Apply `asset-pipeline` Gradle plugin in some test applications with assets
  - This puts `org.graalvm.js:js-community` on the `runtimeClasspath` and avoids `ClassNotFoundException: org.graalvm.polyglot.Context`.
- Re-enable `TckTestSuite` on Windows as it does not seem to fail
- Update `gradle.yml`
- Fix an incorrect log pattern in functional test applications
- Update deprecated `converterClass` attributes in `logback.xml`
- Fix develocity authentication in `grails-gradle`
- Switch some Gradle log statements from `lifecycle` to `info` to clean up the log output a bit.
- Update Gradle Plugin e2e tests to use Groovy 2.0.25.
- Add `mavenCentral` repository to Gradle Plugin e2e tests.
- Switch to using `@PendingFeatureIf` for tests that only fail in `CI`.