### PR TITLE
PR #2 - reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ target
 tmp/
 !grails-fields/src/main/groovy/org/grails/scaffolding/registry/output
 !etc/bin
+etc/bin/results

--- a/etc/bin/extract-build-artifact.sh
+++ b/etc/bin/extract-build-artifact.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+set -e
+
+ARTIFACT_NAME=$1
+
+if [ -z "${ARTIFACT_NAME}" ]; then
+  echo "Usage: $0 <artifact-name>"
+  exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [ -z "${SCRIPT_DIR}/results/first/${ARTIFACT_NAME}" ]; then
+    echo "First Artifact Not found: $ARTIFACT_NAME could not be found under ${SCRIPT_DIR}/results/first/${ARTIFACT_NAME}"
+    exit 1;
+else
+  echo "First Artifact Found @ ${SCRIPT_DIR}/results/first/${ARTIFACT_NAME}"
+fi
+if [ -z "${SCRIPT_DIR}/results/second/${ARTIFACT_NAME}" ]; then
+    echo "Second Artifact Not found: $ARTIFACT_NAME could not be found under ${SCRIPT_DIR}/results/second/${ARTIFACT_NAME}"
+    exit 1;
+else
+  echo "Second Artifact Found @ ${SCRIPT_DIR}/results/first/${ARTIFACT_NAME}"
+fi
+
+rm -rf "${SCRIPT_DIR}/results/firstArtifact" || true
+rm -rf "${SCRIPT_DIR}/results/secondArtifact" || true
+
+unzip "${SCRIPT_DIR}/results/first/${ARTIFACT_NAME}" -d "${SCRIPT_DIR}/results/firstArtifact"
+unzip "${SCRIPT_DIR}/results/second/${ARTIFACT_NAME}" -d "${SCRIPT_DIR}/results/secondArtifact"

--- a/etc/bin/generate-build-artifact-hashes.groovy
+++ b/etc/bin/generate-build-artifact-hashes.groovy
@@ -60,6 +60,7 @@ Files.walk(scanRoot)
             .filter {
                 Files.isRegularFile(it) &&
                         !it.toString().contains("buildSrc") &&
+                        !it.toString().contains("etc") &&
                         it.toString().endsWith('.jar') &&
                         it.toString().contains("${File.separator}build${File.separator}libs${File.separator}")
             }

--- a/etc/bin/test-reproducible-builds.sh
+++ b/etc/bin/test-reproducible-builds.sh
@@ -22,22 +22,43 @@ set -e
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd "$SCRIPT_DIR/../.."
+cd "${SCRIPT_DIR}/../.."
 
-git clean -xdf
+rm -rf "${SCRIPT_DIR}/results" || true
+mkdir -p "${SCRIPT_DIR}/results"
+
+git clean -xdf --exclude='etc/bin'
 killall -e java || true
 ./gradlew build --rerun-tasks -PskipTests --no-build-cache
-FIRST_BUILD=$("$SCRIPT_DIR/generate-build-artifact-hashes.groovy")
+"${SCRIPT_DIR}/generate-build-artifact-hashes.groovy" > "${SCRIPT_DIR}/results/first.txt"
+mkdir -p "${SCRIPT_DIR}/results/first"
+find . -path ./etc -prune -o -type f -path '*/build/libs/*.jar' -print0 | xargs -0 cp --parents -t "${SCRIPT_DIR}/results/first/"
 
-git clean -xdf
+git clean -xdf --exclude='etc/bin'
 killall -e java || true
 ./gradlew build --rerun-tasks -PskipTests --no-build-cache
-SECOND_BUILD=$("$SCRIPT_DIR/generate-build-artifact-hashes.groovy")
+"${SCRIPT_DIR}/generate-build-artifact-hashes.groovy" > "${SCRIPT_DIR}/results/second.txt"
+mkdir -p "${SCRIPT_DIR}/results/second"
+find . -path ./etc -prune -o -type f -path '*/build/libs/*.jar' -print0 | xargs -0 cp --parents -t "${SCRIPT_DIR}/results/second/"
 
 cd -
-echo "$FIRST_BUILD" > first.txt
-echo "$SECOND_BUILD" > second.txt
+cd "${SCRIPT_DIR}/results"
 
 # diff -u first.txt second.txt
+DIFF_RESULTS=$(comm -3 first.txt second.txt | cut -d' ' -f1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | uniq | sort)
 echo "Differing artifacts:"
-comm -3 first.txt second.txt | cut -d' ' -f1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | uniq | sort
+echo "$DIFF_RESULTS" > diff.txt
+cat diff.txt
+
+printf '%s\n' "$DIFF_RESULTS" | sed 's|^etc/bin/results/||' > toPurge.txt
+find first -type f -name '*.jar' -print | sed 's|^first/||' | grep -F -x -v -f toPurge.txt |
+  while IFS= read -r f; do
+    rm -f "./first/$f"
+  done
+find second -type f -name '*.jar' -print | sed 's|^second/||' | grep -F -x -v -f toPurge.txt |
+  while IFS= read -r f; do
+    rm -f "./second/$f"
+  done
+rm toPurge.txt
+find . -type d -empty -delete
+cd -

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,8 @@ githubSlug=apache/grails-core
 githubBranch=7.0.x
 
 org.gradle.caching=true
+# until https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/564 is fixed, we can't cache our configuration
+# org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1536M -XX:MaxMetaspaceSize=1024M

--- a/grails-common/src/main/groovy/org/apache/grails/common/properties/PropertyFileUtils.groovy
+++ b/grails-common/src/main/groovy/org/apache/grails/common/properties/PropertyFileUtils.groovy
@@ -1,0 +1,26 @@
+package org.apache.grails.common.properties
+
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+final class PropertyFileUtils {
+    private PropertyFileUtils() {
+        // prevent  instantiation
+    }
+
+    static void makePropertiesFileReproducible(File factoriesFile) {
+        String sourceDateEpoch = System.getenv('SOURCE_DATE_EPOCH')
+        if (!sourceDateEpoch) {
+            return
+        }
+
+        Instant buildInstant = Instant.ofEpochSecond(sourceDateEpoch as Long)
+        List<String> lines = factoriesFile.readLines(StandardCharsets.ISO_8859_1.name())
+        lines[1] = "# ${Date.from(buildInstant).toString()}" as String
+        factoriesFile.withWriter { BufferedWriter writer ->
+            lines.each { String line ->
+                writer.writeLine(line)
+            }
+        }
+    }
+}

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -33,6 +33,7 @@ import groovy.xml.StreamingMarkupBuilder
 import groovy.xml.XmlSlurper
 import groovy.xml.slurpersupport.GPathResult
 import org.apache.grails.common.compiler.GroovyTransformOrder
+import org.apache.grails.common.properties.PropertyFileUtils
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassHelper
@@ -52,8 +53,6 @@ import org.grails.io.support.GrailsResourceUtils
 import org.grails.io.support.UrlResource
 
 import java.lang.reflect.Modifier
-import java.nio.charset.StandardCharsets
-import java.time.Instant
 
 /**
  * A global transformation that applies Grails' transformations to classes within a Grails project
@@ -211,27 +210,11 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
                 props.store(writer, "Grails Factories File")
             }
 
-            makeFactoriesFileReproducible(factoriesFile)
+            PropertyFileUtils.makePropertiesFileReproducible(factoriesFile)
 
             return true
         }
         return false
-    }
-
-    private static void makeFactoriesFileReproducible(File factoriesFile) {
-        String sourceDateEpoch = System.getenv('SOURCE_DATE_EPOCH')
-        if (!sourceDateEpoch) {
-            return
-        }
-
-        Instant buildInstant = Instant.ofEpochSecond(sourceDateEpoch as Long)
-        List<String> lines = factoriesFile.readLines(StandardCharsets.ISO_8859_1.name())
-        lines[1] = "# ${Date.from(buildInstant).toString()}" as String
-        factoriesFile.withWriter { BufferedWriter writer ->
-            lines.each { String line ->
-                writer.writeLine(line)
-            }
-        }
     }
 
     private static void loadFromFile(Properties props, File factoriesFile) {

--- a/grails-gradle/plugins/src/e2eTest/groovy/org/grails/gradle/test/GrailsPublishPluginSpec.groovy
+++ b/grails-gradle/plugins/src/e2eTest/groovy/org/grails/gradle/test/GrailsPublishPluginSpec.groovy
@@ -702,7 +702,8 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
         javadocJar
-        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("DefaultPackage/TestJava.html", javadocJar)
+        findJarFileEntry("another/TestOtherJava.html", javadocJar)
         findJarFileEntry("org/grails/example/MyProject.html", javadocJar)
 
         File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
@@ -753,7 +754,8 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
         javadocJar
-        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("DefaultPackage/TestJava.html", javadocJar)
+        findJarFileEntry("another/TestOtherJava.html", javadocJar)
         findJarFileEntry("org/grails/example/MyProject.html", javadocJar)
 
         File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
@@ -817,7 +819,8 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
         javadocJar
-        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("TestJava.html", javadocJar) // TODO: Unfortunately, groovydoc seems to always put this under DefaultPackage, while javadoc does not
+        findJarFileEntry("another/TestOtherJava.html", javadocJar)
 
         File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
         sourcesJar
@@ -859,7 +862,8 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
         javadocJar
-        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("DefaultPackage/TestJava.html", javadocJar)
+        findJarFileEntry("another/TestOtherJava.html", javadocJar)
 
         File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }
         sourcesJar
@@ -905,7 +909,8 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
         javadocJar
-        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("DefaultPackage/TestJava.html", javadocJar)
+        findJarFileEntry("another/TestOtherJava.html", javadocJar)
         findJarFileEntry("org/grails/example/SubProject1.html", javadocJar)
         !findJarFileEntry("org/grails/example/SubProject2.html", javadocJar)
 
@@ -956,7 +961,8 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
         javadocJar
-        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("DefaultPackage/TestJava.html", javadocJar)
+        findJarFileEntry("another/TestOtherJava.html", javadocJar)
         findJarFileEntry("org/grails/example/SubProject1.html", javadocJar)
         !findJarFileEntry("org/grails/example/SubProject2.html", javadocJar)
 
@@ -1004,7 +1010,8 @@ class GrailsPublishPluginSpec extends GradleSpecification {
 
         File javadocJar = artifacts.find{ it.name.endsWith("javadoc.jar") }
         javadocJar
-        findJarFileEntry("TestJava.html", javadocJar)
+        findJarFileEntry("DefaultPackage/TestJava.html", javadocJar)
+        findJarFileEntry("another/TestOtherJava.html", javadocJar)
         findJarFileEntry("org/grails/example/MyProject.html", javadocJar)
 
         File sourcesJar = artifacts.find{ it.name.endsWith("sources.jar") }

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/explicit-jar-creation-without-gradle-assistance/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/groovy-doc-disabled/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/java-already-configured/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/java-only-project/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-child/subproject1/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/subproject1/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multi-project-plugins-applied-parent/subproject1/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/multiple-source-sets/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/non-groovy-java-sources-included/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/src/main/java/another/TestOtherJava.java
+++ b/grails-gradle/plugins/src/e2eTest/resources/publish-projects/other-artifacts/simple-project/src/main/java/another/TestOtherJava.java
@@ -1,0 +1,13 @@
+package another;
+
+/**
+ * Some example javadoc
+ */
+public class TestOtherJava {
+    /**
+     * An example method
+     */
+    public void sayHelloFromJava() {
+        System.out.println("Hello");
+    }
+}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
@@ -520,6 +520,10 @@ Note: if project properties are used, the properties must be defined prior to ap
             if (groovyDocTask) {
                 jar.dependsOn(groovyDocTask)
 
+                // Ensure the java source set is included in the groovydoc source set
+                SourceSetContainer sourceSets = project.extensions.getByType(SourceSetContainer)
+                groovyDocTask.source(project.files(sourceSets.main.java.srcDirs))
+
                 ConfigurableFileCollection groovyDocFiles = project.files(groovyDocTask.destinationDir)
                 jar.from(groovyDocFiles)
                 jar.inputs.files(groovyDocFiles)

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
@@ -25,6 +25,7 @@ import io.github.gradlenexus.publishplugin.NexusPublishPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.plugins.*
 import org.gradle.api.publish.maven.MavenPublication
@@ -34,6 +35,7 @@ import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.javadoc.Groovydoc
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
@@ -499,35 +501,53 @@ Note: if project properties are used, the properties must be defined prior to ap
             it.withSourcesJar()
         }
 
-        final TaskContainer taskContainer = project.tasks
-        taskContainer.named('javadocJar', Jar).configure { Jar task ->
-            project.rootProject.logger.info("Configuring javadocJar task for project {} to include groovydoc", project.name)
-            Task groovyDocTask = taskContainer.findByName('groovydoc')
+        final TaskContainer tasks = project.tasks
+        tasks.named('javadoc').configure {
+            Task groovyDocTask = tasks.findByName('groovydoc')
             if (groovyDocTask) {
-                task.dependsOn groovyDocTask
-
-                task.duplicatesStrategy = DuplicatesStrategy.INCLUDE
-                task.from groovyDocTask.outputs
+                project.rootProject.logger.info("Configuring javadocJar task for project {} to include groovydoc", project.name)
+                it.enabled = false
             }
-
-            task.outputs.cacheIf { true }
         }
 
-        taskContainer.named('sourcesJar', Jar).configure { Jar task ->
+        tasks.named('javadocJar', Jar).configure { Jar jar ->
+            jar.reproducibleFileOrder = true
+            jar.preserveFileTimestamps = false
+            jar.dirMode = 0755 // To avoid platform specific defaults
+            jar.fileMode = 0644 // to avoid platform specific defaults
+
+            Groovydoc groovyDocTask = tasks.findByName('groovydoc')
+            if (groovyDocTask) {
+                jar.dependsOn(groovyDocTask)
+
+                ConfigurableFileCollection groovyDocFiles = project.files(groovyDocTask.destinationDir)
+                jar.from(groovyDocFiles)
+                jar.inputs.files(groovyDocFiles)
+            }
+        }
+
+        tasks.named('sourcesJar', Jar).configure { Jar jar ->
             SourceSetContainer sourceSets = SourceSets.findSourceSets(project)
-            task.duplicatesStrategy = DuplicatesStrategy.INCLUDE
-            // don't only include main, but any source set
-            task.from sourceSets.collect { it.allSource }
+            jar.reproducibleFileOrder = true
+            jar.preserveFileTimestamps = false
+            jar.dirMode = 0755 // To avoid platform specific defaults
+            jar.fileMode = 0644 // to avoid platform specific defaults
+            jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-            task.outputs.cacheIf { true }
+            // don't only include main, but any source set
+            jar.from sourceSets.collect { it.allSource }
+            jar.inputs.files(sourceSets.collect { it.allSource })
         }
 
-        project.tasks.register('testSourcesJar', Jar).configure {
-            it.dependsOn('testClasses')
-            it.from project.sourceSets.test.output
-            it.archiveClassifier.set('tests')
-
-            it.outputs.cacheIf { true }
+        project.tasks.register('testSourcesJar', Jar).configure { Jar jar ->
+            jar.dependsOn('testClasses')
+            jar.reproducibleFileOrder = true
+            jar.preserveFileTimestamps = false
+            jar.dirMode = 0755 // To avoid platform specific defaults
+            jar.fileMode = 0644 // to avoid platform specific defaults
+            jar.from project.sourceSets.test.output
+            jar.inputs.files(project.sourceSets.test.output)
+            jar.archiveClassifier.set('tests')
         }
 
         SourceSetContainer sourceSets = SourceSets.findSourceSets(project)

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
@@ -21,6 +21,7 @@ package org.grails.gsp.compiler
 import grails.config.ConfigMap
 import org.apache.commons.logging.LogFactory
 import org.apache.commons.logging.Log
+import org.apache.grails.common.properties.PropertyFileUtils
 import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.Phases
@@ -158,6 +159,7 @@ class GroovyPageCompiler {
                 viewregistryFile.withOutputStream { viewsOut ->
                     views.store(viewsOut, "Precompiled views for ${packagePrefix}")
                 }
+                PropertyFileUtils.makePropertiesFileReproducible(viewregistryFile)
             } finally {
                 // eventListener?.triggerEvent("StatusUpdate", "Shutting Down ThreadPool")
                 threadPool.shutdown()

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagLibraryLookup.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagLibraryLookup.java
@@ -42,10 +42,10 @@ import java.util.*;
 public class TagLibraryLookup implements ApplicationContextAware, GrailsApplicationAware, InitializingBean {
     protected ApplicationContext applicationContext;
     protected GrailsApplication grailsApplication;
-    protected Map<String, Map<String, Object>> tagNamespaces = new HashMap<>();
-    protected Map<String, NamespacedTagDispatcher> namespaceDispatchers = new HashMap<>();
-    protected Map<String, Set<String>> tagsThatReturnObjectForNamespace = new HashMap<String, Set<String>>();
-    protected Map<String, Map<String,Map<String, Object>>> encodeAsForTagNamespaces = new HashMap<String, Map<String,Map<String, Object>>>();
+    protected Map<String, Map<String, Object>> tagNamespaces = new LinkedHashMap<>();
+    protected Map<String, NamespacedTagDispatcher> namespaceDispatchers = new LinkedHashMap<>();
+    protected Map<String, Set<String>> tagsThatReturnObjectForNamespace = new LinkedHashMap<String, Set<String>>();
+    protected Map<String, Map<String, Map<String, Object>>> encodeAsForTagNamespaces = new LinkedHashMap<String, Map<String, Map<String, Object>>>();
 
     public void afterPropertiesSet() throws Exception {
         if (grailsApplication == null || applicationContext == null) {

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/encoder/WithCodecHelper.groovy
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/encoder/WithCodecHelper.groovy
@@ -125,7 +125,7 @@ class WithCodecHelper {
             }
             String allFallback = null
             String nameFallback = null
-            (Map<String,String>)((Map)codecInfo).each { k, v ->
+            ((Map) codecInfo).each { k, v ->
                 String codecWriterName = k.toString().toLowerCase() - 'codec'
                 if (codecWriterName == OutputEncodingSettings.INHERIT_SETTING_NAME || codecWriterName == OutputEncodingSettings.REPLACE_ONLY_SETTING_NAME) {
                     codecInfoMap.put(codecWriterName, convertToBoolean(v))
@@ -188,7 +188,7 @@ class WithCodecHelper {
         if (currentSettings) {
             Map<String, Object> canonicalCodecInfo = makeSettingsCanonical(currentSettings)
             if (parentSettings != null) {
-                codecInfoMap = new HashMap<String, Object>()
+                codecInfoMap = new LinkedHashMap<String, Object>()
                 codecInfoMap.putAll(parentSettings)
                 codecInfoMap.putAll(canonicalCodecInfo)
             } else {


### PR DESCRIPTION
* This PR will eliminate the duplicate files that get generated in the various grails publish - javadoc / groovydoc / sources / testSources jars
* it adds a script to make it easier to diff reruns of builds
* it fixes views.properties to be reproducible
* it fixes a taglib issue where the order of a lookup could be indeterminate 