### PR TITLE
Additional outstanding issues for grails-shell-cli

### DIFF
--- a/gradle/assemble-config.gradle
+++ b/gradle/assemble-config.gradle
@@ -19,13 +19,14 @@
 
 tasks.register('installToHomeDist').configure { Task task ->
     task.inputs.files(tasks.named('jar'))
-    task.inputs.files(tasks.named('sourcesJar'))
-    task.inputs.files(tasks.named('javadocJar'))
     task.outputs.dir(distInstallDir)
 
     doLast {
         copy {
-            it.from layout.buildDirectory.dir('libs')
+            it.from layout.buildDirectory.dir('libs').map { it.asFileTree.matching {
+                include '**/*.jar'
+                exclude '**/*-sources.jar', '**/*-javadoc.jar'
+            } }
             it.into distInstallDir
         }
     }

--- a/gradle/assemble-config.gradle
+++ b/gradle/assemble-config.gradle
@@ -23,11 +23,9 @@ tasks.register('installToHomeDist').configure { Task task ->
 
     doLast {
         copy {
-            it.from layout.buildDirectory.dir('libs').map { it.asFileTree.matching {
-                include '**/*.jar'
-                exclude '**/*-sources.jar', '**/*-javadoc.jar'
-            } }
+            it.from layout.buildDirectory.dir('libs')
             it.into distInstallDir
+            it.exclude '*sources.jar', '*-javadoc.jar'
         }
     }
 }

--- a/gradle/assemble-root-config.gradle
+++ b/gradle/assemble-root-config.gradle
@@ -116,7 +116,7 @@ tasks.register('assemble', Zip).configure {
 
     into("grails-$grailsVersion") {
         from(rootProject.layout.projectDirectory) {
-            include 'bin/grails', 'bin/grails.bat', 'lib/', 'media/icons/grails.icns', 'LICENSE', 'INSTALL'
+            include 'bin/grails', 'bin/grails.bat', 'lib/', 'media/icons/grails.icns', 'LICENSE', 'INSTALL', 'NOTICE'
 
             def pathsToExclude = [
                     'ant/bin', 'src/grails', 'src/war'

--- a/gradle/assemble-root-config.gradle
+++ b/gradle/assemble-root-config.gradle
@@ -116,8 +116,7 @@ tasks.register('assemble', Zip).configure {
 
     into("grails-$grailsVersion") {
         from(rootProject.layout.projectDirectory) {
-            // Some of these are probably not needed as they are not present in the project folder
-            include 'bin/grails', 'bin/grails.bat', 'lib/', 'media/icons/grails.icns', 'samples/', 'scripts/', 'LICENSE', 'INSTALL'
+            include 'bin/grails', 'bin/grails.bat', 'lib/', 'media/icons/grails.icns', 'LICENSE', 'INSTALL'
 
             def pathsToExclude = [
                     'ant/bin', 'src/grails', 'src/war'

--- a/gradle/assemble-root-config.gradle
+++ b/gradle/assemble-root-config.gradle
@@ -117,7 +117,7 @@ tasks.register('assemble', Zip).configure {
     into("grails-$grailsVersion") {
         from(rootProject.layout.projectDirectory) {
             // Some of these are probably not needed as they are not present in the project folder
-            include 'bin/grails', 'bin/grails.bat', 'lib/', 'media/', 'samples/', 'scripts/', 'LICENSE', 'INSTALL'
+            include 'bin/grails', 'bin/grails.bat', 'lib/', 'media/icons/grails.icns', 'samples/', 'scripts/', 'LICENSE', 'INSTALL'
 
             def pathsToExclude = [
                     'ant/bin', 'src/grails', 'src/war'

--- a/grails-shell-cli/src/main/groovy/org/grails/cli/GrailsCli.groovy
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/GrailsCli.groovy
@@ -507,12 +507,7 @@ class GrailsCli {
     private initializeProfile() {
         BuildSettings.TARGET_DIR?.mkdirs()
 
-        if(!new File(BuildSettings.BASE_DIR, "profile.yml").exists()) {
-            populateContextLoader()
-        }
-        else {
-            this.profileRepository = createMavenProfileRepository()
-        }
+        this.profileRepository = createMavenProfileRepository()
 
         String profileName = applicationConfig.get(BuildSettings.PROFILE) ?: getSetting(BuildSettings.PROFILE, String, DEFAULT_PROFILE_NAME)
         this.profile = profileRepository.getProfile(profileName)

--- a/grails-shell-cli/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
@@ -76,6 +76,8 @@ class GrailsDependencyVersions implements DependencyManagement {
             grape.addResolver([name:"mavenCentral", root:"https://repo1.maven.org/maven2"] as Map<String, Object>)
         }
 
+        grape.addResolver([name:"grailsCentral", root:"https://repo.grails.org/grails/core"] as Map<String, Object>)
+
         grape
     }
 

--- a/grails-wrapper-impl/src/main/groovy/grails/init/RunCommand.groovy
+++ b/grails-wrapper-impl/src/main/groovy/grails/init/RunCommand.groovy
@@ -51,11 +51,13 @@ class RunCommand {
 
         GroovyClassLoader groovyClassLoader = new GroovyClassLoader(RunCommand.classLoader)
 
-        List<RepositoryConfiguration> repositoryConfigurations = [new RepositoryConfiguration("mavenCentral", new URI("https://repo1.maven.org/maven2"), true)]
+        List<RepositoryConfiguration> repositoryConfigurations = [new RepositoryConfiguration("mavenCentral", new URI("https://repo1.maven.org/maven2"), false)]
+
+        repositoryConfigurations.add(new RepositoryConfiguration("grailsCentral", new URI("https://repo.grails.org/grails/core"), true))
 
         // Only add snapshot repository when grailsVersion is not set or groovyVersion or grailsVersion ends in SNAPSHOT
         if (!grailsVersion || grailsVersion.endsWith("SNAPSHOT") || groovyVersion?.endsWith("SNAPSHOT")) {
-            repositoryConfigurations.add(new RepositoryConfiguration("apacheSnapshot", new URI("https://repository.apache.org/content/groups/snapshots"), true))
+            repositoryConfigurations.add(new RepositoryConfiguration("apacheRepository", new URI("https://repository.apache.org/content/groups/public"), true))
         }
 
         MavenResolverGrapeEngine grapeEngine = MavenResolverGrapeEngineFactory.create(groovyClassLoader, repositoryConfigurations, new DependencyResolutionContext(), false)


### PR DESCRIPTION
1. Add https://repo.grails.org/grails/core back allows gradle-tooling-api to load from https://repo.grails.org/ui/native/core/org/gradle/gradle-tooling-api/
2. Remove javadoc and source jars from dist directory, these are not used from this location
3. Remove most of media directory (6,610,788 bytes - 25 files)
Size comp
> 49,109,290 bytes
> 264 Files, 131 Folders
> 
> vs
> 
> 31,282,479 bytes
> 117 Files, 129 Folders
4. Fix No profile found for name [web] by Always creating a maven profile repository to lookup profile