### PR TITLE
Rat adjustments based on grails-forge PR feedback

### DIFF
--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -28,8 +28,6 @@ on:
   workflow_dispatch:
 jobs:
   rat-audit:
-    permissions:
-      contents: read  #  to fetch code (actions/checkout)
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout repository"


### PR DESCRIPTION
- Remove permission that is defaulted
- Make rat task lazily configured

Based on feedback from https://github.com/apache/grails-forge/pull/562, which started with copies of the same files from grails-core.

