### PR TITLE
Update to Spring boot 3.5.0-RC1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,7 +44,7 @@ ext {
             'objenesis.version'                  : '3.4',
             'gradle-spock.version'               : '2.3-groovy-3.0',
             'gradle-nexus-publish-plugin.version': '2.0.0',
-            'spring-boot.version'                : '3.4.5',
+            'spring-boot.version'                : '3.5.0-RC1',
             'springloaded.version'               : '1.2.8.RELEASE',
     ]
 

--- a/grails-gradle/build.gradle
+++ b/grails-gradle/build.gradle
@@ -32,7 +32,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-        maven { url = 'https://repo.grails.org/grails/core' }
+        maven { url = 'https://repo.spring.io/milestone' }
     }
 
     props.forEach { k, v -> project.ext.set(k as String, v) }

--- a/grails-gradle/build.gradle
+++ b/grails-gradle/build.gradle
@@ -32,6 +32,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
+        maven { url = 'https://repo.grails.org/grails/core' }
     }
 
     props.forEach { k, v -> project.ext.set(k as String, v) }


### PR DESCRIPTION
Given the current timeline for Grails 7.0.0-RC1 and 7.0.0 and the overlapping Spring Boot 3.5.x timeline, this bumps the Spring Boot version for Grails 7.0.x to 3.5.x.  https://spring.io/blog/2025/04/25/spring-boot-3-5-0-RC1-available-now

I don't believe this will introduce any delay in the Grails RC1 or GA and it will have the benefit of providing nearly 12 months of OSS support for the Spring Boot Version in Grails 7.0.x.   It will also save us time by not having to immediately start work on Grails 7.1.x (based on Spring Boot 3.5.x), right after the Grails 7.0.x release.  Spring Boot 3.5.0 will be released between May 19 and 23, 2025, based on the last two May releases.

all tests in grails-core pass with spring-boot 3.5.0-RC1.

we can immediately switch to spring-boot 3.5.0-RC1, since Grails is currently at the milestone stage.

Discuss Thread:  https://lists.apache.org/thread/2ldncvvmq2t7m1sn85lssykcvh1jm6v7