### PR TITLE
fix(temp): use Groovy 4.0.27-SNAPSHOT for documentation

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -84,7 +84,7 @@ ext {
             'bootstrap.version'            : '5.3.3',
             'commons-codec.version'        : '1.17.1',
             'geb-spock.version'            : '7.0',
-            'groovy.version'               : '4.0.27-SNAPSHOT',
+            'groovy.version'               : '4.0.26',
             'h2.version'                   : '2.3.232',
             'jackson.version'              : '2.18.2',
             'jquery.version'               : '3.7.1',

--- a/grails-gradle/gradle/docs-config.gradle
+++ b/grails-gradle/gradle/docs-config.gradle
@@ -31,11 +31,19 @@ dependencies {
     add('documentation', 'org.fusesource.jansi:jansi')
     add('documentation', 'jline:jline')
     add('documentation', 'com.github.javaparser:javaparser-core')
+/*
+    Temporarily use 4.0.27-SNAPSHOT for documentation generation until 4.0.27 is released.
     add('documentation', "org.apache.groovy:groovy:${bomDependencyVersions['groovy.version']}")
     add('documentation', "org.apache.groovy:groovy-groovydoc:${bomDependencyVersions['groovy.version']}")
     add('documentation', "org.apache.groovy:groovy-ant:${bomDependencyVersions['groovy.version']}")
     add('documentation', "org.apache.groovy:groovy-docgenerator:${bomDependencyVersions['groovy.version']}")
     add('documentation', "org.apache.groovy:groovy-templates:${bomDependencyVersions['groovy.version']}")
+*/
+    add('documentation', 'org.apache.groovy:groovy:4.0.27-SNAPSHOT')
+    add('documentation', 'org.apache.groovy:groovy-groovydoc:4.0.27-SNAPSHOT')
+    add('documentation', 'org.apache.groovy:groovy-ant:4.0.27-SNAPSHOT')
+    add('documentation', 'org.apache.groovy:groovy-docgenerator:4.0.27-SNAPSHOT')
+    add('documentation', 'org.apache.groovy:groovy-templates:4.0.27-SNAPSHOT')
 }
 
 ext {


### PR DESCRIPTION
- Groovy 4.0.27-SNAPSHOT has fixes for reproducible builds regarding generating groovydoc.
- Go back to 4.0.26 for the rest of the projects for now.