### PR TITLE
Buildscript Repository config consolidation for Tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,16 @@ allprojects {
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
         // mavenLocal() // Keep, this will be uncommented and used by CI (groovy-joint-workflow)
     }
+
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven { url = 'https://repo.grails.org/grails/core' }
+            maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
+            maven { url = 'https://repository.apache.org/content/groups/snapshots' }
+            // mavenLocal() // Keep, this will be uncommented and used by CI (groovy-joint-workflow)
+        }
+    }
 }
 
 subprojects {

--- a/grails-test-examples/app1/build.gradle
+++ b/grails-test-examples/app1/build.gradle
@@ -18,12 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        mavenCentral()
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/app2/build.gradle
+++ b/grails-test-examples/app2/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/app3/build.gradle
+++ b/grails-test-examples/app3/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/async-events-pubsub-demo/build.gradle
+++ b/grails-test-examples/async-events-pubsub-demo/build.gradle
@@ -18,12 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        mavenCentral()
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/cache/build.gradle
+++ b/grails-test-examples/cache/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/datasources/build.gradle
+++ b/grails-test-examples/datasources/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/demo33/build.gradle
+++ b/grails-test-examples/demo33/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'

--- a/grails-test-examples/external-configuration/build.gradle
+++ b/grails-test-examples/external-configuration/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:$projectVersion")
         classpath "org.apache.grails:grails-gradle-plugins"

--- a/grails-test-examples/external-configuration/build.gradle
+++ b/grails-test-examples/external-configuration/build.gradle
@@ -28,12 +28,6 @@ buildscript {
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
 
-repositories {
-    maven { url = 'https://repo.grails.org/grails/core' }
-    maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    mavenCentral()
-}
-
 version = '0.1'
 group = 'test.app'
 

--- a/grails-test-examples/geb/build.gradle
+++ b/grails-test-examples/geb/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:$projectVersion")
         classpath "org.apache.grails:grails-gradle-plugins"

--- a/grails-test-examples/geb/build.gradle
+++ b/grails-test-examples/geb/build.gradle
@@ -33,12 +33,6 @@ apply plugin: 'asset-pipeline'
 group = 'org.demo.spock'
 version = projectVersion
 
-repositories {
-    maven { url = 'https://repo.grails.org/grails/core' }
-    maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    mavenCentral()
-}
-
 dependencies {
 
     implementation platform(project(':grails-bom'))

--- a/grails-test-examples/gorm/build.gradle
+++ b/grails-test-examples/gorm/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/gsp-sitemesh3/build.gradle
+++ b/grails-test-examples/gsp-sitemesh3/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/hyphenated/build.gradle
+++ b/grails-test-examples/hyphenated/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/issue-11102/build.gradle
+++ b/grails-test-examples/issue-11102/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/issue-11767/build.gradle
+++ b/grails-test-examples/issue-11767/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/issue-698-domain-save-npe/build.gradle
+++ b/grails-test-examples/issue-698-domain-save-npe/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/issue-views-182/build.gradle
+++ b/grails-test-examples/issue-views-182/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/namespaces/build.gradle
+++ b/grails-test-examples/namespaces/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/issue-11767-plugin/build.gradle
+++ b/grails-test-examples/plugins/issue-11767-plugin/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/issue11005/build.gradle
+++ b/grails-test-examples/plugins/issue11005/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/loadafter/build.gradle
+++ b/grails-test-examples/plugins/loadafter/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/loadfirst/build.gradle
+++ b/grails-test-examples/plugins/loadfirst/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/loadsecond/build.gradle
+++ b/grails-test-examples/plugins/loadsecond/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'


### PR DESCRIPTION
Repository config was already consolidated in the root `build.gradle` file.  This extends the consolidation for `buildscript{ repositories {}}`.