### PR TITLE
Functional test repository config consolidation with Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,16 @@ allprojects {
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
         // mavenLocal() // Keep, this will be uncommented and used by CI (groovy-joint-workflow)
     }
+
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven { url = 'https://repo.grails.org/grails/core' }
+            maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
+            maven { url = 'https://repository.apache.org/content/groups/snapshots' }
+            // mavenLocal() // Keep, this will be uncommented and used by CI (groovy-joint-workflow)
+        }
+    }
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -52,16 +52,6 @@ allprojects {
         maven { url = 'https://repository.apache.org/content/groups/snapshots' }
         // mavenLocal() // Keep, this will be uncommented and used by CI (groovy-joint-workflow)
     }
-
-    buildscript {
-        repositories {
-            mavenCentral()
-            maven { url = 'https://repo.grails.org/grails/core' }
-            maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
-            maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-            // mavenLocal() // Keep, this will be uncommented and used by CI (groovy-joint-workflow)
-        }
-    }
 }
 
 subprojects {

--- a/buildSrc/src/main/groovy/grails/functional/FunctionalTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/grails/functional/FunctionalTestPlugin.groovy
@@ -31,6 +31,7 @@ class FunctionalTestPlugin implements Plugin<Project> {
             maven { url = 'https://repo.grails.org/grails/core' }
             maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
             maven { url = 'https://repository.apache.org/content/groups/snapshots' }
+            maven { url = 'https://repo.spring.io/milestone' }
         }
     }
 }

--- a/buildSrc/src/main/groovy/grails/functional/FunctionalTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/grails/functional/FunctionalTestPlugin.groovy
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package grails.functional
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class FunctionalTestPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.buildscript.repositories {
+            mavenCentral()
+            maven { url = 'https://repo.grails.org/grails/core' }
+            maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
+            maven { url = 'https://repository.apache.org/content/groups/snapshots' }
+        }
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/grails.functional-test.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/grails.functional-test.properties
@@ -1,0 +1,19 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+implementation-class=grails.functional.FunctionalTestPlugin

--- a/grails-test-examples/app1/build.gradle
+++ b/grails-test-examples/app1/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'functionaltests'
 

--- a/grails-test-examples/app1/build.gradle
+++ b/grails-test-examples/app1/build.gradle
@@ -18,12 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        mavenCentral()
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/app2/build.gradle
+++ b/grails-test-examples/app2/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/app2/build.gradle
+++ b/grails-test-examples/app2/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'app2'
 

--- a/grails-test-examples/app3/build.gradle
+++ b/grails-test-examples/app3/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'app3'
 

--- a/grails-test-examples/app3/build.gradle
+++ b/grails-test-examples/app3/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/async-events-pubsub-demo/build.gradle
+++ b/grails-test-examples/async-events-pubsub-demo/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = rootProject.version
 group = 'pubsub.demo'
 

--- a/grails-test-examples/async-events-pubsub-demo/build.gradle
+++ b/grails-test-examples/async-events-pubsub-demo/build.gradle
@@ -18,12 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        mavenCentral()
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/cache/build.gradle
+++ b/grails-test-examples/cache/build.gradle
@@ -24,11 +24,11 @@ buildscript {
     }
 }
 
-
 plugins {
     id 'groovy'
     id 'idea'
     id 'eclipse'
+    id 'grails.functional-test'
 }
 
 version = projectVersion

--- a/grails-test-examples/cache/build.gradle
+++ b/grails-test-examples/cache/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/datasources/build.gradle
+++ b/grails-test-examples/datasources/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/datasources/build.gradle
+++ b/grails-test-examples/datasources/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'datasources'
 

--- a/grails-test-examples/demo33/build.gradle
+++ b/grails-test-examples/demo33/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'

--- a/grails-test-examples/demo33/build.gradle
+++ b/grails-test-examples/demo33/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 group = 'org.example.grails'
 version = '0.0.1'
 

--- a/grails-test-examples/external-configuration/build.gradle
+++ b/grails-test-examples/external-configuration/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
 

--- a/grails-test-examples/external-configuration/build.gradle
+++ b/grails-test-examples/external-configuration/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:$projectVersion")
         classpath "org.apache.grails:grails-gradle-plugins"

--- a/grails-test-examples/external-configuration/build.gradle
+++ b/grails-test-examples/external-configuration/build.gradle
@@ -28,12 +28,6 @@ buildscript {
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
 
-repositories {
-    maven { url = 'https://repo.grails.org/grails/core' }
-    maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    mavenCentral()
-}
-
 version = '0.1'
 group = 'test.app'
 

--- a/grails-test-examples/geb/build.gradle
+++ b/grails-test-examples/geb/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
 apply plugin: 'org.apache.grails.gradle.grails-gsp'

--- a/grails-test-examples/geb/build.gradle
+++ b/grails-test-examples/geb/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:$projectVersion")
         classpath "org.apache.grails:grails-gradle-plugins"

--- a/grails-test-examples/geb/build.gradle
+++ b/grails-test-examples/geb/build.gradle
@@ -33,12 +33,6 @@ apply plugin: 'asset-pipeline'
 group = 'org.demo.spock'
 version = projectVersion
 
-repositories {
-    maven { url = 'https://repo.grails.org/grails/core' }
-    maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    mavenCentral()
-}
-
 dependencies {
 
     implementation platform(project(':grails-bom'))

--- a/grails-test-examples/gorm/build.gradle
+++ b/grails-test-examples/gorm/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/gorm/build.gradle
+++ b/grails-test-examples/gorm/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'gorm'
 

--- a/grails-test-examples/gsp-sitemesh3/build.gradle
+++ b/grails-test-examples/gsp-sitemesh3/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/gsp-sitemesh3/build.gradle
+++ b/grails-test-examples/gsp-sitemesh3/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.0.1'
 group = 'org.sitemesh.grails.plugins.sitemesh3'
 

--- a/grails-test-examples/hyphenated/build.gradle
+++ b/grails-test-examples/hyphenated/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/hyphenated/build.gradle
+++ b/grails-test-examples/hyphenated/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'hyphenated'
 

--- a/grails-test-examples/issue-11102/build.gradle
+++ b/grails-test-examples/issue-11102/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'issue11102'
 

--- a/grails-test-examples/issue-11102/build.gradle
+++ b/grails-test-examples/issue-11102/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/issue-11767/build.gradle
+++ b/grails-test-examples/issue-11767/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/issue-698-domain-save-npe/build.gradle
+++ b/grails-test-examples/issue-698-domain-save-npe/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/issue-698-domain-save-npe/build.gradle
+++ b/grails-test-examples/issue-698-domain-save-npe/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'grails301.domain.save.npe'
 

--- a/grails-test-examples/issue-views-182/build.gradle
+++ b/grails-test-examples/issue-views-182/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'issueviews182'
 

--- a/grails-test-examples/issue-views-182/build.gradle
+++ b/grails-test-examples/issue-views-182/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/namespaces/build.gradle
+++ b/grails-test-examples/namespaces/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/namespaces/build.gradle
+++ b/grails-test-examples/namespaces/build.gradle
@@ -25,6 +25,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1'
 group = 'namespaces'
 

--- a/grails-test-examples/plugins/issue-11767-plugin/build.gradle
+++ b/grails-test-examples/plugins/issue-11767-plugin/build.gradle
@@ -18,10 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/issue11005/build.gradle
+++ b/grails-test-examples/plugins/issue11005/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/issue11005/build.gradle
+++ b/grails-test-examples/plugins/issue11005/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 apply plugin: 'java-library'
 apply plugin: 'org.apache.grails.gradle.grails-plugin'
 apply plugin: 'org.apache.grails.gradle.grails-gsp'

--- a/grails-test-examples/plugins/loadafter/build.gradle
+++ b/grails-test-examples/plugins/loadafter/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1-SNAPSHOT'
 group = 'com.example.grails.plugins'
 

--- a/grails-test-examples/plugins/loadafter/build.gradle
+++ b/grails-test-examples/plugins/loadafter/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/loadfirst/build.gradle
+++ b/grails-test-examples/plugins/loadfirst/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1-SNAPSHOT'
 group = 'com.example.grails.plugins'
 

--- a/grails-test-examples/plugins/loadfirst/build.gradle
+++ b/grails-test-examples/plugins/loadfirst/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'

--- a/grails-test-examples/plugins/loadsecond/build.gradle
+++ b/grails-test-examples/plugins/loadsecond/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'grails.functional-test'
+}
+
 version = '0.1-SNAPSHOT'
 group = 'com.example.grails.plugins'
 

--- a/grails-test-examples/plugins/loadsecond/build.gradle
+++ b/grails-test-examples/plugins/loadsecond/build.gradle
@@ -18,11 +18,6 @@
  */
 
 buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/core' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
     dependencies {
         classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
         classpath 'org.apache.grails:grails-gradle-plugins'


### PR DESCRIPTION
This PR builds on #14720 and changes to use a Gradle plugin to selectively appy the buildscript repositories to only the functional test projects.