### PR TITLE
Ensure we only remove update-wrapper argument.

### DIFF
--- a/grails-wrapper/src/main/java/grails/init/Start.java
+++ b/grails-wrapper/src/main/java/grails/init/Start.java
@@ -146,8 +146,7 @@ public class Start {
                     detailedVersion = getSnapshotVersion(baseVersion);
                 }
                 updateJar(baseVersion, detailedVersion);
-                // remove "update-wrapper" command argument
-                if (args.length > 0) {
+                if (args.length > 0 && args[0].trim().equals("update-wrapper")) {
                     args[0] = null;
                 }
             }

--- a/grails-wrapper/src/main/java/grails/init/Start.java
+++ b/grails-wrapper/src/main/java/grails/init/Start.java
@@ -146,6 +146,7 @@ public class Start {
                     detailedVersion = getSnapshotVersion(baseVersion);
                 }
                 updateJar(baseVersion, detailedVersion);
+                // remove "update-wrapper" command argument
                 if (args.length > 0 && args[0].trim().equals("update-wrapper")) {
                     args[0] = null;
                 }


### PR DESCRIPTION
Previously any arg would be removed assuming it was update-wrapper, despite the fact we can get here without an update-wrapper argument.

For us, this was causing our builds to use the wrong environment as:
```
-Dgrails.env=staging war
```
was being turned into
```
war
```