### PR TITLE
Run workflow with Java 24 instead of 23, in addition to LTS versions …

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21, 23 ]
+        java: [ 17, 21, 24 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21, 23 ]
+        java: [ 17, 21, 24 ]
     runs-on: ubuntu-24.04
     steps:
       - name: "📥 Checkout repository"


### PR DESCRIPTION
…17 and 21

24 was released on March 18, 2025