### PR TITLE
Revert "Comment out verify grails-wrapper step"

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -226,14 +226,14 @@ jobs:
       - name: "🔨 Create Grails Wrapper Distribution Zip"
         run: >
           ./gradlew :grails-wrapper:distZip
-#      - name: "✅ Verify grails-wrapper"
-#        if: success()
-#        run: |
-#          cp grails-wrapper/build/distributions/grails-wrapper-*.zip build/wrapper.zip
-#          cd build
-#          unzip wrapper -d tmp
-#          mv tmp/grails-wrapper-* tmp/wrapper
-#          ./tmp/wrapper/grailsw --version
+      - name: "✅ Verify grails-wrapper"
+        if: success()
+        run: |
+          cp grails-wrapper/build/distributions/grails-wrapper-*.zip build/wrapper.zip
+          cd build
+          unzip wrapper -d tmp
+          mv tmp/grails-wrapper-* tmp/wrapper
+          ./tmp/wrapper/grailsw --version
       - name: "📤 Upload Wrapper Zip to Workflow Summary Page"
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Reverts apache/grails-core#14740

This should pass now that https://repository.apache.org/content/groups/public/org/apache/grails/grails-cli/maven-metadata.xml has been published from https://github.com/apache/grails-forge/actions/runs/15055363204/job/42320334853