### PR TITLE
remove theme.js from main layout

### DIFF
--- a/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
+++ b/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
@@ -8,7 +8,6 @@
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <asset:link rel="icon" href="favicon.ico" type="image/x-ico"/>
-    <asset:javascript src="theme.js"/>
     <asset:stylesheet src="application.css"/>
     <g:layoutHead/>
 </head>


### PR DESCRIPTION
Resolves: https://github.com/apache/grails-forge/issues/537

Related to:  https://github.com/apache/grails-forge/pull/577

<asset:javascript src="theme.js"/> does not exist

This was included in https://github.com/apache/grails-forge/pull/452, but the file never existed.