### PR TITLE
Remove buildscript{} from test-example projects

### DIFF
--- a/grails-test-examples/app1/build.gradle
+++ b/grails-test-examples/app1/build.gradle
@@ -17,20 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        mavenCentral()
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'
-    }
-}
-
 version = '0.1'
 group = 'functionaltests'
 

--- a/grails-test-examples/app2/build.gradle
+++ b/grails-test-examples/app2/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'
-    }
-}
 
 version = '0.1'
 group = 'app2'

--- a/grails-test-examples/app3/build.gradle
+++ b/grails-test-examples/app3/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1'
 group = 'app3'
 

--- a/grails-test-examples/async-events-pubsub-demo/build.gradle
+++ b/grails-test-examples/async-events-pubsub-demo/build.gradle
@@ -17,19 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        mavenCentral()
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = rootProject.version
 group = 'pubsub.demo'
 

--- a/grails-test-examples/cache/build.gradle
+++ b/grails-test-examples/cache/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
-
 plugins {
     id 'groovy'
     id 'idea'

--- a/grails-test-examples/datasources/build.gradle
+++ b/grails-test-examples/datasources/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1'
 group = 'datasources'
 

--- a/grails-test-examples/demo33/build.gradle
+++ b/grails-test-examples/demo33/build.gradle
@@ -17,19 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 group = 'org.example.grails'
 version = '0.0.1'
 

--- a/grails-test-examples/external-configuration/build.gradle
+++ b/grails-test-examples/external-configuration/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:$projectVersion")
-        classpath "org.apache.grails:grails-gradle-plugins"
-        classpath "com.bertramlabs.plugins:asset-pipeline-gradle"
-    }
-}
-
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
 

--- a/grails-test-examples/geb/build.gradle
+++ b/grails-test-examples/geb/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:$projectVersion")
-        classpath "org.apache.grails:grails-gradle-plugins"
-        classpath "com.bertramlabs.plugins:asset-pipeline-gradle"
-    }
-}
-
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
 apply plugin: 'org.apache.grails.gradle.grails-gsp'

--- a/grails-test-examples/gorm/build.gradle
+++ b/grails-test-examples/gorm/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1'
 group = 'gorm'
 

--- a/grails-test-examples/gsp-sitemesh3/build.gradle
+++ b/grails-test-examples/gsp-sitemesh3/build.gradle
@@ -17,19 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'
-    }
-}
-
 version = '0.0.1'
 group = 'org.sitemesh.grails.plugins.sitemesh3'
 

--- a/grails-test-examples/gsp-spring-boot/app/build.gradle
+++ b/grails-test-examples/gsp-spring-boot/app/build.gradle
@@ -17,21 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url 'https://repo.grails.org/grails/restricted/' }
-        maven {
-            name = 'ASF Snapshot repo'
-            url = 'https://repository.apache.org/content/groups/snapshots'
-        }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:$projectVersion")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 plugins {
     id 'java'
     id 'war'

--- a/grails-test-examples/hyphenated/build.gradle
+++ b/grails-test-examples/hyphenated/build.gradle
@@ -17,19 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'
-    }
-}
-
 version = '0.1'
 group = 'hyphenated'
 

--- a/grails-test-examples/issue-11102/build.gradle
+++ b/grails-test-examples/issue-11102/build.gradle
@@ -17,19 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'
-    }
-}
-
 version = '0.1'
 group = 'issue11102'
 

--- a/grails-test-examples/issue-11767/build.gradle
+++ b/grails-test-examples/issue-11767/build.gradle
@@ -17,17 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 group = 'issue11767.app'
 
 apply plugin: 'org.apache.grails.gradle.grails-web'

--- a/grails-test-examples/issue-698-domain-save-npe/build.gradle
+++ b/grails-test-examples/issue-698-domain-save-npe/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1'
 group = 'grails301.domain.save.npe'
 

--- a/grails-test-examples/issue-views-182/build.gradle
+++ b/grails-test-examples/issue-views-182/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1'
 group = 'issueviews182'
 

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -17,19 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-        classpath "com.bertramlabs.plugins:asset-pipeline-gradle"
-    }
-}
-
 version = '0.1'
 group = 'micronaut'
 

--- a/grails-test-examples/namespaces/build.gradle
+++ b/grails-test-examples/namespaces/build.gradle
@@ -17,19 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle'
-    }
-}
-
 version = '0.1'
 group = 'namespaces'
 

--- a/grails-test-examples/plugins/issue-11767-plugin/build.gradle
+++ b/grails-test-examples/plugins/issue-11767-plugin/build.gradle
@@ -17,17 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1-SNAPSHOT'
 group 'issue11767.plugin'
 

--- a/grails-test-examples/plugins/issue11005/build.gradle
+++ b/grails-test-examples/plugins/issue11005/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 apply plugin: 'java-library'
 apply plugin: 'org.apache.grails.gradle.grails-plugin'
 apply plugin: 'org.apache.grails.gradle.grails-gsp'

--- a/grails-test-examples/plugins/loadafter/build.gradle
+++ b/grails-test-examples/plugins/loadafter/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1-SNAPSHOT'
 group = 'com.example.grails.plugins'
 

--- a/grails-test-examples/plugins/loadfirst/build.gradle
+++ b/grails-test-examples/plugins/loadfirst/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1-SNAPSHOT'
 group = 'com.example.grails.plugins'
 

--- a/grails-test-examples/plugins/loadsecond/build.gradle
+++ b/grails-test-examples/plugins/loadsecond/build.gradle
@@ -17,18 +17,6 @@
  *  under the License.
  */
 
-buildscript {
-    repositories {
-        // mavenLocal()
-        maven { url = 'https://repo.grails.org/grails/restricted' }
-        maven { url = 'https://repository.apache.org/content/groups/snapshots' }
-    }
-    dependencies {
-        classpath platform("org.apache.grails:grails-gradle-bom:${project.projectVersion}")
-        classpath 'org.apache.grails:grails-gradle-plugins'
-    }
-}
-
 version = '0.1-SNAPSHOT'
 group = 'com.example.grails.plugins'
 


### PR DESCRIPTION
given the root buildSrc provides these Gradle plugin dependencies for all projects

This PR's goal was the reduce the number of locations with a list of maven repositories.  