### PR TITLE
Switch back to 3.4.3 to fix nested jar file loading until 3.5.0 is out with the spring framework 6.2.7.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,20 +1,18 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 // see https://github.com/dependabot/dependabot-core/issues/1618
@@ -44,7 +42,8 @@ ext {
             'objenesis.version'                  : '3.4',
             'gradle-spock.version'               : '2.3-groovy-3.0',
             'gradle-nexus-publish-plugin.version': '2.0.0',
-            'spring-boot.version'                : '3.5.0-RC1',
+            // 3.4.4 to 3.5.0-RC1 has https://github.com/spring-projects/spring-framework/issues/34796 which prevents running apps via jar (nested jar failures)
+            'spring-boot.version': '3.4.3',
             'springloaded.version'               : '1.2.8.RELEASE',
     ]
 


### PR DESCRIPTION
Merging the dependency downgrade from https://github.com/apache/grails-core/pull/14745 to make sure the tests work as expected in that PR