### PR TITLE
Run Java CI workflow against MongoDB 7.0 and 8.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 21 ]
-        mongodb-version: [ '7.0', '8.0' ]
+        mongodb-version: [ '7.0', '8.0' ] # test with supported versions https://www.mongodb.com/legal/support-policy/lifecycles
     steps:
       - name: "📥 Checkout the repository"
         uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 21 ]
-        mongodb-version: [ '5.0', '6.0', '7.0', '8.0' ]
+        mongodb-version: [ '7.0', '8.0' ]
     steps:
       - name: "📥 Checkout the repository"
         uses: actions/checkout@v4


### PR DESCRIPTION
5.0 is no longer supported

6.0 ends on 31 Jul 2025

test with supported versions https://www.mongodb.com/legal/support-policy/lifecycles