### PR TITLE
Bug fix - AutoTimestamp annotation support for non persistent super classes

### DIFF
--- a/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/CustomAutoTimestampSpec.groovy
+++ b/grails-datamapping-core-test/src/test/groovy/org/grails/datastore/gorm/CustomAutoTimestampSpec.groovy
@@ -28,7 +28,7 @@ import static grails.gorm.annotation.AutoTimestamp.EventType.CREATED
 
 class CustomAutoTimestampSpec extends GrailsDataTckSpec<GrailsDataCoreTckManager> {
     void setupSpec() {
-        manager.domainClasses.addAll([RecordCustom])
+        manager.domainClasses.addAll([AutoTimestampedChildEntity, AutoTimestampedParentEntity, Image, RecordCustom])
     }
 
     void "Test when the auto timestamp properties are customized, they are correctly set"() {
@@ -123,6 +123,30 @@ class CustomAutoTimestampSpec extends GrailsDataTckSpec<GrailsDataCoreTckManager
         previousModified.time < r.modified.time
         previousCreated.time == r.created.time
     }
+
+    void 'AutoTimestamp annotation works when used in non-entity parent classes'() {
+        when: 'An entity extending a non-entity class using AutoTimestamp is persisted'
+        def i = new Image(format: 'jpg')
+        i.save(flush: true, failOnError: true)
+        manager.session.clear()
+        i = Image.get(i.id)
+
+        then: 'the auto timestamp properties are set'
+        i.modified != null
+        i.created != null
+    }
+
+    void 'AutoTimestamp annotation works when used in entity parent classes'() {
+        when: 'An entity extending an entity class using AutoTimestamp is persisted'
+        def e = new AutoTimestampedChildEntity(name: 'John')
+        e.save(flush: true, failOnError: true)
+        manager.session.clear()
+        e = AutoTimestampedChildEntity.get(e.id)
+
+        then: 'the auto timestamp properties are set'
+        e.modified != null
+        e.created != null
+    }
 }
 
 @Entity
@@ -133,4 +157,31 @@ class RecordCustom {
     Date created
     @AutoTimestamp
     Date modified
+}
+
+class Media {
+    @AutoTimestamp(CREATED)
+    Date created
+    @AutoTimestamp
+    Date modified
+}
+
+@Entity
+class Image extends Media {
+    Long id
+    String format
+}
+
+@Entity
+class AutoTimestampedParentEntity {
+    Long id
+    @AutoTimestamp(CREATED)
+    Date created
+    @AutoTimestamp
+    Date modified
+}
+
+@Entity
+class AutoTimestampedChildEntity extends AutoTimestampedParentEntity {
+    String name
 }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
@@ -155,14 +155,13 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
         return properties == null ? null : properties.orElse(null);
     }
 
-    private static Field getFieldFromHierarchy(PersistentEntity persistentEntity, String fieldName) {
-        Class<?> clazz = persistentEntity.getJavaClass();
+    private static Field getFieldFromHierarchy(Class<?> entity, String fieldName) {
+        Class<?> clazz = entity;
         while (clazz != null) {
             try {
                 return clazz.getDeclaredField(fieldName);
             } catch (NoSuchFieldException e) {
-                persistentEntity = persistentEntity.getParentEntity();
-                clazz = persistentEntity == null? null : persistentEntity.getJavaClass();
+                clazz = clazz.getSuperclass();
             }
         }
         return null;
@@ -179,7 +178,7 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
                     } else if (property.getName().equals(DATE_CREATED_PROPERTY)) {
                         storeTimestampAvailability(entitiesWithDateCreated, persistentEntity, property);
                     } else {
-                        Field field = getFieldFromHierarchy(persistentEntity, property.getName());
+                        Field field = getFieldFromHierarchy(persistentEntity.getJavaClass(), property.getName());
                         if (field != null && field.isAnnotationPresent(AutoTimestamp.class)) {
                             AutoTimestamp autoTimestamp = field.getAnnotation(AutoTimestamp.class);
                             if (autoTimestamp.value() == AutoTimestamp.EventType.UPDATED) {


### PR DESCRIPTION
Previously annotations would only be detected if the super class was another domain class. 

This allows a domain class to have parent class that is not a domain class and still utilized the `@AutoTimestamp` annotation

e.g. this now works and does not work without this fix
`src/main/groovy/example/Media.groovy`
```groovy
class Media {
     @AutoTimestamp Date modified
}
```

`grails-app/domain/example/Image.groovy`
```groovy
class Image extends Media {
     String format
}
```

`grails-app/domain/example/Video.groovy`
```groovy
class Media extends Media {
      int frames
}
```