### PR TITLE
test: fix flakiness in `ReservedWordOverrideTests`

### DIFF
--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/pages/ReservedWordOverrideTests.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/pages/ReservedWordOverrideTests.groovy
@@ -25,10 +25,11 @@ import org.junit.jupiter.api.Test
  * @author Graeme Rocher
  * @since 1.0
  */
-class ReservedWordOverrideTests extends AbstractGrailsTagTests{
+class ReservedWordOverrideTests extends AbstractGrailsTagTests {
 
     @Test
     void testCannotOverrideReservedWords() {
-        assertOutputNotContains "bad", '${pageScope}', [pageScope:"bad"]
+        def expected = 'terrible'
+        assertOutputNotContains(expected, '${pageScope}', [pageScope: expected])
     }
 }


### PR DESCRIPTION
The test failed intermittently when the `toString()` of `pageScope` produced a string containing the word 'bad'. This is a valid hexadecimal value that can appear in the default `toString()` representation (e.g., `ClassName@17224bad`), causing the test to fail unexpectedly. The test has been updated to avoid relying on fragile string patterns.