### PR TITLE
Use groovy 4 for grails-gradle-tasks

### DIFF
--- a/grails-gradle/plugins/build.gradle
+++ b/grails-gradle/plugins/build.gradle
@@ -34,12 +34,11 @@ dependencies {
     // see: https://docs.gradle.org/current/userguide/compatibility.html#groovy
     compileOnly "org.codehaus.groovy:groovy"
 
-    implementation project(':grails-gradle-tasks')
-
-    implementation project(':grails-gradle-model'), {
+    implementation project(':grails-gradle-tasks'), {
         exclude group: 'org.apache.groovy'
-        exclude group: 'org.spockframework'
     }
+
+    implementation project(':grails-gradle-model')
 
     implementation 'io.github.gradle-nexus:publish-plugin'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin'

--- a/grails-gradle/plugins/build.gradle
+++ b/grails-gradle/plugins/build.gradle
@@ -38,7 +38,10 @@ dependencies {
         exclude group: 'org.apache.groovy'
     }
 
-    implementation project(':grails-gradle-model')
+    // spock is leaking from the grails-gradle-bom through grails-gradle-model
+    implementation project(':grails-gradle-model'), {
+        exclude group: 'org.spockframework'
+    }
 
     implementation 'io.github.gradle-nexus:publish-plugin'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin'

--- a/grails-gradle/plugins/build.gradle
+++ b/grails-gradle/plugins/build.gradle
@@ -34,9 +34,7 @@ dependencies {
     // see: https://docs.gradle.org/current/userguide/compatibility.html#groovy
     compileOnly "org.codehaus.groovy:groovy"
 
-    implementation project(':grails-gradle-tasks'), {
-        exclude group: 'org.apache.groovy'
-    }
+    implementation project(':grails-gradle-tasks')
 
     // spock is leaking from the grails-gradle-bom through grails-gradle-model
     implementation project(':grails-gradle-model'), {

--- a/grails-gradle/tasks/build.gradle
+++ b/grails-gradle/tasks/build.gradle
@@ -29,10 +29,9 @@ group = 'org.apache.grails'
 dependencies {
     implementation platform(project(':grails-gradle-bom'))
 
-    implementation "org.codehaus.groovy:groovy"
+    implementation "org.apache.groovy:groovy:${bomDependencyVersions['groovy.version']}"
 
     implementation project(':grails-gradle-model'), {
-        exclude group: 'org.apache.groovy'
         exclude group: 'org.spockframework'
     }
 

--- a/grails-gradle/tasks/build.gradle
+++ b/grails-gradle/tasks/build.gradle
@@ -31,9 +31,7 @@ dependencies {
 
     implementation "org.apache.groovy:groovy:${bomDependencyVersions['groovy.version']}"
 
-    implementation project(':grails-gradle-model'), {
-        exclude group: 'org.spockframework'
-    }
+    implementation project(':grails-gradle-model')
 
     implementation 'io.github.gradle-nexus:publish-plugin'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin'

--- a/grails-gradle/tasks/build.gradle
+++ b/grails-gradle/tasks/build.gradle
@@ -31,7 +31,10 @@ dependencies {
 
     implementation "org.apache.groovy:groovy:${bomDependencyVersions['groovy.version']}"
 
-    implementation project(':grails-gradle-model')
+    // spock is leaking from the grails-gradle-bom through grails-gradle-model
+    implementation project(':grails-gradle-model'), {
+        exclude group: 'org.spockframework'
+    }
 
     implementation 'io.github.gradle-nexus:publish-plugin'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin'


### PR DESCRIPTION
Groovy 3 was conflicting with Groovy 4 version used by some other Grails dependencies in the build, such as `org.apache.grails:grails-data-hibernate5`

Resolves:

```
A problem occurred configuring root project 'Test8'.
> Could not resolve all artifacts for configuration 'classpath'.
   > Could not resolve org.apache.groovy:groovy:4.0.26.
     Required by:
         root project : > org.apache.grails:grails-bom:7.0.0-SNAPSHOT:20250520.032711-84 > org.apache.groovy:groovy-bom:4.0.26
         root project : > org.apache.grails:grails-bom:7.0.0-SNAPSHOT:20250520.032711-84 > org.apache.grails:grails-spring:7.0.0-SNAPSHOT:20250520.032711-84 > org.apache.groovy:groovy-xml:4.0.26
      > Module 'org.apache.groovy:groovy' has been rejected:
           Cannot select module with conflict on capability 'org.codehaus.groovy:groovy:4.0.26' also provided by [org.codehaus.groovy:groovy:3.0.24(runtime)]
   > Could not resolve org.codehaus.groovy:groovy.
     Required by:
         root project : > org.apache.grails:grails-gradle-plugins:7.0.0-SNAPSHOT:20250520.001817-109 > org.apache.grails:grails-gradle-tasks:7.0.0-SNAPSHOT:20250520.001817-1
      > Module 'org.codehaus.groovy:groovy' has been rejected:
           Cannot select module with conflict on capability 'org.codehaus.groovy:groovy:3.0.24' also provided by [org.apache.groovy:groovy:4.0.26(groovyRuntimeElements)]
> There are 2 more failures with identical causes.
```
