### PR TITLE
Java 20 date time formatting

### DIFF
--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -261,3 +261,7 @@ These are now removed in Grails 7. If you still need them, you can add them to y
 
 Jar artifacts produced by Grails Plugins will no longer have the suffix `-plain`.
 Please see ticket https://github.com/apache/grails-gradle-plugin/pull/347[#347] for details.
+
+===== 12.8 Java 20+ Date Formatting Changes
+
+In Java 20+, https://cldr.unicode.org/downloads/cldr-42[Unicode CLDR42] was implemented which changed the space character preceding the period (AM or PM) in formatted date/time text from a standard space (" ") to a narrow non-breaking space (NNBSP: "\u202F"). Additionally, when using the LONG or FULL timeStyle with dateStyle, the date and time separator has changed from ' at ' to ', '. IE. January 5, 1941, 8:00:00 AM UTC vs. January 5, 1941 at 8:00:00 AM UTC

--- a/grails-doc/src/en/ref/Tags - GSP/formatDate.adoc
+++ b/grails-doc/src/en/ref/Tags - GSP/formatDate.adoc
@@ -57,6 +57,8 @@ Formats `java.util.Date`, `java.time.LocalDate`, and `java.time.LocalDateTime` i
 
 Attributes
 
+WARNING: In Java 20+, https://cldr.unicode.org/downloads/cldr-42[Unicode CLDR42] was implemented which changed the space character preceding the period (AM or PM) in formatted date/time text from a standard space (" ") to a narrow non-breaking space (NNBSP: "\u202F").  Additionally, when using the LONG or FULL timeStyle with dateStyle, the date and time separator has changed from ' at ' to ', '.  IE. January 5, 1941, 8:00:00 AM UTC vs. January 5, 1941 at 8:00:00 AM UTC
+
 * `date` (required) - The date object to format. It could be the instance of `java.util.Date`, `java.time.LocalDate`, `java.time.LocalDateTime`.
 * `format` (optional) - The formatting pattern to use for the date, see {javase}java.base/java/text/SimpleDateFormat.html[SimpleDateFormat]
 * `formatName` (optional) - Look up `format` from the default MessageSource / ResourceBundle (i18n/*.properties file) with this key. If `format` and `formatName` are empty, `format` is looked up with '`default.date.format`' key. Defaults to 'yyyy-MM-dd HH:mm:ss z' if the key not specified

--- a/grails-gsp/plugin/src/test/groovy/org/grails/plugins/web/DefaultDateHelperSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/plugins/web/DefaultDateHelperSpec.groovy
@@ -111,9 +111,9 @@ class DefaultDateHelperSpec extends Specification {
 
         where:
         style    | expected
-        'LONG'   | '8:00:00 AM UTC'
-        'MEDIUM' | '8:00:00 AM'
-        null     | '8:00 AM'
+        'LONG'   | '8:00:00\u202FAM UTC'
+        'MEDIUM' | '8:00:00\u202FAM'
+        null     | '8:00\u202FAM'
     }
 
     @Requires({ Jvm.current.isJava17() })
@@ -149,7 +149,7 @@ class DefaultDateHelperSpec extends Specification {
 
         where:
         style  | expected
-        'FULL' | '8:00:00 AM Coordinated Universal Time'
+        'FULL' | '8:00:00\u202FAM Coordinated Universal Time'
     }
 
     @Requires({ jvm.isJava8() })
@@ -209,10 +209,10 @@ class DefaultDateHelperSpec extends Specification {
 
         where:
         dateStyle | timeStyle | expected
-        'FULL'    | 'FULL'    | 'Sunday, January 5, 1941, 8:00:00 AM Coordinated Universal Time'
-        'LONG'    | 'LONG'    | 'January 5, 1941, 8:00:00 AM UTC'
-        'MEDIUM'  | 'MEDIUM'  | 'Jan 5, 1941, 8:00:00 AM'
-        null      | null      | '1/5/41, 8:00 AM'
+        'FULL'    | 'FULL'    | 'Sunday, January 5, 1941, 8:00:00\u202FAM Coordinated Universal Time'
+        'LONG'    | 'LONG'    | 'January 5, 1941, 8:00:00\u202FAM UTC'
+        'MEDIUM'  | 'MEDIUM'  | 'Jan 5, 1941, 8:00:00\u202FAM'
+        null      | null      | '1/5/41, 8:00\u202FAM'
     }
 
     void "test supportsDatePickers"() {

--- a/grails-gsp/plugin/src/test/groovy/org/grails/plugins/web/DefaultDateHelperSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/plugins/web/DefaultDateHelperSpec.groovy
@@ -96,10 +96,9 @@ class DefaultDateHelperSpec extends Specification {
         null     | '8:00 AM'
     }
 
-    @PendingFeature
-    @Requires({ !Jvm.current.isJava17() })
+    @Requires({ Jvm.current.isJava20Compatible() })
     @Unroll
-    void "Java 21+ - Full getTimeFormat for style #style returns #expected"(String style, String expected) {
+    void "Java 20+ - getTimeFormat for style #style returns #expected"(String style, String expected) {
         given:
         DateTimeFormatter format
 
@@ -111,8 +110,10 @@ class DefaultDateHelperSpec extends Specification {
         format.format(localTime) == expected
 
         where:
-        style  | expected
-        'FULL' | '8:00:00 AM UTC'
+        style    | expected
+        'LONG'   | '8:00:00 AM UTC'
+        'MEDIUM' | '8:00:00 AM'
+        null     | '8:00 AM'
     }
 
     @Requires({ Jvm.current.isJava17() })
@@ -131,6 +132,24 @@ class DefaultDateHelperSpec extends Specification {
         where:
         style  | expected
         'FULL' | '8:00:00 AM Coordinated Universal Time'
+    }
+
+    @Requires({ Jvm.current.isJava20Compatible() })
+    @Unroll
+    void "Java 20+ - Full getTimeFormat for style #style returns #expected"(String style, String expected) {
+        given:
+        DateTimeFormatter format
+
+        when:
+        format = helper.getTimeFormat(style, ZoneId.of('UTC'), Locale.ENGLISH)
+
+        then:
+        format.zone == ZoneId.of('UTC')
+        format.format(localTime) == expected
+
+        where:
+        style  | expected
+        'FULL' | '8:00:00 AM Coordinated Universal Time'
     }
 
     @Requires({ jvm.isJava8() })
@@ -173,6 +192,27 @@ class DefaultDateHelperSpec extends Specification {
         'LONG'    | 'LONG'    | 'January 5, 1941 at 8:00:00 AM UTC'
         'MEDIUM'  | 'MEDIUM'  | 'Jan 5, 1941, 8:00:00 AM'
         null      | null      | '1/5/41, 8:00 AM'
+    }
+
+    @Requires({ Jvm.current.isJava20Compatible() })
+    @Unroll("for getDateTimeFormat(#dateStyle, #timeStyle) => #expected")
+    void "Java 20+ - test getDateTimeFormat"(String dateStyle, String timeStyle, String expected) {
+        given:
+        DateTimeFormatter format
+
+        when:
+        format = helper.getDateTimeFormat(dateStyle, timeStyle, ZoneId.of('UTC'), Locale.ENGLISH)
+
+        then:
+        format.zone == ZoneId.of('UTC')
+        format.format(LocalDateTime.of(localDate, localTime)) == expected
+
+        where:
+        dateStyle | timeStyle | expected
+        'FULL'    | 'FULL'    | 'Sunday, January 5, 1941, 8:00:00 AM Coordinated Universal Time'
+        'LONG'    | 'LONG'    | 'January 5, 1941, 8:00:00 AM UTC'
+        'MEDIUM'  | 'MEDIUM'  | 'Jan 5, 1941, 8:00:00 AM'
+        null      | null      | '1/5/41, 8:00 AM'
     }
 
     void "test supportsDatePickers"() {


### PR DESCRIPTION
In Java 20+, [Unicode CLDR42](https://cldr.unicode.org/downloads/cldr-42 ) was implemented which changed the space character preceding the period (AM or PM) in formatted date/time text from a standard space (" ") to a narrow non-breaking space (NNBSP: "\u202F"). Additionally, when using the LONG or FULL timeStyle with dateStyle, the date and time separator has changed from ' at ' to ', '. IE. January 5, 1941, 8:00:00 AM UTC vs. January 5, 1941 at 8:00:00 AM UTC

We already had Java 8 and 17 specific tests.  For each of the Java version specific scenarios covered by prior tests, a Java 20+ test was added. 