### PR TITLE
Support disabling spring dependency management plugin & disable in core

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -91,7 +91,7 @@ jobs:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🔨 Build project"
         run: >
-          ./gradlew :grails-bom:publishMavenPublicationToLocalBomRepository build :grails-shell-cli:installDist groovydoc
+          ./gradlew build :grails-shell-cli:installDist groovydoc
           --continue --stacktrace -PonlyCoreTests
   functional:
     name: "Functional Tests"
@@ -117,7 +117,7 @@ jobs:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🏃 Run Functional Tests"
         run: >
-          ./gradlew :grails-bom:publishMavenPublicationToLocalBomRepository bootJar check
+          ./gradlew bootJar check
           --continue --stacktrace
           -PonlyFunctionalTests
           -PskipHibernate5Tests
@@ -149,7 +149,7 @@ jobs:
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          ./gradlew :grails-bom:publishMavenPublicationToLocalBomRepository bootJar cleanTest check
+          ./gradlew bootJar cleanTest check
           --continue --stacktrace
           -PonlyMongodbTests
           -PmongodbContainerVersion=${{ matrix.mongodb-version }}
@@ -179,7 +179,7 @@ jobs:
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          ./gradlew :grails-bom:publishMavenPublicationToLocalBomRepository bootJar cleanTest check
+          ./gradlew bootJar cleanTest check
           --continue --stacktrace
           -PonlyHibernate5Tests
   publishGradle:

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ import java.time.format.DateTimeFormatter
 
 
 ext {
+    isReproducibleBuild = System.getenv("SOURCE_DATE_EPOCH") != null
     buildInstant = java.util.Optional.ofNullable(System.getenv("SOURCE_DATE_EPOCH"))
             .map(Long::parseLong)
             .map(Instant::ofEpochSecond)
@@ -80,7 +81,7 @@ subprojects {
 
     configurations.configureEach {
         resolutionStrategy {
-            def cacheHours = isCiBuild ? 0 : 24
+            def cacheHours = isCiBuild || isReproducibleBuild ? 0 : 24
             cacheDynamicVersionsFor(cacheHours, 'hours')
             cacheChangingModulesFor(cacheHours, 'hours')
         }

--- a/gradle/grails-extension-gradle-config.gradle
+++ b/gradle/grails-extension-gradle-config.gradle
@@ -1,0 +1,15 @@
+// do not cache SNAPSHOT dependencies
+//dependencyManagement {
+//    resolutionStrategy {
+//        cacheChangingModulesFor 0, 'seconds'
+//        cacheDynamicVersionsFor 0, 'seconds'
+//    }
+//}
+
+grails {
+    // WARNING: enabling spring dependency management in core can have unintended side effects.
+    // since it loads the bom via a pom file, it can't use a gradle project() reference
+    // this means you MUST publish locally via ./gradlew :grails-bom:publishMavenPublicationToLocalBomRepository
+    // this causes unexpected version mismatches in the various plugin projects
+    springDependencyManagement = false
+}

--- a/gradle/grails-extension-gradle-config.gradle
+++ b/gradle/grails-extension-gradle-config.gradle
@@ -1,3 +1,22 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 // do not cache SNAPSHOT dependencies
 //dependencyManagement {
 //    resolutionStrategy {

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -74,6 +74,18 @@ dependencies {
         api "org.apache.grails:grails-gradle-plugins:${projectVersion}"
         api "org.apache.grails.gradle:grails-gradle-model:${projectVersion}"
         api "org.apache.grails:grails-docs-core:${projectVersion}"
+
+        // because we are not yet publishing hibernate6, just force the hibernate5 version for now
+        api("org.liquibase:liquibase-core") {
+            version {
+                strictly "$liquibaseHibernate5Version"
+            }
+        }
+        api("org.liquibase.ext:liquibase-hibernate5") {
+            version {
+                strictly "$liquibaseHibernate5Version"
+            }
+        }
     }
 }
 

--- a/grails-cache/build.gradle
+++ b/grails-cache/build.gradle
@@ -63,4 +63,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-data-hibernate5/dbmigration/build.gradle
+++ b/grails-data-hibernate5/dbmigration/build.gradle
@@ -95,4 +95,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/hibernate5-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-data-hibernate5/dbmigration/build.gradle
+++ b/grails-data-hibernate5/dbmigration/build.gradle
@@ -37,10 +37,12 @@ ext {
 
 dependencies {
     // TODO: Clarify and clean up dependencies
-    implementation platform(project(':grails-bom'))
+    implementation platform(project(':grails-bom')) {
+        exclude group: 'org.liquibase', module: 'liquibase-core'
+    }
 
-    api("org.liquibase:liquibase-core:$liquibaseHibernate5Version")
-    api("org.liquibase.ext:liquibase-hibernate5:$liquibaseHibernate5Version") {
+    implementation("org.liquibase:liquibase-core:$liquibaseHibernate5Version")
+    implementation("org.liquibase.ext:liquibase-hibernate5:$liquibaseHibernate5Version") {
         exclude group: 'org.hibernate', module: 'hibernate-core'
         exclude group: 'org.hibernate', module: 'hibernate-entitymanager'
         exclude group: 'org.hibernate', module: 'hibernate-envers'
@@ -48,14 +50,13 @@ dependencies {
         exclude group: 'org.liquibase', module: 'liquibase-commercial'
     }
 
-    api(project(':grails-shell-cli')) {
+    implementation(project(':grails-shell-cli')) {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
 
         // TODO: the shell cli is exporting groovy 3, while this project is expected to use groovy 4
         //       this plugin needs split into commands & the plugin itself so that different versions
         //       of groovy can be used
-        exclude group: 'org.codehaus.groovy', module: 'groovy'
-        exclude group: 'org.codehaus.groovy', module: 'groovy-bom'
+        exclude group: 'org.codehaus.groovy'
     }
 
     compileOnly 'org.springframework.boot:spring-boot-starter-logging'
@@ -71,6 +72,19 @@ dependencies {
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation project(':grails-testing-support-web')
     testImplementation 'com.h2database:h2'
+
+    constraints {
+        implementation("org.liquibase:liquibase-core") {
+            version {
+                strictly "$liquibaseHibernate5Version"
+            }
+        }
+        implementation("org.liquibase.ext:liquibase-hibernate5") {
+            version {
+                strictly "$liquibaseHibernate5Version"
+            }
+        }
+    }
 }
 
 tasks.named('jar', Jar) {

--- a/grails-data-hibernate5/grails-plugin/build.gradle
+++ b/grails-data-hibernate5/grails-plugin/build.gradle
@@ -88,4 +88,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/hibernate5-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-data-mongodb/grails-plugin/build.gradle
+++ b/grails-data-mongodb/grails-plugin/build.gradle
@@ -42,6 +42,7 @@ ext {
 dependencies {
 
     implementation platform(project(':grails-bom'))
+    testFixturesImplementation platform(project(':grails-bom'))
 
     api project(':grails-data-mongodb-core'), {
         // api: needed as classes should also be available when compiling apps. eg. MongoEntity
@@ -131,4 +132,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/mongodb-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-fields/build.gradle
+++ b/grails-fields/build.gradle
@@ -63,4 +63,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-geb/build.gradle
+++ b/grails-geb/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     // For most core projects, we don't apply the plugin and only add what we need so we need the platform
     // for consistency, add the platform here and later move away from the grails-plugin gradle plugin apply
     implementation platform(project(':grails-bom'))
-    testFixturesApi(platform(project(':grails-bom')))
     testFixturesImplementation platform(project(':grails-bom'))
 
     compileOnly project(':grails-core') // Provided, as this is a Grails plugin
@@ -69,4 +68,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -61,6 +61,11 @@ class GrailsExtension {
     boolean importJavaTime = false
 
     /**
+     * Whether the spring dependency management plugin should be applied by default
+     */
+    boolean springDependencyManagement = true
+
+    /**
      * Configure the reloading agent
      */
     Agent agent = new Agent()

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -317,12 +317,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
         'web'
     }
 
-    protected String getDefaultMicronautVersion() {
-        '4.6.5'
-    }
-
     void addDefaultProfile(Project project, Configuration profileConfig) {
-        project.dependencies.add('profile', "org.apache.grails.profiles:${System.getProperty("grails.profile") ?: defaultProfile}:")
+        def bomProject = project.rootProject.subprojects.find { it.name == 'grails-bom' }
+        project.dependencies.add(PROFILE_CONFIGURATION, project.dependencies.platform(bomProject ?: "org.apache.grails:grails-bom:${project.properties.get('grailsVersion')}"))
+        project.dependencies.add(PROFILE_CONFIGURATION, "org.apache.grails.profiles:${System.getProperty("grails.profile") ?: defaultProfile}:")
     }
 
     @CompileDynamic

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -107,9 +107,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
         configureProfile(project)
 
-        applyDefaultPlugins(project)
-
         registerGrailsExtension(project)
+
+        applyDefaultPlugins(project)
 
         configureGroovy(project)
 
@@ -283,14 +283,19 @@ class GrailsGradlePlugin extends GroovyPlugin {
     protected void applyDefaultPlugins(Project project) {
         applySpringBootPlugin(project)
 
-        Plugin dependencyManagementPlugin = project.plugins.findPlugin(DependencyManagementPlugin)
-        if (dependencyManagementPlugin == null) {
-            project.plugins.apply(DependencyManagementPlugin)
+        project.afterEvaluate {
+            GrailsExtension ge = project.extensions.getByType(GrailsExtension)
+            if(ge.springDependencyManagement) {
+                Plugin dependencyManagementPlugin = project.plugins.findPlugin(DependencyManagementPlugin)
+                if (dependencyManagementPlugin == null) {
+                    project.plugins.apply(DependencyManagementPlugin)
+                }
+
+                DependencyManagementExtension dme = project.extensions.findByType(DependencyManagementExtension)
+
+                applyBomImport(dme, project)
+            }
         }
-
-        DependencyManagementExtension dme = project.extensions.findByType(DependencyManagementExtension)
-
-        applyBomImport(dme, project)
     }
 
     protected void applySpringBootPlugin(Project project) {

--- a/grails-gsp/grails-sitemesh3/build.gradle
+++ b/grails-gsp/grails-sitemesh3/build.gradle
@@ -85,4 +85,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-gsp/plugin/build.gradle
+++ b/grails-gsp/plugin/build.gradle
@@ -185,4 +185,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-gsp/spring-boot/build.gradle
+++ b/grails-gsp/spring-boot/build.gradle
@@ -40,7 +40,8 @@ dependencies {
 apply {
     // java-configuration must be applied first since tasks are now lazy registered
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
-    from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
+    //TODO: no docs until this is a publish project (its docs likely will need to be handled differently)
+    // from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-gsp/spring-boot/build.gradle
+++ b/grails-gsp/spring-boot/build.gradle
@@ -35,3 +35,11 @@ ext {
 dependencies {
     api project(':grails-sitemesh3')
 }
+
+apply {
+    // java-configuration must be applied first since tasks are now lazy registered
+    from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
+}

--- a/grails-gsp/spring-boot/build.gradle
+++ b/grails-gsp/spring-boot/build.gradle
@@ -33,6 +33,7 @@ ext {
 }
 
 dependencies {
+    implementation platform(project(':grails-bom'))
     api project(':grails-sitemesh3')
 }
 

--- a/grails-scaffolding/build.gradle
+++ b/grails-scaffolding/build.gradle
@@ -47,4 +47,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/app1/build.gradle
+++ b/grails-test-examples/app1/build.gradle
@@ -80,4 +80,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/app2/build.gradle
+++ b/grails-test-examples/app2/build.gradle
@@ -59,6 +59,7 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }
 
 //bootRun {

--- a/grails-test-examples/app3/build.gradle
+++ b/grails-test-examples/app3/build.gradle
@@ -60,4 +60,5 @@ grails {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/async-events-pubsub-demo/build.gradle
+++ b/grails-test-examples/async-events-pubsub-demo/build.gradle
@@ -66,4 +66,5 @@ bootRun {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/cache/build.gradle
+++ b/grails-test-examples/cache/build.gradle
@@ -68,4 +68,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/datasources/build.gradle
+++ b/grails-test-examples/datasources/build.gradle
@@ -50,4 +50,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/demo33/build.gradle
+++ b/grails-test-examples/demo33/build.gradle
@@ -66,4 +66,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/external-configuration/build.gradle
+++ b/grails-test-examples/external-configuration/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }
 
 tasks.withType(Test).configureEach {

--- a/grails-test-examples/geb/build.gradle
+++ b/grails-test-examples/geb/build.gradle
@@ -71,4 +71,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/gorm/build.gradle
+++ b/grails-test-examples/gorm/build.gradle
@@ -57,4 +57,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/gsp-sitemesh3/build.gradle
+++ b/grails-test-examples/gsp-sitemesh3/build.gradle
@@ -62,4 +62,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/gsp-spring-boot/app/build.gradle
+++ b/grails-test-examples/gsp-spring-boot/app/build.gradle
@@ -27,15 +27,6 @@ plugins {
 
 apply plugin: 'org.apache.grails.gradle.grails-gsp'
 
-repositories {
-    mavenCentral()
-    maven {
-        name = 'ASF Snapshot repo'
-        url = 'https://repository.apache.org/content/groups/snapshots'
-    }
-    maven { url 'https://repo.grails.org/grails/restricted/' }
-}
-
 jar {
     processResources.exclude('**/*.gsp')
 }

--- a/grails-test-examples/hibernate5/grails-data-service/build.gradle
+++ b/grails-test-examples/hibernate5/grails-data-service/build.gradle
@@ -50,4 +50,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/hibernate5/grails-database-per-tenant/build.gradle
+++ b/grails-test-examples/hibernate5/grails-database-per-tenant/build.gradle
@@ -56,4 +56,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/hibernate5/grails-hibernate-groovy-proxy/build.gradle
+++ b/grails-test-examples/hibernate5/grails-hibernate-groovy-proxy/build.gradle
@@ -44,4 +44,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/hibernate5/grails-hibernate/build.gradle
+++ b/grails-test-examples/hibernate5/grails-hibernate/build.gradle
@@ -67,4 +67,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/build.gradle
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/build.gradle
@@ -63,4 +63,5 @@ sourceSets {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/build.gradle
+++ b/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/build.gradle
@@ -55,4 +55,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/hibernate5/grails-schema-per-tenant/build.gradle
+++ b/grails-test-examples/hibernate5/grails-schema-per-tenant/build.gradle
@@ -55,4 +55,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/hibernate5/issue450/build.gradle
+++ b/grails-test-examples/hibernate5/issue450/build.gradle
@@ -60,4 +60,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/hyphenated/build.gradle
+++ b/grails-test-examples/hyphenated/build.gradle
@@ -69,4 +69,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/issue-11102/build.gradle
+++ b/grails-test-examples/issue-11102/build.gradle
@@ -83,4 +83,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/issue-11767/build.gradle
+++ b/grails-test-examples/issue-11767/build.gradle
@@ -48,4 +48,5 @@ application {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/issue-698-domain-save-npe/build.gradle
+++ b/grails-test-examples/issue-698-domain-save-npe/build.gradle
@@ -50,4 +50,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/issue-views-182/build.gradle
+++ b/grails-test-examples/issue-views-182/build.gradle
@@ -70,4 +70,5 @@ bootRun {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -96,4 +96,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/mongodb/base/build.gradle
+++ b/grails-test-examples/mongodb/base/build.gradle
@@ -60,4 +60,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/mongodb/database-per-tenant/build.gradle
+++ b/grails-test-examples/mongodb/database-per-tenant/build.gradle
@@ -53,4 +53,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/mongodb/gson-templates/build.gradle
+++ b/grails-test-examples/mongodb/gson-templates/build.gradle
@@ -53,4 +53,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/mongodb/hibernate5/build.gradle
+++ b/grails-test-examples/mongodb/hibernate5/build.gradle
@@ -67,4 +67,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/mongodb/test-data-service/build.gradle
+++ b/grails-test-examples/mongodb/test-data-service/build.gradle
@@ -52,4 +52,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/namespaces/build.gradle
+++ b/grails-test-examples/namespaces/build.gradle
@@ -60,4 +60,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/plugins/issue-11767-plugin/build.gradle
+++ b/grails-test-examples/plugins/issue-11767-plugin/build.gradle
@@ -33,4 +33,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/plugins/issue11005/build.gradle
+++ b/grails-test-examples/plugins/issue11005/build.gradle
@@ -45,4 +45,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/plugins/loadafter/build.gradle
+++ b/grails-test-examples/plugins/loadafter/build.gradle
@@ -44,4 +44,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/plugins/loadfirst/build.gradle
+++ b/grails-test-examples/plugins/loadfirst/build.gradle
@@ -42,4 +42,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/plugins/loadsecond/build.gradle
+++ b/grails-test-examples/plugins/loadsecond/build.gradle
@@ -41,4 +41,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/views-functional-tests-plugin/build.gradle
+++ b/grails-test-examples/views-functional-tests-plugin/build.gradle
@@ -39,4 +39,5 @@ dependencies {
 apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-test-examples/views-functional-tests/build.gradle
+++ b/grails-test-examples/views-functional-tests/build.gradle
@@ -74,4 +74,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-webjar-asset-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-views-gson/build.gradle
+++ b/grails-views-gson/build.gradle
@@ -68,4 +68,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/grails-views-markup/build.gradle
+++ b/grails-views-markup/build.gradle
@@ -57,4 +57,5 @@ apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -134,6 +134,7 @@ include (
         'grails-web-gsp-taglib',
         'grails-web-jsp',
         'grails-web-taglib',
+        'grails-gsp-spring-boot',
 
         'grails-datastore-core',
         'grails-datastore-web',
@@ -188,6 +189,7 @@ project(':grails-web-gsp').projectDir = file('grails-gsp/grails-web-gsp')
 project(':grails-web-gsp-taglib').projectDir = file('grails-gsp/grails-web-gsp-taglib')
 project(':grails-web-jsp').projectDir = file('grails-gsp/grails-web-jsp')
 project(':grails-web-taglib').projectDir = file('grails-gsp/grails-web-taglib')
+project(':grails-gsp-spring-boot').projectDir = file('grails-gsp/spring-boot')
 
 // Data Mapping - Documentation
 include 'grails-data-docs-guide-developer'
@@ -359,7 +361,7 @@ project(':grails-test-examples-geb').projectDir = file('grails-test-examples/geb
 project(':grails-test-examples-namespaces').projectDir = file('grails-test-examples/namespaces')
 project(':grails-test-examples-gorm').projectDir = file('grails-test-examples/gorm')
 project(':grails-test-examples-gsp-sitemesh3').projectDir = file('grails-test-examples/gsp-sitemesh3')
-project(':grails-test-examples-gsp-spring-boot').projectDir = file('grails-test-examples/gsp-spring-boot')
+project(':grails-test-examples-gsp-spring-boot').projectDir = file('grails-test-examples/gsp-spring-boot/app')
 project(':grails-test-examples-issue-698-domain-save-npe').projectDir = file('grails-test-examples/issue-698-domain-save-npe')
 project(':grails-test-examples-hyphenated').projectDir = file('grails-test-examples/hyphenated')
 project(':grails-test-examples-issue-views-182').projectDir = file('grails-test-examples/issue-views-182')


### PR DESCRIPTION
Was troubleshooting the groovy reproducibility changes, and realized that spring dependency management was causing the version of groovy to cache unexpectedly.  Even after clearing / ignoring the cache.  

Given how much we've talked about adding this support, this PR adds an option to disable spring dependency management and uses it to turn it off in core.  

I intentionally am leaving this undocumented for us to run with it for awhile before advocating a larger adoption.  