### PR TITLE
Configures a task to verify that essential Grails project directories exist and creates them if missing

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -776,7 +776,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
         verifyGrailsProjectDirectoriesTask.configure { Task task ->
             task.group = 'other'
-
+            task.description = 'Ensures essential Grails project directories exist and creates them if missing.'
             task.doFirst {
                 ['grails-app/services', 'grails-app/domain',
                  'grails-app/taglib', 'grails-app/migrations'].each { String dir ->

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -162,6 +162,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 }
             """.stripIndent(16)
         }
+
+        verifyGrailsProjectDirectories(project)
     }
 
     private void configureGroovyCompiler(Project project) {
@@ -767,5 +769,33 @@ class GrailsGradlePlugin extends GroovyPlugin {
             fileCollection = fileCollection + it.filter({ File file -> !file.name.startsWith('spring-boot-devtools') })
         }
         fileCollection
+    }
+
+    private void verifyGrailsProjectDirectories(Project project) {
+        TaskProvider<Task> verifyGrailsProjectDirectoriesTask = project.tasks.register('verifyGrailsProjectDirectories')
+
+        verifyGrailsProjectDirectoriesTask.configure { Task task ->
+            task.group = 'other'
+
+            task.doFirst {
+                ['grails-app/services', 'grails-app/domain',
+                 'grails-app/taglib', 'grails-app/migrations'].each { String dir ->
+                    Directory directory = project.layout.projectDirectory.dir(dir)
+                    if (!directory.asFile.exists()) {
+                        directory.asFile.mkdirs()
+                    }
+                }
+            }
+        }
+
+        project.afterEvaluate {
+            // prepareKotlinBuildScriptModel runs when a project is created or synced in IntelliJ
+            // cleanGroovyCompilerConfig is run by most other tasks
+            ['prepareKotlinBuildScriptModel', 'cleanGroovyCompilerConfig'].each { String taskName ->
+                it.tasks.findByName(taskName)?.configure { Task dependent ->
+                    dependent?.dependsOn verifyGrailsProjectDirectoriesTask
+                }
+            }
+        }
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -806,10 +806,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
         project.afterEvaluate {
             // prepareKotlinBuildScriptModel runs when a project is created or synced in IntelliJ
             // cleanGroovyCompilerConfig is run by most other tasks
-            ['prepareKotlinBuildScriptModel', 'cleanGroovyCompilerConfig'].each { String taskName ->
-                it.tasks.findByName(taskName)?.configure { Task dependent ->
-                    dependent?.dependsOn verifyGrailsProjectDirectoriesTask
-                }
+            it.tasks.matching { it.name in ['prepareKotlinBuildScriptModel', 'cleanGroovyCompilerConfig'] }.configureEach { Task dependent ->
+                dependent.dependsOn verifyGrailsProjectDirectoriesTask
             }
         }
     }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -781,7 +781,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
      * - grails-app/taglib
      * - grails-app/migrations
      *
-     * Additionally, it sets up dependencies for tasks like 'prepareKotlinBuildScriptModel' and
+     * Additionally, it sets up dependencies for tasks 'prepareKotlinBuildScriptModel' and
      * 'cleanGroovyCompilerConfig' to ensure that the directories are verified before these tasks run.
      *
      * @param project The Gradle project for which the directories are verified and tasks are configured.

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -772,7 +772,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     /**
-     * Ensures that essential Grails project directories exist and configures a task to verify them.
+     * Configures a task to verify that essential Grails project directories exist and creates them if missing.
      *
      * This method registers a task named 'verifyGrailsProjectDirectories' that creates the following
      * directories if they do not already exist:

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -789,12 +789,14 @@ class GrailsGradlePlugin extends GroovyPlugin {
     private void verifyGrailsProjectDirectories(Project project) {
         TaskProvider<Task> verifyGrailsProjectDirectoriesTask = project.tasks.register('verifyGrailsProjectDirectories')
 
+        def grailsProjectDirectories = ['grails-app/services', 'grails-app/domain',
+                                 'grails-app/taglib', 'grails-app/migrations']
+
         verifyGrailsProjectDirectoriesTask.configure { Task task ->
             task.group = 'other'
             task.description = 'Ensures essential Grails project directories exist and creates them if missing.'
             task.doFirst {
-                ['grails-app/services', 'grails-app/domain',
-                 'grails-app/taglib', 'grails-app/migrations'].each { String dir ->
+                grailsProjectDirectories.each { String dir ->
                     Directory directory = project.layout.projectDirectory.dir(dir)
                     if (!directory.asFile.exists()) {
                         directory.asFile.mkdirs()
@@ -806,7 +808,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
         project.afterEvaluate {
             // prepareKotlinBuildScriptModel runs when a project is created or synced in IntelliJ
             // cleanGroovyCompilerConfig is run by most other tasks
-            it.tasks.matching { it.name in ['prepareKotlinBuildScriptModel', 'cleanGroovyCompilerConfig'] }.configureEach { Task dependent ->
+            it.tasks.matching { Task task ->
+                task.name in ['prepareKotlinBuildScriptModel', 'cleanGroovyCompilerConfig'] }
+                    .configureEach { Task dependent ->
                 dependent.dependsOn verifyGrailsProjectDirectoriesTask
             }
         }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -793,7 +793,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                                  'grails-app/taglib', 'grails-app/migrations']
 
         verifyGrailsProjectDirectoriesTask.configure { Task task ->
-            task.group = 'other'
+            task.group = 'build'
             task.description = 'Ensures essential Grails project directories exist and creates them if missing.'
             task.doFirst {
                 grailsProjectDirectories.each { String dir ->

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -771,6 +771,21 @@ class GrailsGradlePlugin extends GroovyPlugin {
         fileCollection
     }
 
+    /**
+     * Ensures that essential Grails project directories exist and configures a task to verify them.
+     *
+     * This method registers a task named 'verifyGrailsProjectDirectories' that creates the following
+     * directories if they do not already exist:
+     * - grails-app/services
+     * - grails-app/domain
+     * - grails-app/taglib
+     * - grails-app/migrations
+     *
+     * Additionally, it sets up dependencies for tasks like 'prepareKotlinBuildScriptModel' and
+     * 'cleanGroovyCompilerConfig' to ensure that the directories are verified before these tasks run.
+     *
+     * @param project The Gradle project for which the directories are verified and tasks are configured.
+     */
     private void verifyGrailsProjectDirectories(Project project) {
         TaskProvider<Task> verifyGrailsProjectDirectoriesTask = project.tasks.register('verifyGrailsProjectDirectories')
 


### PR DESCRIPTION
runs on project creation or sync in IntelliJ or on most other build tasks