### PR TITLE
show progress message for wrapper downloads

### DIFF
--- a/grails-wrapper/src/main/java/grails/init/GrailsUpdater.java
+++ b/grails-wrapper/src/main/java/grails/init/GrailsUpdater.java
@@ -27,8 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -54,8 +52,8 @@ public class GrailsUpdater {
     }
 
     /**
-     * @param allowedTypes the release types that are allowed to be updated to
-     * @param preferredVersion the preferred version to update to
+     * @param allowedTypes       the release types that are allowed to be updated to
+     * @param preferredVersion   the preferred version to update to
      * @param possibleGrailsHome a possible directory for the grails home
      * @throws IOException if canonicalizing the grails home fails
      */
@@ -68,11 +66,11 @@ public class GrailsUpdater {
      * @return the `grails-cli` version that was selected by this updater
      */
     public GrailsVersion getSelectedVersion() {
-        if(preferredVersion != null) {
+        if (preferredVersion != null) {
             return preferredVersion;
         }
 
-        if(updatedVersion != null) {
+        if (updatedVersion != null) {
             return updatedVersion;
         }
 
@@ -92,11 +90,11 @@ public class GrailsUpdater {
      */
     public boolean needsUpdating() {
         File jarFile = grailsWrapperHome.getLatestWrapperImplementation();
-        if(jarFile == null) {
+        if (jarFile == null) {
             return true;
         }
 
-        if(preferredVersion != null) {
+        if (preferredVersion != null) {
             if (!grailsWrapperHome.versions.contains(preferredVersion)) {
                 return true;
             }
@@ -117,14 +115,12 @@ public class GrailsUpdater {
         GrailsWrapperRepo repo = GrailsWrapperRepo.getSelectedRepo();
 
         GrailsVersion latestVersion = null;
-        if(preferredVersion != null) {
+        if (preferredVersion != null) {
             latestVersion = preferredVersion;
-        }
-        else {
+        } else {
             try {
                 latestVersion = getLastVersion(repo);
-            }
-            catch(Exception e) {
+            } catch (Exception e) {
                 System.err.println("Unable to fetch latest Grails CLI.");
                 e.printStackTrace();
                 System.exit(1);
@@ -135,8 +131,7 @@ public class GrailsUpdater {
         if (latestVersion.releaseType.isSnapshot()) {
             try {
                 detailedVersion = fetchSnapshotForVersion(repo, latestVersion);
-            }
-            catch(Exception e) {
+            } catch (Exception e) {
                 System.err.println("Could not parse snapshot version from maven metadata.");
                 e.printStackTrace();
                 System.exit(1);
@@ -144,7 +139,7 @@ public class GrailsUpdater {
         }
 
         boolean theResult = updateJar(repo, latestVersion, detailedVersion);
-        if(theResult) {
+        if (theResult) {
             updatedVersion = latestVersion;
         }
 
@@ -162,20 +157,22 @@ public class GrailsUpdater {
             File downloadedJar = File.createTempFile(localJarFilename, jarFileExtension);
             String wrapperUrl = repo.getFileUrl(version, remoteJarFilename + jarFileExtension);
 
+            long contentLength = -1;
             InputStream inputStream;
-            if(repo.isFile) {
+            if (repo.isFile) {
                 File jarFile = new File(wrapperUrl);
-                if(!jarFile.exists()) {
+                if (!jarFile.exists()) {
                     throw new IllegalStateException("Could not determine local metadata file from local maven repository: " + jarFile.getAbsolutePath() + " does not exist");
                 }
                 inputStream = Files.newInputStream(jarFile.toPath());
-            }
-            else {
+                contentLength = jarFile.length();
+            } else {
                 HttpURLConnection conn = createHttpURLConnection(wrapperUrl);
+                contentLength = conn.getContentLengthLong();
                 inputStream = conn.getInputStream();
             }
 
-            success = downloadWrapperJar(version, downloadedJar, inputStream, repo.isFile);
+            success = downloadWrapperJar(version, downloadedJar, inputStream, contentLength, repo.isFile);
         } catch (Exception e) {
             System.err.println("There was an error downloading the wrapper jar");
             e.printStackTrace();
@@ -183,16 +180,71 @@ public class GrailsUpdater {
         return success;
     }
 
-    private boolean downloadWrapperJar(GrailsVersion version, File downloadJarLocation, InputStream inputStream, boolean isLocal) throws IOException {
-        ReadableByteChannel rbc = Channels.newChannel(inputStream);
-        try (FileOutputStream fos = new FileOutputStream(downloadJarLocation)) {
-            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+    private void transfer(File downloadJarLocation, InputStream inputStream, long expectedSize) throws IOException {
+        try (inputStream; FileOutputStream fos = new FileOutputStream(downloadJarLocation)) {
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            long totalBytesRead = 0;
+            int lastProgressPercent = 0;
+            long lastMillis = System.currentTimeMillis();
+            long lastBytes = 0;
+
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                fos.write(buffer, 0, bytesRead);
+                totalBytesRead += bytesRead;
+
+                if (expectedSize > 0) {
+                    // can determine the max size, so show a progress bar with % and speed
+                    long currentMillis = System.currentTimeMillis();
+                    if (currentMillis - lastMillis >= 500) {
+                        long elapsedMillis = currentMillis - lastMillis;
+                        long bytesThisRound = totalBytesRead - lastBytes;
+                        double bytesPerSecond = bytesThisRound / (elapsedMillis / 1000.0);
+
+                        int progressPercent = (int) (totalBytesRead * 100 / expectedSize);
+                        if (progressPercent != lastProgressPercent) {
+                            String transferSpeed = readableSize((long) bytesPerSecond, true);
+                            System.out.printf("\r... %3d%% (%s)", progressPercent, transferSpeed);
+                            lastProgressPercent = progressPercent;
+                        }
+
+                        lastMillis = currentMillis;
+                        lastBytes = totalBytesRead;
+                    }
+                }
+                else {
+                    // cannot determine the size
+                    System.out.printf("\r... %s", readableSize(totalBytesRead, false));
+                }
+            }
+            System.out.print("\n");
         }
+    }
+
+    public static String readableSize(long bytes, boolean addSeconds) {
+        List<String> units = List.of("KiB", "MiB", "GiB", "TiB");
+        List<Long> thresholds = List.of(1024L, 1_048_576L, 1_073_741_824L, 1_099_511_627_776L);
+
+        if (bytes > 1_099_511_627_776L) {
+            return "---";
+        }
+
+        for (int i = thresholds.size() - 1; i >= 0; i--) {
+            if (bytes >= thresholds.get(i)) {
+                double thresholdValue = (double) bytes / thresholds.get(i);
+                return String.format(addSeconds ? "%.2f %s/s" : "%.2f %s", thresholdValue, units.get(i));
+            }
+        }
+
+        return addSeconds ? "B/s" : "B";
+    }
+
+    private boolean downloadWrapperJar(GrailsVersion version, File downloadJarLocation, InputStream inputStream, long expectedSize, boolean isLocal) throws IOException {
+        transfer(downloadJarLocation, inputStream, expectedSize);
 
         try {
             grailsWrapperHome.cleanupOtherVersions(version);
-        }
-        catch(Exception e) {
+        } catch (Exception e) {
             System.err.println("Unable to cleanup old versions of the wrapper");
             e.printStackTrace();
         }
@@ -209,19 +261,17 @@ public class GrailsUpdater {
     }
 
     private static InputStream retrieveMavenMetadata(GrailsWrapperRepo repo, String metadataUrl) throws IOException {
-        if(repo.isFile) {
+        if (repo.isFile) {
             File metadataFile = new File(metadataUrl);
-            if(!metadataFile.exists()) {
+            if (!metadataFile.exists()) {
                 throw new IllegalStateException("Could not determine local metadata file from local maven repository: " + metadataFile.getAbsolutePath() + " does not exist");
             }
             return Files.newInputStream(metadataFile.toPath());
-        }
-        else {
+        } else {
             HttpURLConnection connection = createHttpURLConnection(metadataUrl);
             try {
                 return connection.getInputStream();
-            }
-            catch(Exception e) {
+            } catch (Exception e) {
                 throw new RuntimeException("There was an error downloading the metadata file", e);
             }
         }
@@ -232,13 +282,12 @@ public class GrailsUpdater {
         SAXParser saxParser = factory.newSAXParser();
         FindLastReleaseHandler findLastReleaseHandler = new FindLastReleaseHandler();
 
-        try(InputStream stream = retrieveMavenMetadata(repo, repo.getRootMetadataUrl())) {
+        try (InputStream stream = retrieveMavenMetadata(repo, repo.getRootMetadataUrl())) {
             saxParser.parse(stream, findLastReleaseHandler);
             String parsedVersion = findLastReleaseHandler.getVersion();
             try {
                 return new GrailsVersion(parsedVersion);
-            }
-            catch(Exception e) {
+            } catch (Exception e) {
                 throw new IllegalStateException("Failed to parse version '" + parsedVersion + "' from maven repository.", e);
             }
         }
@@ -251,7 +300,7 @@ public class GrailsUpdater {
         SAXParser saxParser = factory.newSAXParser();
         FindLastSnapshotHandler findVersionHandler = new FindLastSnapshotHandler();
 
-        try(InputStream stream = retrieveMavenMetadata(repo, repo.getMetadataUrl(baseVersion))) {
+        try (InputStream stream = retrieveMavenMetadata(repo, repo.getMetadataUrl(baseVersion))) {
             saxParser.parse(stream, findVersionHandler);
             return findVersionHandler.getVersion();
         }


### PR DESCRIPTION
With the slower download speeds for repository.apache.org, I decided to write a basic percentage & speed output.  The output then looks like this: 

     Updating Grails wrapper, allowed versions to update to are [RELEASE,RC,MILESTONE,SNAPSHOT]...
     ...A Grails snapshot version has been detected. Downloading latest snapshot.
     ... 99% (100.00 KiB/s)
     ...Moving remotely downloaded jar to: /Users/jdaugherty/.grails/wrapper/7.0.0-SNAPSHOT/grails-cli-7.0.0-SNAPSHOT.jar


The line `... 99% (100.00 KiB/s)` will update inline.  An example starting value would be `...   2% (99.34 KiB/s)` 
This way it doesn't look like grailsw is hung when the repo transfers slowly.