### PR TITLE
initial attempt at GitHub -> Mailing List notifications

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# see https://s.apache.org/asfyaml
 github:
   # deployment environments to delay releasing until the necessary steps have completed
   environments:
@@ -22,3 +39,14 @@ github:
         - id: jdaugherty
           type: User
       wait_timer: 0
+notifications:
+  # GitHub related
+  commits: commits@grails.apache.org
+  jobs: notifications@grails.apache.org
+  pullrequests_status: dev@grails.apache.org
+  pullrequests_comment: dev@grails.apache.org
+  pullrequests_bot_dependabot: dev@grails.apache.org
+  issues: users@grails.apache.org
+  issues_status: users@grails.apache.org
+  issues_comment: users@grails.apache.org
+  discussions: users@grails.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,9 +43,9 @@ notifications:
   # GitHub related
   commits: commits@grails.apache.org
   jobs: notifications@grails.apache.org
-  pullrequests_status: commits@grails.apache.org
-  pullrequests_comment: commits@grails.apache.org
-  pullrequests_bot_dependabot: commits@grails.apache.org
+  pullrequests_status: notifications@grails.apache.org
+  pullrequests_comment: notifications@grails.apache.org
+  pullrequests_bot_dependabot: notifications@grails.apache.org
   issues: notifications@grails.apache.org
   issues_status: notifications@grails.apache.org
   issues_comment: notifications@grails.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,7 +46,7 @@ notifications:
   pullrequests_status: commits@grails.apache.org
   pullrequests_comment: commits@grails.apache.org
   pullrequests_bot_dependabot: commits@grails.apache.org
-  issues: users@grails.apache.org
-  issues_status: users@grails.apache.org
-  issues_comment: users@grails.apache.org
+  issues: notifications@grails.apache.org
+  issues_status: notifications@grails.apache.org
+  issues_comment: notifications@grails.apache.org
   discussions: users@grails.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,9 +43,9 @@ notifications:
   # GitHub related
   commits: commits@grails.apache.org
   jobs: notifications@grails.apache.org
-  pullrequests_status: dev@grails.apache.org
-  pullrequests_comment: dev@grails.apache.org
-  pullrequests_bot_dependabot: dev@grails.apache.org
+  pullrequests_status: commits@grails.apache.org
+  pullrequests_comment: commits@grails.apache.org
+  pullrequests_bot_dependabot: commits@grails.apache.org
   issues: users@grails.apache.org
   issues_status: users@grails.apache.org
   issues_comment: users@grails.apache.org


### PR DESCRIPTION
https://lists.apache.org/list.html?commits@grails.apache.org is currently receiving most of these.

https://lists.apache.org/list.html?notifications@grails.apache.org, https://lists.apache.org/list.html?users@grails.apache.org and https://lists.apache.org/list.html?dev@grails.apache.org are not currently receiving any of these notification types
