### PR TITLE
Update Geb documentation changes in Breaking Changes Section

### DIFF
--- a/grails-doc/src/en/guide/introduction/whatsNew.adoc
+++ b/grails-doc/src/en/guide/introduction/whatsNew.adoc
@@ -34,7 +34,7 @@ See the xref:conf.adoc#externalConfiguration[Configuration] section for details.
 
 === Ubiquitous Containerized Browser Testing with Geb
 
-The https://github.com/apache/grails-geb[Grails Geb Plugin] has received a significant update, introducing test fixtures that enable ubiquitous containerized browser testing.
+The https://github.com/apache/grails-core/tree/HEAD/grails-geb#readme[Grails Geb Plugin] has received a significant update, introducing test fixtures that enable ubiquitous containerized browser testing.
 
 This new approach is now the recommended way to write functional tests in Grails. However, the previous method using WebDriver binaries remains supported for backward compatibility.
 

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -281,3 +281,34 @@ Please see ticket https://github.com/apache/grails-gradle-plugin/pull/347[#347] 
 ===== 12.8 Java 20+ Date Formatting Changes
 
 In Java 20+, https://cldr.unicode.org/downloads/cldr-42[Unicode CLDR42] was implemented which changed the space character preceding the period (AM or PM) in formatted date/time text from a standard space (" ") to a narrow non-breaking space (NNBSP: "\u202F"). Additionally, when using the LONG or FULL timeStyle with dateStyle, the date and time separator has changed from ' at ' to ', '. IE. January 5, 1941, 8:00:00 AM UTC vs. January 5, 1941 at 8:00:00 AM UTC
+
+===== 12.9 Container runtime environment is now required for standard Geb functional and integration tests
+
+The https://github.com/apache/grails-core/tree/HEAD/grails-geb#readme[Grails Geb Plugin] has received a significant update, introducing test fixtures that enable ubiquitous containerized browser testing.
+
+This new approach is now the recommended way to write functional tests in Grails, but it *requires a container runtime environment*.
+
+The previous method using WebDriver binaries remains supported for backward compatibility, although matching driver and browser versions can be challenging.
+
+====== Key Features
+
+By extending your test classes with `ContainerGebSpec`, your tests will automatically leverage a containerized browser provided by https://www.testcontainers.org[Testcontainers]. This setup eliminates the need for managing browser versions and ensures consistent test environments.
+
+====== Requirements
+
+To use `ContainerGebSpec`, ensure that you have a compatible container runtime installed. Supported options include:
+
+- **Docker Desktop**
+- **OrbStack** (macOS only)
+- **Rancher Desktop**
+- **Podman Desktop**
+- **Colima** (macOS and Linux)
+
+====== How It Works
+
+Once a compatible container runtime is installed, no additional configuration is needed. Simply extend your test classes with `ContainerGebSpec` (instead of `GebSpec`), and the following will happen:
+
+1. A container will be started automatically when you run your integration tests.
+2. The container will be configured to launch a browser capable of accessing your application under test.
+
+With this setup, you gain the benefits of containerized testing, such as isolation, reproducibility, and reduced setup complexity.

--- a/grails-doc/src/en/ref/Command Line/plugin-info.adoc
+++ b/grails-doc/src/en/ref/Command Line/plugin-info.adoc
@@ -58,7 +58,7 @@ This command will display more detailed info about a given plugin such as the au
 Plugin that adds Geb functional testing code generation features.
 
 * License: APACHE
-* Documentation: http://grails.org/plugin/geb
-* Issue Tracker: https://github.com/apache/grails-geb/issues
-* Source: https://github.com/apache/grails-geb/
+* Documentation: https://github.com/apache/grails-core/tree/HEAD/grails-geb#readme
+* Issue Tracker: https://github.com/apache/grails-core/issues
+* Source: https://github.com/apache/grails-core/
 ----

--- a/grails-doc/src/en/ref/Command Line/plugin-info.adoc
+++ b/grails-doc/src/en/ref/Command Line/plugin-info.adoc
@@ -60,5 +60,5 @@ Plugin that adds Geb functional testing code generation features.
 * License: APACHE
 * Documentation: https://github.com/apache/grails-core/tree/HEAD/grails-geb#readme
 * Issue Tracker: https://github.com/apache/grails-core/issues
-* Source: https://github.com/apache/grails-core/
+* Source: https://github.com/apache/grails-core
 ----

--- a/grails-geb/src/main/groovy/grails/plugin/geb/GebGrailsPlugin.groovy
+++ b/grails-geb/src/main/groovy/grails/plugin/geb/GebGrailsPlugin.groovy
@@ -32,8 +32,8 @@ class GebGrailsPlugin extends Plugin {
     def author = "Graeme Rocher"
     def authorEmail = ""
     def description = 'Plugin that adds Geb functional testing code generation features.'
-    def documentation = "https://plugins.grails.org/plugin/grails/geb"
+    def documentation = "https://github.com/apache/grails-core/tree/HEAD/grails-geb#readme"
     def license = "APACHE"
-    def issueManagement = [system: "Github Issues", url: "https://github.com/grails/geb/issues"]
-    def scm = [url: "https://github.com/grails/geb"]
+    def issueManagement = [system: "Github Issues", url: "https://github.com/apache/grails-core/issues"]
+    def scm = [url: "https://github.com/apache/grails-core"]
 }

--- a/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/ContainerFileDetectorSpockSpec.groovy
+++ b/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/ContainerFileDetectorSpockSpec.groovy
@@ -42,7 +42,7 @@ class ContainerFileDetectorSpockSpec extends ContainerGebSpec {
         ServiceRegistry.setInstance(ContainerFileDetector, null)
     }
 
-    @PendingFeature(reason = 'https://github.com/grails/geb/pull/146#issuecomment-2691433277')
+    @PendingFeature(reason = 'https://github.com/apache/grails-geb/pull/146#issuecomment-2691433277')
     void 'should fail to find file with fileDetector changed to UselessContainerFileDetector in setupSpec'() {
         given:
         def uploadPage = to UploadPage


### PR DESCRIPTION
This is similar to documentation in the `what's new` section, but is more focused on the `container runtime requirement` which when missing will cause tests to fail.