### PR TITLE
Unnest the snapshot zip uploaded to workflow results

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -266,7 +266,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wrapper-artifacts
-          path: grails-wrapper/build/distributions/apache-grails-wrapper-*.zip
+          path: tmp/wrapper
   docs:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ publish ]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -265,7 +265,7 @@ jobs:
       - name: "📤 Upload Wrapper Zip to Workflow Summary Page"
         uses: actions/upload-artifact@v4
         with:
-          name: wrapper-artifacts
+          name: apache-grails-wrapper-SNAPSHOT-incubating-bin
           path: tmp/wrapper
   docs:
     if: github.repository_owner == 'apache' && github.event_name == 'push'


### PR DESCRIPTION
This does not run the publish steps until the PR is merged.

Example with nesting:  https://github.com/apache/grails-core/actions/runs/15598307628/artifacts/3311305695