### PR TITLE
Support specifying the publication name so that gradle plugins can be published

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
@@ -90,6 +90,11 @@ class GrailsPublishExtension {
      */
     Closure pomCustomization
 
+    /**
+     * The name of the publication
+     */
+    String publicationName = 'maven'
+
     License getLicense() {
         return license
     }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
@@ -274,7 +274,7 @@ Note: if project properties are used, the properties must be defined prior to ap
 
                 final GrailsPublishExtension gpe = extensionContainer.findByType(GrailsPublishExtension)
                 publications {
-                    maven(MavenPublication) {
+                    it.create(gpe.publicationName, MavenPublication) {
                         delegate.artifactId = gpe.artifactId ?: project.name
                         delegate.groupId = gpe.groupId ?: project.group
 


### PR DESCRIPTION
Working on the asset plugin, we need to be able to specify the maven publication name (pluginMaven) so gradle plugins can be published with the grails publish plugin