### PR TITLE
Rework mainClass gradle find logic

### DIFF
--- a/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
+++ b/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
@@ -91,11 +91,12 @@ class GrailsApplicationContextCommandRunner extends DevelopmentGrailsApplication
      */
     public static void main(String[] args) {
         if(args.size() > 1) {
-            Class applicationClass
+            Class applicationClass = null
+            String className = args.last()
             try {
-                applicationClass = Thread.currentThread().contextClassLoader.loadClass(args.last())
+                applicationClass = Thread.currentThread().contextClassLoader.loadClass(className)
             } catch (Throwable e) {
-                System.err.println("Application class not found")
+                System.err.println("runCommand: Application class ${className} not found")
                 System.exit(1)
             }
 

--- a/grails-console/src/main/groovy/grails/ui/script/GrailsApplicationScriptRunner.groovy
+++ b/grails-console/src/main/groovy/grails/ui/script/GrailsApplicationScriptRunner.groovy
@@ -103,11 +103,12 @@ class GrailsApplicationScriptRunner extends DevelopmentGrailsApplication {
      */
     public static void main(String[] args) {
         if(args.size() > 1) {
-            Class applicationClass
+            Class applicationClass = null
+            String className = args.last()
             try {
-                applicationClass = Thread.currentThread().contextClassLoader.loadClass(args.last())
+                applicationClass = Thread.currentThread().contextClassLoader.loadClass(className)
             } catch (Throwable e) {
-                System.err.println("Application class not found")
+                System.err.println("runScript: Application class ${className} not found")
                 System.exit(1)
             }
             String[] scriptNames = args.init() as String[]

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -169,7 +169,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
         Provider<FindMainClassTask> findMainClassTask = project.tasks.named('findMainClass', FindMainClassTask)
         project.provider {
             File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
-            if (!cacheFile.exists()) {
+            if (!cacheFile?.exists()) {
                 return null
             }
 
@@ -450,7 +450,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                     project.tasks.register(taskName, ApplicationContextCommandTask).configure {
                         it.classpath = fileCollection
                         it.command = commandName
-                        it.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
+                        it.systemProperty(Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName()))
                         List<Object> args = []
                         def otherArgs = project.findProperty('args')
                         if (otherArgs) {
@@ -596,7 +596,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
         def consoleTask = tasks.register('console', JavaExec)
         project.afterEvaluate {
             consoleTask.configure {
-                it.dependsOn(tasks.named('classes'), tasks.named('findMainClass', FindMainClassTask))
+                it.dependsOn(tasks.named('classes'), tasks.named('findMainClass'))
                 it.classpath = project.sourceSets.main.runtimeClasspath + configuration.get()
                 it.mainClass.set('grails.ui.console.GrailsSwingConsole')
 
@@ -615,7 +615,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
         def shellTask = tasks.register('shell', JavaExec)
         project.afterEvaluate {
             shellTask.configure {
-                it.dependsOn(tasks.named('classes'), tasks.named('findMainClass', FindMainClassTask))
+                it.dependsOn(tasks.named('classes'), tasks.named('findMainClass'))
                 it.classpath = project.sourceSets.main.runtimeClasspath + configuration.get()
                 it.mainClass.set('grails.ui.shell.GrailsShell')
                 it.standardInput = System.in
@@ -659,7 +659,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
             project.afterEvaluate {
                 // Support overrides - via mainClass property
                 def propertyMainClassName = project.findProperty('mainClass')
-                if(propertyMainClassName) {
+                if (propertyMainClassName) {
                     findMainClassTask.configure {
                         it.mainClassName.set(propertyMainClassName)
                     }
@@ -668,25 +668,25 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 // Support overrides - via mainClass springboot extension
                 def springBootExtension = project.extensions.getByType(SpringBootExtension)
                 String springBootMainClassName = springBootExtension.mainClass.getOrNull()
-                if(springBootMainClassName) {
+                if (springBootMainClassName) {
                     findMainClassTask.configure {
                         it.mainClassName.set(springBootMainClassName)
                     }
                 }
 
-                if(springBootMainClassName && propertyMainClassName) {
-                    if(springBootMainClassName != propertyMainClassName) {
+                if (springBootMainClassName && propertyMainClassName) {
+                    if (springBootMainClassName != propertyMainClassName) {
                         throw new GradleException("If overriding the mainClass, the property 'mainClass' and the springboot.mainClass must be set to the same value")
                     }
                 }
 
                 def extraProperties = project.extensions.getByType(ExtraPropertiesExtension)
                 def overriddenMainClass = propertyMainClassName ?: springBootMainClassName
-                if(!overriddenMainClass) {
+                if (!overriddenMainClass) {
                     // the findMainClass task needs to set these values
                     extraProperties.set('mainClassName', project.provider {
                         File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
-                        if (!cacheFile.exists()) {
+                        if (!cacheFile?.exists()) {
                             return null
                         }
 
@@ -695,14 +695,13 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
                     springBootExtension.mainClass.set(project.provider {
                         File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
-                        if (!cacheFile.exists()) {
+                        if (!cacheFile?.exists()) {
                             return null
                         }
 
                         cacheFile?.text
                     })
-                }
-                else {
+                } else {
                     // we need to set the overridden value on both
                     extraProperties.set('mainClass', overriddenMainClass)
                     springBootExtension.mainClass.set(overriddenMainClass)
@@ -809,7 +808,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 runTask.configure {
                     SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
                     it.classpath = mainSourceSet.runtimeClasspath + project.configurations.getByName('console')
-                    it.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
+                    it.systemProperty(Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName()))
                     List<Object> args = []
                     def otherArgs = project.findProperty('args')
                     if (otherArgs) {
@@ -835,7 +834,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 runTask.configure {
                     SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
                     it.classpath = mainSourceSet.runtimeClasspath + project.configurations.getByName('console')
-                    it.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
+                    it.systemProperty(Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName()))
 
                     List<Object> args = []
                     def otherArgs = project.findProperty('args')

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -29,6 +29,7 @@ import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
 import org.apache.tools.ant.filters.EscapeUnicode
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -161,6 +162,18 @@ class GrailsGradlePlugin extends GroovyPlugin {
                     }
                 }
             """.stripIndent(16)
+        }
+    }
+
+    private static Provider<String> getMainClassProvider(Project project) {
+        Provider<FindMainClassTask> findMainClassTask = project.tasks.named('findMainClass', FindMainClassTask)
+        project.provider {
+            File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
+            if (!cacheFile.exists()) {
+                return null
+            }
+
+            cacheFile?.text
         }
     }
 
@@ -433,13 +446,22 @@ class GrailsGradlePlugin extends GroovyPlugin {
             for (ctxCommand in applicationContextCommands) {
                 String taskName = GrailsNameUtils.getLogicalPropertyName(ctxCommand, 'Command')
                 String commandName = GrailsNameUtils.getScriptName(GrailsNameUtils.getLogicalName(ctxCommand, 'Command'))
-                if (project.tasks.findByName(taskName) == null) {
-                    project.tasks.create(taskName, ApplicationContextCommandTask) {
-                        classpath = fileCollection
-                        command = commandName
-                        systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
-                        if (project.hasProperty('args')) {
-                            args(CommandLineParser.translateCommandline(project.args))
+                if (!project.tasks.names.contains(taskName)) {
+                    project.tasks.register(taskName, ApplicationContextCommandTask).configure {
+                        it.classpath = fileCollection
+                        it.command = commandName
+                        it.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
+                        List<Object> args = []
+                        def otherArgs = project.findProperty('args')
+                        if (otherArgs) {
+                            args.addAll(CommandLineParser.translateCommandline(otherArgs as String))
+                        }
+
+                        def appClassProvider = GrailsGradlePlugin.getMainClassProvider(project)
+
+                        it.doFirst {
+                            args << appClassProvider.get()
+                            it.args(args)
                         }
                     }
                 }
@@ -564,46 +586,26 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
 
             NamedDomainObjectProvider<Configuration> consoleConfiguration = project.configurations.register('console')
-            def consoleTask = createConsoleTask(project, tasks, consoleConfiguration)
-            def shellTask = createShellTask(project, tasks, consoleConfiguration)
-
-            tasks.named('findMainClass').configure {
-                it.doLast {
-                    def extraProperties = project.getExtensions().getByType(ExtraPropertiesExtension)
-                    if (!extraProperties.has('mainClassName')) {
-                        return // disabled because we don't expect to run a grails app (likely a plugin)
-                    }
-
-                    def mainClassName = extraProperties.get('mainClassName')
-                    if (mainClassName) {
-                        consoleTask.get().args mainClassName
-                        shellTask.get().args mainClassName
-                        project.tasks.withType(ApplicationContextCommandTask) { ApplicationContextCommandTask task ->
-                            task.args mainClassName
-                        }
-                    }
-                    project.tasks.withType(ApplicationContextScriptTask) { ApplicationContextScriptTask task ->
-                        task.args mainClassName
-                    }
-                }
-            }
-
-            consoleTask.configure {
-                it.dependsOn(tasks.named('classes'), tasks.named('findMainClass'))
-            }
-
-            shellTask.configure {
-                it.dependsOn(tasks.named('classes'), tasks.named('findMainClass'))
-            }
+            createConsoleTask(project, tasks, consoleConfiguration)
+            createShellTask(project, tasks, consoleConfiguration)
         }
     }
 
     @CompileDynamic
     protected TaskProvider<JavaExec> createConsoleTask(Project project, TaskContainer tasks, NamedDomainObjectProvider<Configuration> configuration) {
         def consoleTask = tasks.register('console', JavaExec)
-        consoleTask.configure {
-            it.classpath = project.sourceSets.main.runtimeClasspath + configuration.get()
-            it.mainClass.set('grails.ui.console.GrailsSwingConsole')
+        project.afterEvaluate {
+            consoleTask.configure {
+                it.dependsOn(tasks.named('classes'), tasks.named('findMainClass', FindMainClassTask))
+                it.classpath = project.sourceSets.main.runtimeClasspath + configuration.get()
+                it.mainClass.set('grails.ui.console.GrailsSwingConsole')
+
+                def appClass = GrailsGradlePlugin.getMainClassProvider(project)
+
+                it.doFirst {
+                    it.args(appClass.get())
+                }
+            }
         }
         consoleTask
     }
@@ -611,10 +613,19 @@ class GrailsGradlePlugin extends GroovyPlugin {
     @CompileDynamic
     protected TaskProvider<JavaExec> createShellTask(Project project, TaskContainer tasks, NamedDomainObjectProvider<Configuration> configuration) {
         def shellTask = tasks.register('shell', JavaExec)
-        shellTask.configure {
-            it.classpath = project.sourceSets.main.runtimeClasspath + configuration.get()
-            it.mainClass.set('grails.ui.shell.GrailsShell')
-            it.standardInput = System.in
+        project.afterEvaluate {
+            shellTask.configure {
+                it.dependsOn(tasks.named('classes'), tasks.named('findMainClass', FindMainClassTask))
+                it.classpath = project.sourceSets.main.runtimeClasspath + configuration.get()
+                it.mainClass.set('grails.ui.shell.GrailsShell')
+                it.standardInput = System.in
+
+                def appClass = GrailsGradlePlugin.getMainClassProvider(project)
+
+                it.doFirst {
+                    it.args(appClass.get())
+                }
+            }
         }
         shellTask
     }
@@ -629,6 +640,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
         }
     }
 
+    @CompileDynamic
     protected void registerFindMainClassTask(Project project) {
         TaskContainer taskContainer = project.tasks
 
@@ -644,77 +656,72 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 }
             }
 
-            // Set it on the extensions & spring boot extension "just" to be complete in case any other tasks use these values
             project.afterEvaluate {
-                def extraProperties = project.extensions.getByType(ExtraPropertiesExtension)
-                extraProperties.set('mainClassName', project.provider {
-                    if (extraProperties.has('mainClassName')) {
-                        return extraProperties.get('mainClassName')
+                // Support overrides - via mainClass property
+                def propertyMainClassName = project.findProperty('mainClass')
+                if(propertyMainClassName) {
+                    findMainClassTask.configure {
+                        it.mainClassName.set(propertyMainClassName)
                     }
+                }
 
-                    File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
-                    if (!cacheFile.exists()) {
-                        return null
-                    }
-
-                    cacheFile?.text
-                })
-
+                // Support overrides - via mainClass springboot extension
                 def springBootExtension = project.extensions.getByType(SpringBootExtension)
-                springBootExtension.mainClass.set(project.provider {
-                    if (springBootExtension.mainClass.isPresent()) {
-                        return springBootExtension.mainClass.get() as String
+                String springBootMainClassName = springBootExtension.mainClass.getOrNull()
+                if(springBootMainClassName) {
+                    findMainClassTask.configure {
+                        it.mainClassName.set(springBootMainClassName)
                     }
+                }
 
-                    File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
-                    if (!cacheFile.exists()) {
-                        return null
+                if(springBootMainClassName && propertyMainClassName) {
+                    if(springBootMainClassName != propertyMainClassName) {
+                        throw new GradleException("If overriding the mainClass, the property 'mainClass' and the springboot.mainClass must be set to the same value")
                     }
+                }
 
-                    cacheFile?.text
-                })
+                def extraProperties = project.extensions.getByType(ExtraPropertiesExtension)
+                def overriddenMainClass = propertyMainClassName ?: springBootMainClassName
+                if(!overriddenMainClass) {
+                    // the findMainClass task needs to set these values
+                    extraProperties.set('mainClassName', project.provider {
+                        File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
+                        if (!cacheFile.exists()) {
+                            return null
+                        }
+
+                        cacheFile?.text
+                    })
+
+                    springBootExtension.mainClass.set(project.provider {
+                        File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
+                        if (!cacheFile.exists()) {
+                            return null
+                        }
+
+                        cacheFile?.text
+                    })
+                }
+                else {
+                    // we need to set the overridden value on both
+                    extraProperties.set('mainClass', overriddenMainClass)
+                    springBootExtension.mainClass.set(overriddenMainClass)
+                }
             }
 
             project.tasks.withType(BootArchive).configureEach { BootArchive bootTask ->
                 bootTask.dependsOn(findMainClassTask)
-                bootTask.mainClass.convention(project.provider {
-                    File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
-                    if (!cacheFile.exists()) {
-                        return null
-                    }
-
-                    cacheFile?.text
-                })
+                bootTask.mainClass.convention(GrailsGradlePlugin.getMainClassProvider(project))
             }
 
             project.tasks.withType(BootRun).configureEach { BootRun it ->
                 it.dependsOn(findMainClassTask)
-                it.mainClass.convention(project.provider {
-                    File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
-                    if (!cacheFile.exists()) {
-                        return null
-                    }
-
-                    cacheFile?.text
-                })
+                it.mainClass.convention(GrailsGradlePlugin.getMainClassProvider(project))
             }
 
             project.tasks.withType(ResolveMainClassName).configureEach {
                 it.dependsOn(findMainClassTask)
-
-                it.configuredMainClassName.set(project.provider {
-                    def springBootExtension = project.extensions.getByType(SpringBootExtension)
-                    if (springBootExtension.mainClass.isPresent()) {
-                        return springBootExtension.mainClass.get() as String
-                    }
-
-                    File cacheFile = findMainClassTask.get().mainClassCacheFile.orNull?.asFile
-                    if (!cacheFile.exists()) {
-                        return null
-                    }
-
-                    cacheFile?.text
-                })
+                it.configuredMainClassName.convention(GrailsGradlePlugin.getMainClassProvider(project))
             }
         } else if (!FindMainClassTask.class.isAssignableFrom(existingTask.class)) {
             project.logger.warn('Grails Projects typically register a findMainClass task to force the MainClass resolution for Spring Boot. This task already exists so this will not occur.')
@@ -797,13 +804,24 @@ class GrailsGradlePlugin extends GroovyPlugin {
     @CompileDynamic
     protected void configureRunScript(Project project) {
         if (!project.tasks.names.contains('runScript')) {
-            project.tasks.register('runScript', ApplicationContextScriptTask).configure {
-                SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
-                it.classpath = mainSourceSet.runtimeClasspath + project.configurations.getByName('console')
-                it.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
-                def argsProperty = project.findProperty('args')
-                if (argsProperty) {
-                    it.args(CommandLineParser.translateCommandline(argsProperty))
+            def runTask = project.tasks.register('runScript', ApplicationContextScriptTask)
+            project.afterEvaluate {
+                runTask.configure {
+                    SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
+                    it.classpath = mainSourceSet.runtimeClasspath + project.configurations.getByName('console')
+                    it.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
+                    List<Object> args = []
+                    def otherArgs = project.findProperty('args')
+                    if (otherArgs) {
+                        args.addAll(CommandLineParser.translateCommandline(otherArgs as String))
+                    }
+
+                    def appClassProvider = GrailsGradlePlugin.getMainClassProvider(project)
+
+                    it.doFirst {
+                        args << appClassProvider.get()
+                        it.args(args)
+                    }
                 }
             }
         }
@@ -812,13 +830,26 @@ class GrailsGradlePlugin extends GroovyPlugin {
     @CompileDynamic
     protected void configureRunCommand(Project project) {
         if (!project.tasks.names.contains('runCommand')) {
-            project.tasks.register('runCommand', ApplicationContextCommandTask).configure {
-                SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
-                it.classpath = mainSourceSet.runtimeClasspath + project.configurations.getByName('console')
-                it.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
-                def argsProperty = project.findProperty('args')
-                if (argsProperty) {
-                    it.args(CommandLineParser.translateCommandline(argsProperty))
+            def runTask = project.tasks.register('runCommand', ApplicationContextCommandTask)
+            project.afterEvaluate {
+                runTask.configure {
+                    SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
+                    it.classpath = mainSourceSet.runtimeClasspath + project.configurations.getByName('console')
+                    it.systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName())
+
+                    List<Object> args = []
+                    def otherArgs = project.findProperty('args')
+                    if (otherArgs) {
+                        args.addAll(CommandLineParser.translateCommandline(otherArgs as String))
+                    }
+
+                    def appClassProvider = GrailsGradlePlugin.getMainClassProvider(project)
+
+                    it.doFirst {
+                        args << appClassProvider.get()
+                        it.args(args)
+                    }
+
                 }
             }
         }

--- a/grails-gradle/tasks/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
+++ b/grails-gradle/tasks/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
@@ -123,9 +123,9 @@ abstract class FindMainClassTask extends DefaultTask {
             return
         }
 
-        if(mainClassName.isPresent()) {
+        if (mainClassName.isPresent()) {
             def overrideClassName = mainClassName.get()
-            logger.info("Overriding main class with: ${ overrideClassName}")
+            logger.info('Overriding main class with: {}', overrideClassName)
             File cacheFile = mainClassCacheFile.get().asFile
             cacheFile.parentFile.mkdirs()
             cacheFile.text = overrideClassName

--- a/grails-gradle/tasks/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
+++ b/grails-gradle/tasks/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -58,6 +59,13 @@ abstract class FindMainClassTask extends DefaultTask {
 
     @OutputFile
     final RegularFileProperty mainClassCacheFile
+
+    /**
+     * allows forcing the main class name & ensures this task retriggers to save to the cache file if overridden
+     */
+    @Input
+    @Optional
+    final Property<String> mainClassName
 
     @Input
     final Property<Boolean> isGrailsPlugin
@@ -100,6 +108,7 @@ abstract class FindMainClassTask extends DefaultTask {
             Task bootWarTask = project.tasks.findByName(SpringBootPlugin.BOOT_WAR_TASK_NAME)
             (bootWarTask && bootWarTask.enabled) as boolean
         })
+        mainClassName = objects.property(String)
     }
 
     @TaskAction
@@ -111,6 +120,15 @@ abstract class FindMainClassTask extends DefaultTask {
 
         if (!enabledBootJarTask.get() && !enabledBootWarTask.get()) {
             logger.info('There is neither a {} or {} task that will run. Skipping finding main Application class.', SpringBootPlugin.BOOT_JAR_TASK_NAME, SpringBootPlugin.BOOT_WAR_TASK_NAME)
+            return
+        }
+
+        if(mainClassName.isPresent()) {
+            def overrideClassName = mainClassName.get()
+            logger.info("Overriding main class with: ${ overrideClassName}")
+            File cacheFile = mainClassCacheFile.get().asFile
+            cacheFile.parentFile.mkdirs()
+            cacheFile.text = overrideClassName
             return
         }
 


### PR DESCRIPTION
using a provider that gets passed to args() of JavaExec is problematic.  This reworks the mainClass to be centralized around the FindMainTask instead.

This fixes the failing tests in grails-forge.