### PR TITLE
Retry Build and Functional Test Steps when timeout occurs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -91,7 +91,7 @@ jobs:
         with: 
           timeout_seconds: 3600 # normal range 20-40m
           max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 360
+          retry_wait_seconds: 600
           command: >
             ./gradlew build :grails-shell-cli:installDist groovydoc
             --continue --stacktrace -PonlyCoreTests
@@ -121,7 +121,7 @@ jobs:
         with: 
           timeout_seconds: 1200 # normal range 10-12m
           max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 360
+          retry_wait_seconds: 600
           command: >
             ./gradlew bootJar check
             --continue --stacktrace
@@ -157,7 +157,7 @@ jobs:
         with: 
           timeout_seconds: 1500 # normal range 15m
           max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 360
+          retry_wait_seconds: 600
           command: >
             ./gradlew bootJar cleanTest check
             --continue --stacktrace
@@ -191,7 +191,7 @@ jobs:
         with: 
           timeout_seconds: 1200 # normal range 10-12m
           max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 360
+          retry_wait_seconds: 600
           command: >
             ./gradlew bootJar cleanTest check
             --continue --stacktrace

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -90,8 +90,8 @@ jobs:
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
         with: 
           timeout_seconds: 3600 # normal range 20-40m
-          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 180
+          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 240
           command: >
             ./gradlew build :grails-shell-cli:installDist groovydoc
             --continue --stacktrace -PonlyCoreTests
@@ -120,8 +120,8 @@ jobs:
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
         with: 
           timeout_seconds: 1200 # normal range 10-12m
-          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 180
+          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 240
           command: >
             ./gradlew bootJar check
             --continue --stacktrace
@@ -156,8 +156,8 @@ jobs:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with: 
           timeout_seconds: 1500 # normal range 15m
-          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 180
+          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 240
           command: >
             ./gradlew bootJar cleanTest check
             --continue --stacktrace
@@ -190,8 +190,8 @@ jobs:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with: 
           timeout_seconds: 1200 # normal range 10-12m
-          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 180
+          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 240
           command: >
             ./gradlew bootJar cleanTest check
             --continue --stacktrace

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -90,8 +90,8 @@ jobs:
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
         with: 
           timeout_seconds: 3600 # normal range 20-40m
-          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 240
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 360
           command: >
             ./gradlew build :grails-shell-cli:installDist groovydoc
             --continue --stacktrace -PonlyCoreTests
@@ -120,8 +120,8 @@ jobs:
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
         with: 
           timeout_seconds: 1200 # normal range 10-12m
-          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 240
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 360
           command: >
             ./gradlew bootJar check
             --continue --stacktrace
@@ -156,8 +156,8 @@ jobs:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with: 
           timeout_seconds: 1500 # normal range 15m
-          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 240
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 360
           command: >
             ./gradlew bootJar cleanTest check
             --continue --stacktrace
@@ -190,8 +190,8 @@ jobs:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with: 
           timeout_seconds: 1200 # normal range 10-12m
-          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 240
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 360
           command: >
             ./gradlew bootJar cleanTest check
             --continue --stacktrace

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -117,13 +117,18 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🏃 Run Functional Tests"
-        run: >
-          ./gradlew bootJar check
-          --continue --stacktrace
-          -PonlyFunctionalTests
-          -PskipHibernate5Tests
-          -PskipMongodbTests
-          --rerun-tasks
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
+        with: 
+          timeout_seconds: 1200 # normal range 10-12m
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 180
+          command: >
+            ./gradlew bootJar check
+            --continue --stacktrace
+            -PonlyFunctionalTests
+            -PskipHibernate5Tests
+            -PskipMongodbTests
+            --rerun-tasks
   mongodbFunctional:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     name: "Mongodb Functional Tests"
@@ -146,14 +151,19 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "🏃 Run Functional Tests"
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          ./gradlew bootJar cleanTest check
-          --continue --stacktrace
-          -PonlyMongodbTests
-          -PmongodbContainerVersion=${{ matrix.mongodb-version }}
-          --rerun-tasks
+        with: 
+          timeout_seconds: 1500 # normal range 15m
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 180
+          command: >
+            ./gradlew bootJar cleanTest check
+            --continue --stacktrace
+            -PonlyMongodbTests
+            -PmongodbContainerVersion=${{ matrix.mongodb-version }}
+            --rerun-tasks
   hibernate5Functional:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     name: "Hibernate5 Functional Tests"
@@ -175,13 +185,18 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "🏃 Run Functional Tests"
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          ./gradlew bootJar cleanTest check
-          --continue --stacktrace
-          -PonlyHibernate5Tests
-          --rerun-tasks
+        with: 
+          timeout_seconds: 1200 # normal range 10-12m
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 180
+          command: >
+            ./gradlew bootJar cleanTest check
+            --continue --stacktrace
+            -PonlyHibernate5Tests
+            --rerun-tasks
   publishGradle:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ buildGradle ]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -87,10 +87,15 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
       - name: "🔨 Build project"
-        run: >
-          ./gradlew build :grails-shell-cli:installDist groovydoc
-          --continue --stacktrace -PonlyCoreTests
-          --rerun-tasks
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
+        with: 
+          timeout_seconds: 3600 # normal range 20-40m
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 180
+          command: >
+            ./gradlew build :grails-shell-cli:installDist groovydoc
+            --continue --stacktrace -PonlyCoreTests
+            --rerun-tasks
   functional:
     name: "Functional Tests"
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -158,6 +158,11 @@ jobs:
         run: |
           sed -i "/['\"]groovy\.version['\"][[:space:]]*:/c\'groovy.version':'${{ needs.build_groovy.outputs.groovyVersion }}'," dependencies.gradle
       - name: "🔨 Build and test Grails using the locally built Groovy snapshot"
-        run: >
-          ./gradlew build
-          -x groovydoc
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
+        with: 
+          timeout_seconds: 2700 # normal range 10-30m
+          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 240
+          command: >
+            ./gradlew build
+            -x groovydoc

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -161,8 +161,8 @@ jobs:
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2 
         with: 
           timeout_seconds: 2700 # normal range 10-30m
-          max_attempts: 5 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 240
+          max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
+          retry_wait_seconds: 360
           command: >
             ./gradlew build
             -x groovydoc

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -162,7 +162,7 @@ jobs:
         with: 
           timeout_seconds: 2700 # normal range 10-30m
           max_attempts: 3 # Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out
-          retry_wait_seconds: 360
+          retry_wait_seconds: 600
           command: >
             ./gradlew build
             -x groovydoc


### PR DESCRIPTION
Attempts to address: Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connect timed out

```
max_attempts: 3
retry_wait_seconds: 600
```

nick-fields/retry is already used in publish

![image](https://github.com/user-attachments/assets/e0d50672-15d2-4c92-97f6-c40099242b8a)

![image](https://github.com/user-attachments/assets/5b75fbd0-b639-4e1f-9bd0-21b75693c068)

