### PR TITLE
Support not adding components from the grails publish plugin

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishExtension.groovy
@@ -91,6 +91,11 @@ class GrailsPublishExtension {
     Closure pomCustomization
 
     /**
+     * If another process will add the components set this to false so only the publication is created
+     */
+    Boolean addComponents = true
+
+    /**
      * The name of the publication
      */
     String publicationName = 'maven'

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/publishing/GrailsPublishGradlePlugin.groovy
@@ -278,10 +278,12 @@ Note: if project properties are used, the properties must be defined prior to ap
                         delegate.artifactId = gpe.artifactId ?: project.name
                         delegate.groupId = gpe.groupId ?: project.group
 
-                        doAddArtefact(project, delegate)
-                        def extraArtefact = getDefaultExtraArtifact(project)
-                        if (extraArtefact) {
-                            artifact extraArtefact
+                        if(gpe.addComponents) {
+                            doAddArtefact(project, delegate)
+                            def extraArtefact = getDefaultExtraArtifact(project)
+                            if (extraArtefact) {
+                                artifact extraArtefact
+                            }
                         }
 
                         pom.withXml {


### PR DESCRIPTION
In order to publish gradle plugins, we must let the [gradle publish plugin](https://plugins.gradle.org/docs/publish-plugin) handle adding components.