### PR TITLE
Correct dependency to `grails-codecs-core`

### DIFF
--- a/grails-codecs/build.gradle
+++ b/grails-codecs/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api project(':grails-web-core')
     api project(':grails-encoder')
     api 'org.apache.groovy:groovy'
-    runtimeOnly project(':grails-codecs')
+    runtimeOnly project(':grails-codecs-core')
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
     compileOnly 'org.springframework:spring-test', {


### PR DESCRIPTION
When migrating to Apache coordinates, `grails-codecs` was renamed to `grails-codecs-core`, and `grails-plugin-codecs` became `grails-codecs`. This commit updates a reference to `grails-codecs` that should have been changed to `grails-codecs-core` but was missed earlier.

Resolves gh-14843