### PR TITLE
chore: update to 5.0.12 for the asset pipeline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,12 +54,6 @@ allprojects {
                 includeVersionByRegex('org[.]apache[.](grails|groovy).*', '.*', '.*-SNAPSHOT')
             }
         }
-        maven {
-            url = 'https://central.sonatype.com/repository/maven-snapshots'
-            content {
-                includeVersionByRegex('cloud[.]wondrify', '.*', '.*-SNAPSHOT')
-            }
-        }
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -37,12 +37,6 @@ repositories {
             includeVersionByRegex('org[.]apache[.](grails|groovy).*', '.*', '.*SNAPSHOT')
         }
     }
-    maven {
-        url = 'https://central.sonatype.com/repository/maven-snapshots'
-        content {
-            includeVersionByRegex('cloud[.]wondrify', '.*', '.*-SNAPSHOT')
-        }
-    }
     maven { url = 'https://repo.grails.org/grails/restricted' }
     mavenCentral()
     gradlePluginPortal()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -25,7 +25,7 @@ ext {
             'ant.version'                        : '1.10.15',
             'asciidoctor-gradle-jvm.version'     : '4.0.4',
             'asciidoctorj.version'               : '3.0.0',
-            'asset-pipeline-gradle.version'      : '5.0.10-SNAPSHOT',
+            'asset-pipeline-gradle.version'      : '5.0.12',
             'byte-buddy.version'                 : '1.15.5',
             'commons-text.version'               : '1.12.0',
             'directory-watcher.version'          : '0.18.0',
@@ -77,7 +77,7 @@ ext {
     ]
 
     bomDependencyVersions = [
-            'asset-pipeline-grails.version': '5.0.10-SNAPSHOT',
+            'asset-pipeline-grails.version': '5.0.12',
             'bootstrap-icons.version'      : '1.11.3',
             'bootstrap.version'            : '5.3.3',
             'commons-codec.version'        : '1.17.1',

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -196,12 +196,16 @@ Both the legacy `grails-shell-cli` and `grails-forge-cli` are now included with 
 
 Grails 7.0.0 introduces several breaking changes that may require updates to your application.
 
-===== 12.0
+===== 12.1
 
 Due to the significant changes in Grails 7, all prior Grails Plugin will need updated to work with Grails 7. For plugins in the https://github.com/grails-plugins/[Grails Plugins] GitHub organization, the Grails Core team is updating them as time permits and when requested.
 If there is a plugin that you require updating, please reach out via https://github.com/apache/grails-core/issues[ticket] to see if we can help.
 
-===== 12.1 javax -> Jakarta
+===== 12.0 Asset Pipeline
+
+The asset pipeline has a new https://github.com/wondrify/asset-pipeline[home]. Version 5.0.12 and forward is compatible with Grails 7.x.
+
+===== 12.2 javax -> Jakarta
 
 Spring has switched from javax to https://jakarta.ee/[jakarta] packages.
 Please consult the Spring upgrade guides for the impacts of this change.
@@ -222,7 +226,7 @@ jakartaeeMigration {
 }
 ----
 
-===== 12.2 Removed libraries/classes
+===== 12.3 Removed libraries/classes
 - The `grails-web-fileupload` library, including its sole class `ContentLengthAwareCommonsMultipartResolver`, has been removed. This change was necessitated by the removal of the superclass `CommonsMultipartResolver` in Spring 6. The `ContentLengthAwareCommonsMultipartResolver` was originally introduced to address a bug in Safari back in 2007, but it is likely no longer needed. Spring has transitioned away from `CommonsMultipartResolver` and now recommends using the built-in support for multipart uploads provided by servlet containers. For more information on handling file uploads in Spring Boot, please refer to the relevant sections of the https://docs.spring.io/spring-boot/how-to/spring-mvc.html#howto.spring-mvc.multipart-file-uploads[Spring Boot documentation] and the https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#web-applications-1[Spring Framework 6 upgrade guide].
 - `org.grails.spring.beans.factory.OptimizedAutowireCapableBeanFactory` was previously deprecated and is now removed.
 - The following deprecated classes were removed, please use the suggested replacement:
@@ -232,7 +236,7 @@ jakartaeeMigration {
 3. `org.grails.core.DefaultGrailsTagLibClass` -> `org.grails.core.gsp.DefaultGrailsTagLibClass`
 4. `org.grails.plugins.CodecsGrailsPlugin` -> `org.grails.plugins.codecs.CodecsGrailsPlugin`
 
-===== 12.3 Micronaut in Grails is now supported via the Micronaut Spring Boot Starter
+===== 12.4 Micronaut in Grails is now supported via the Micronaut Spring Boot Starter
 - This change was made based on community input: https://github.com/orgs/grails/discussions/13517
 - The removal of Micronaut enabled simplification of the Grails codebase and the return of Live Reload via https://github.com/HotswapProjects/HotswapAgent
 - The Micronaut Parent Context is no longer in Grails by default.
@@ -241,7 +245,7 @@ jakartaeeMigration {
 - Using Micronaut Parent Context: https://micronaut-projects.github.io/micronaut-spring/latest/guide/#springParentContext
 - Using a Bean Post Processor: https://micronaut-projects.github.io/micronaut-spring/latest/guide/#beanPostProcessor
 
-===== 12.4 hibernate-ehcache
+===== 12.5 hibernate-ehcache
 
 The `org.hibernate:hibernate-ehcache` library is no longer provided by the `org.apache.grails:grails-hibernate5` plugin. If
 your application depends on `hibernate-ehcache`, you must now add it explicitly to your project dependencies.
@@ -263,32 +267,36 @@ dependencies {
 }
 ----
 
-===== 12.5 H2
+===== 12.6 H2
 
 The test database H2 is stricter about reserved keywords.
 If you use H2 in your application, please take a look at this https://github.com/grails/grails-data-hibernate5/pull/910/commits/c8de45df204966ccc228b46b94beeb2142ae0f59[pull request] for examples of these new restrictions.
 
-===== 12.6 Removal of Test Dependencies from Production Classpath
+===== 12.7 Removal of Test Dependencies from Production Classpath
 
 Prior versions of Grails included test dependencies on the production classpath.
 These are now removed in Grails 7. If you still need them, you can add them to your `implementation` configuration in your build.gradle file.
 
-===== 12.7 Jar Artifact name changes
+===== 12.8 Jar Artifact name changes
 
 Jar artifacts produced by Grails Plugins will no longer have the suffix `-plain`.
 Please see ticket https://github.com/apache/grails-gradle-plugin/pull/347[#347] for details.
 
-===== 12.8 Java 20+ Date Formatting Changes
+===== 12.9 Java 20+ Date Formatting Changes
 
 In Java 20+, https://cldr.unicode.org/downloads/cldr-42[Unicode CLDR42] was implemented which changed the space character preceding the period (AM or PM) in formatted date/time text from a standard space (" ") to a narrow non-breaking space (NNBSP: "\u202F"). Additionally, when using the LONG or FULL timeStyle with dateStyle, the date and time separator has changed from ' at ' to ', '. IE. January 5, 1941, 8:00:00 AM UTC vs. January 5, 1941 at 8:00:00 AM UTC
 
-===== 12.9 Container runtime environment is now required for standard Geb functional and integration tests
+===== 12.10 Container runtime environment is now required for standard Geb functional and integration tests
 
 The https://github.com/apache/grails-core/tree/HEAD/grails-geb#readme[Grails Geb Plugin] has received a significant update, introducing test fixtures that enable ubiquitous containerized browser testing.
 
 This new approach is now the recommended way to write functional tests in Grails, but it *requires a container runtime environment*.
 
 The previous method using WebDriver binaries remains supported for backward compatibility, although matching driver and browser versions can be challenging.
+
+===== 12.11 Asset Pipeline
+
+The asset pipeline has a new https://github.com/wondrify/asset-pipeline[home]. Version 5.0.12 and forward is compatible with Grails 7.x.
 
 ====== Key Features
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleRepository.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleRepository.java
@@ -50,16 +50,6 @@ public interface GradleRepository extends Ordered {
                     )
             ));
         }
-        repositories.add(new DefaultGradleRepository(
-                repositories.size(),
-                "https://central.sonatype.com/repository/maven-snapshots",
-                null,
-                List.of(
-                        new VersionRegexRepoFilter(
-                                "cloud[.]wondrify", ".*", ".*-SNAPSHOT"
-                        )
-                )
-        ));
 
         return repositories;
     }

--- a/grails-gradle/build.gradle
+++ b/grails-gradle/build.gradle
@@ -35,12 +35,6 @@ allprojects {
                 includeVersionByRegex('org[.]apache[.](grails|groovy).*', '.*', '.*SNAPSHOT')
             }
         }
-        maven {
-            url = 'https://central.sonatype.com/repository/maven-snapshots'
-            content {
-                includeVersionByRegex('cloud[.]wondrify', '.*', '.*-SNAPSHOT')
-            }
-        }
     }
 
     props.forEach { k, v -> project.ext.set(k as String, v) }


### PR DESCRIPTION
The asset pipeline is now published to both the gradle plugin portal & maven central.  

#14828