### PR TITLE
fix: #14854 - remove duplicate repo definition (restricted contains maven central)

### DIFF
--- a/grails-shell-cli/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
@@ -72,9 +72,6 @@ class GrailsDependencyVersions implements DependencyManagement {
         if (!Environment.grailsVersion || Environment.grailsVersion.endsWith("SNAPSHOT")) {
             grape.addResolver([name:"apacheRepository", root:"https://repository.apache.org/content/groups/public"] as Map<String, Object>)
         }
-        else {
-            grape.addResolver([name:"mavenCentral", root:"https://repo1.maven.org/maven2"] as Map<String, Object>)
-        }
 
         grape.addResolver([name:"grailsCentral", root:"https://repo.grails.org/grails/restricted"] as Map<String, Object>)
 


### PR DESCRIPTION
#14854  This may be caused by the grailsCentral repo containing the maven central repo.  This PR removes the duplicate definition of maven central.