### PR TITLE
fix: #14090 - fix baseUrl returning the wrong result when forwardPort is null

### DIFF
--- a/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/GrailsWebRequest.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/GrailsWebRequest.java
@@ -476,9 +476,7 @@ public class GrailsWebRequest extends DispatcherServletWebRequest  {
             //ignore port append if the request was forwarded from a VIP as actual source port is now not known
             if (forwardedScheme == null && (("http".equals(scheme) && port != 80) || ("https".equals(scheme) && port != 443))) {
                 sb.append(":").append(port);
-            } else if (forwardedPort != null &&
-                    ("http".equals(forwardedScheme) && !"80".equals(forwardedPort)) ||
-                    ("https".equals(forwardedScheme) && !"443".equals(forwardedPort))) {
+            } else if (forwardedPort != null && (("http".equals(forwardedScheme) && !"80".equals(forwardedPort)) || ("https".equals(forwardedScheme) && !"443".equals(forwardedPort)))) {
                 sb.append(":").append(forwardedPort);
             }
 


### PR DESCRIPTION
Per https://github.com/apache/grails-core/issues/14090 there needs to be parens around the check for the port.  This was a bug introduced in 6.1.1