### PR TITLE
Fix snapshot docs URL, currently only appears on snapshot docs

### DIFF
--- a/grails-gradle/docs-core/src/main/groovy/grails/doc/dropdown/CreateReleaseDropDownTask.groovy
+++ b/grails-gradle/docs-core/src/main/groovy/grails/doc/dropdown/CreateReleaseDropDownTask.groovy
@@ -154,7 +154,7 @@ abstract class CreateReleaseDropDownTask extends DefaultTask {
         softwareVersions
                 .forEach { softwareVersion ->
                     final String versionName = softwareVersion?.versionText
-                    final String href = GRAILS_DOC_BASE_URL + "/" + versionName + "/" + pageRelativePath
+                    final String href = GRAILS_DOC_BASE_URL + "/" + (versionName?.endsWith("-SNAPSHOT") ? 'snapshot' : versionName) + "/" + pageRelativePath
                     options << option(href, versionName, version == versionName)
                 }
 


### PR DESCRIPTION
Fixes the snapshot URL in the dropdown on https://docs.grails.org/snapshot/guide/single.html

https://docs.grails.org/7.0.0-SNAPSHOT/guide/single.html should be https://docs.grails.org/snapshot/guide/single.html

```
<select onchange="window.document.location.href=this.options[this.selectedIndex].value;">
<option selected="selected" value="https://docs.grails.org/snapshot/guide/single.html">SNAPSHOT</option>
<option selected="selected" value="https://docs.grails.org/7.0.0-SNAPSHOT/guide/single.html">7.0.0-SNAPSHOT</option></select>
```

with

```
<select onchange="window.document.location.href=this.options[this.selectedIndex].value;">
<option selected="selected" value="https://docs.grails.org/snapshot/guide/single.html">SNAPSHOT</option>
<option selected="selected" value="https://docs.grails.org/snapshot/guide/single.html">7.0.0-SNAPSHOT</option>
</select>
```

