### PR TITLE
fix: #14910 - make property files reproducible by default (per day)

### DIFF
--- a/grails-common/src/main/groovy/org/apache/grails/common/properties/PropertyFileUtils.groovy
+++ b/grails-common/src/main/groovy/org/apache/grails/common/properties/PropertyFileUtils.groovy
@@ -17,6 +17,8 @@
 package org.apache.grails.common.properties
 
 import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.regex.Pattern
 
 final class PropertyFileUtils {
@@ -30,7 +32,9 @@ final class PropertyFileUtils {
     static void makePropertiesFileReproducible(File factoriesFile) {
         String sourceDateEpoch = System.getenv('SOURCE_DATE_EPOCH')
         if (!sourceDateEpoch) {
-            return
+            sourceDateEpoch = LocalDate.now(ZoneOffset.UTC)
+                    .atStartOfDay(ZoneOffset.UTC)
+                    .toEpochSecond().toString()
         }
 
         Pattern timeRegex = Pattern.compile('^#(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)(?:,|\\\\s).*$')

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -72,6 +72,8 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 import javax.inject.Inject
 import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.regex.Pattern
 
 /**
@@ -173,7 +175,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
     static void makePropertiesFileReproducible(File factoriesFile) {
         String sourceDateEpoch = System.getenv('SOURCE_DATE_EPOCH')
         if (!sourceDateEpoch) {
-            return
+            sourceDateEpoch = LocalDate.now(ZoneOffset.UTC)
+                    .atStartOfDay(ZoneOffset.UTC)
+                    .toEpochSecond().toString()
         }
 
         Pattern timeRegex = Pattern.compile('^#(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)(?:,|\\\\s).*$')


### PR DESCRIPTION
Addresses https://github.com/apache/grails-core/issues/14910 

This is a follow-up to @jprinet 's initial contribution. The property files should now be reproducible by day.

This affects: 
* `grails.build.info` - has correct inputs & outputs
* `grails.factories` - generated by AST code, and code changes will trigger a new compile
* `views.properties` - generated by the gsp compilation process, so should match because gsp has the correct inputs/outputs

Longer term: we may want to evaluate replacing dates with a specific version (snapshot could still use dates).  