### PR TITLE
Set spring boot dev tools as a default feature in forge to match profiles

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
@@ -116,6 +116,10 @@ public class GradleDependency extends DependencyCoordinate {
         if (isPom() || gradleConfiguration == INTEGRATION_TEST_IMPLEMENTATION_TEST_FIXTURES) {
             snippet += ")";
         }
+        if (getArtifactId() == "spring-boot-devtools") {
+            snippet += " // Spring Boot DevTools may cause performance slowdowns on larger applications";
+        }
+
         return snippet;
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleDependency.java
@@ -117,7 +117,7 @@ public class GradleDependency extends DependencyCoordinate {
             snippet += ")";
         }
         if (getArtifactId() == "spring-boot-devtools") {
-            snippet += " // Spring Boot DevTools may cause performance slowdowns on larger applications";
+            snippet += " // Spring Boot DevTools may cause performance slowdowns or compatibility issues on larger applications";
         }
 
         return snippet;

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/reloading/SpringBootDevTools.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/reloading/SpringBootDevTools.java
@@ -19,13 +19,18 @@
 package org.grails.forge.feature.reloading;
 
 import jakarta.inject.Singleton;
+import org.grails.forge.application.ApplicationType;
 import org.grails.forge.application.generator.GeneratorContext;
 import org.grails.forge.build.dependencies.Dependency;
 import org.grails.forge.build.dependencies.Scope;
+import org.grails.forge.feature.DefaultFeature;
+import org.grails.forge.feature.Feature;
+import org.grails.forge.options.Options;
 
+import java.util.Set;
 
 @Singleton
-public class SpringBootDevTools implements ReloadingFeature {
+public class SpringBootDevTools implements ReloadingFeature, DefaultFeature {
     @Override
     public String getName() {
         return "spring-boot-devtools";
@@ -55,7 +60,17 @@ public class SpringBootDevTools implements ReloadingFeature {
     }
 
     @Override
+    public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
+        return true;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
     public String getDocumentation() {
-        return "https://docs.spring.io/spring-boot/docs/2.7.12/reference/htmlsingle/#using.devtools";
+        return "https://docs.spring.io/spring-boot/reference/using/devtools.html";
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -842,6 +842,11 @@ class GrailsGradlePlugin extends GroovyPlugin {
                     SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
                     it.classpath = mainSourceSet.runtimeClasspath + project.configurations.getByName('console')
                     it.systemProperty(Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName()))
+
+                    // devtools' automatic restart mechanism uses a specialized classloader setup, which can interfere
+                    // with Grails' plugin management and bean wiring when running CLI scripts via Gradle
+                    it.systemProperty 'spring.devtools.restart.enabled', 'false'
+
                     List<Object> args = []
                     def otherArgs = project.findProperty('args')
                     if (otherArgs) {
@@ -868,6 +873,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
                     SourceSet mainSourceSet = SourceSets.findMainSourceSet(project)
                     it.classpath = mainSourceSet.runtimeClasspath + project.configurations.getByName('console')
                     it.systemProperty(Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.getName()))
+
+                    // devtools' automatic restart mechanism uses a specialized classloader setup, which can interfere
+                    // with Grails' plugin management and bean wiring when running CLI commands via Gradle
+                    it.systemProperty 'spring.devtools.restart.enabled', 'false'
 
                     List<Object> args = []
                     def otherArgs = project.findProperty('args')


### PR DESCRIPTION
This matches the default in Grails 5.x.x and Grails 6.2.1+, for grails-shell generated applications.

This PR also resolves a conflict between spring boot dev tools and runCommand and runScript gradle tasks.

https://github.com/apache/grails-core/issues/13523
https://github.com/apache/grails-core/issues/13509
https://github.com/apache/grails-core/issues/11588