### PR TITLE
Add non-default, optional virtual thread feature to Forge for Java 24+

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootVirtualThreads.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootVirtualThreads.java
@@ -21,12 +21,8 @@ package org.grails.forge.feature.spring;
 import jakarta.inject.Singleton;
 import org.grails.forge.application.ApplicationType;
 import org.grails.forge.application.generator.GeneratorContext;
-import org.grails.forge.feature.Feature;
-import org.grails.forge.feature.config.ConfigurationFeature;
-import org.grails.forge.options.Options;
 
 import java.util.Map;
-import java.util.Set;
 
 @Singleton
 public class SpringBootVirtualThreads implements SpringThreadingFeature {

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootVirtualThreads.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootVirtualThreads.java
@@ -1,0 +1,71 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.forge.feature.spring;
+
+import jakarta.inject.Singleton;
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.application.generator.GeneratorContext;
+import org.grails.forge.feature.Feature;
+import org.grails.forge.feature.config.ConfigurationFeature;
+import org.grails.forge.options.Options;
+
+import java.util.Map;
+import java.util.Set;
+
+@Singleton
+public class SpringBootVirtualThreads implements SpringThreadingFeature {
+
+    @Override
+    public String getName() {
+        return "spring-boot-virtual-threads";
+    }
+
+    @Override
+    public String getTitle() {
+        return "Spring Boot Virtual Threads";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Enables Virtual Threads in Spring Boot for JDK 24+.";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        Map<String, Object> config = generatorContext.getConfiguration();
+
+        // Enable by default only for JDK 24+
+        config.put("spring.threads.virtual.enabled", generatorContext.getJdkVersion().majorVersion() >= 24);
+    }
+
+    @Override
+    public boolean isVisible() {
+        return true;
+    }
+
+    @Override
+    public String getDocumentation() {
+        return "https://docs.spring.io/spring-boot/reference/features/spring-application.html#features.spring-application.virtual-threads";
+    }
+}

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringThreadingFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringThreadingFeature.java
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.forge.feature.spring;
+
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.feature.Category;
+import org.grails.forge.feature.OneOfFeature;
+
+public interface SpringThreadingFeature extends OneOfFeature {
+
+    @Override
+    default Class<?> getFeatureClass() {
+        return SpringThreadingFeature.class;
+    }
+
+    @Override
+    default boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    default String getCategory() {
+        return Category.SPRING;
+    }
+}

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
@@ -104,7 +104,7 @@ public class GrailsGsp implements DefaultFeature {
                 .groupId("org.apache.grails")
                 .artifactId("grails-gsp")
                 .implementation());
-        if(!generatorContext.isFeaturePresent(Sitemesh3.class)) {
+        if (!generatorContext.isFeaturePresent(Sitemesh3.class)) {
             generatorContext.addDependency(Dependency.builder()
                     .groupId("org.apache.grails")
                     .artifactId("grails-layout")

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
@@ -31,7 +31,9 @@ import java.util.stream.Collectors;
 public enum JdkVersion {
     JDK_17(17),
     JDK_21(21),
-    JDK_23(23);
+    // 24 is the current non-LTS release and will be replaced by 25 (LTS) in Sep 2025
+    // Spring Framework 6.2.x and Spring Boot 3.5.x will support 25
+    JDK_24(24);
 
     public static final JdkVersion DEFAULT_OPTION = JDK_17;
 

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootVirtualThreadsSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootVirtualThreadsSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.forge.feature.spring
+
+import org.grails.forge.BeanContextSpec
+import org.grails.forge.application.generator.GeneratorContext
+import org.grails.forge.fixture.CommandOutputFixture
+import org.grails.forge.options.JdkVersion
+import org.grails.forge.options.Options
+import org.grails.forge.options.TestFramework
+
+class SpringBootVirtualThreadsSpec extends BeanContextSpec implements CommandOutputFixture {
+
+    void "test spring boot virtual threads not enabled for JDK 17, when optional feature selected"() {
+        when:
+        GeneratorContext commandContext = buildGeneratorContext(['spring-boot-virtual-threads'], new Options(TestFramework.DEFAULT_OPTION, JdkVersion.JDK_17))
+
+        then:
+        commandContext.configuration.get('spring.threads.virtual.enabled'.toString()) == false
+    }
+
+    void "test spring boot virtual threads enabled for JDK 24+, when optional feature selected"() {
+        when:
+        GeneratorContext commandContext = buildGeneratorContext(['spring-boot-virtual-threads'], new Options(TestFramework.DEFAULT_OPTION, JdkVersion.JDK_24))
+
+        then:
+        commandContext.configuration.get('spring.threads.virtual.enabled'.toString()) == true
+    }
+}


### PR DESCRIPTION
Adds `spring.threads.virtual.enabled` to application.yml.  Set to true for JDK 24+ and false for lower versions.

`spring.threads.virtual.enabled` technically works with JDK 21+, but 24+ is where it works well.  https://docs.spring.io/spring-boot/reference/features/spring-application.html#features.spring-application.virtual-threads