### PR TITLE
Issues-14899 fixes Documentation: Cleanup missing files

### DIFF
--- a/grails-data-hibernate5/docs/build.gradle
+++ b/grails-data-hibernate5/docs/build.gradle
@@ -64,7 +64,7 @@ tasks.named('asciidoctor', AsciidoctorTask) { AsciidoctorTask it ->
     it.jvm {
         jvmArgs('--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED')
     }
-    it.baseDirFollowsSourceDir()
+    it.baseDirFollowsSourceFile()
     it.sourceDir layout.projectDirectory.dir('src/docs/asciidoc')
     it.outputDir = layout.buildDirectory.dir('asciidoc/manual')
 


### PR DESCRIPTION
Fixes warnings from asciidoctor when running
    ./gradlew assemble

I am pretty sure the issue is when generating the sub-templates, fx.: https://docs.grails.org/latest/grails-data/hibernate5/manual/services/

that are assembled into the final documentation:
https://docs.grails.org/latest/grails-data/hibernate5/manual/#dataServices

The relative path (baseDir) was wrong when building the sub templates https://asciidoctor.github.io/asciidoctor-gradle-plugin/master/user-guide/#_task_configuration

Issue 14899:
    https://github.com/apache/grails-core/issues/14899