### PR TITLE
Fix plugin profile build issue by adjusting rest transform dependency

### DIFF
--- a/grails-profiles/base/profile.yml
+++ b/grails-profiles/base/profile.yml
@@ -43,6 +43,8 @@ dependencies:
       coords: "org.apache.grails:grails-core"
     - scope: implementation
       coords: "org.apache.grails:grails-i18n"
+    - scope: implementation
+      coords: "org.apache.grails:grails-rest-transforms"
     - scope: testImplementation
       coords: "org.apache.grails:grails-testing-support-datamapping"
     - scope: console

--- a/grails-profiles/rest-api-plugin/profile.yml
+++ b/grails-profiles/rest-api-plugin/profile.yml
@@ -37,8 +37,6 @@ dependencies:
     - scope: implementation
       coords: "org.apache.grails:grails-url-mappings"
     - scope: implementation
-      coords: "org.apache.grails:grails-rest-transforms"
-    - scope: implementation
       coords: "org.apache.grails:grails-codecs"
     - scope: implementation
       coords: "org.apache.grails:grails-interceptors"

--- a/grails-profiles/rest-api/profile.yml
+++ b/grails-profiles/rest-api/profile.yml
@@ -32,8 +32,6 @@ dependencies:
     - scope: implementation
       coords: "org.apache.grails:grails-url-mappings"
     - scope: implementation
-      coords: "org.apache.grails:grails-rest-transforms"
-    - scope: implementation
       coords: "org.apache.grails:grails-interceptors"
     - scope: implementation
       coords: "org.apache.grails:grails-services"

--- a/grails-profiles/web/profile.yml
+++ b/grails-profiles/web/profile.yml
@@ -36,8 +36,6 @@ dependencies:
     - scope: implementation
       coords: "org.apache.grails:grails-logging"
     - scope: implementation
-      coords: "org.apache.grails:grails-rest-transforms"
-    - scope: implementation
       coords: "org.apache.grails:grails-databinding"
     - scope: implementation
       coords: "org.apache.grails:grails-services"

--- a/grails-shell-cli/src/main/groovy/org/grails/cli/compiler/autoconfigure/GrailsCompilerAutoConfiguration.java
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/compiler/autoconfigure/GrailsCompilerAutoConfiguration.java
@@ -38,9 +38,9 @@ public class GrailsCompilerAutoConfiguration extends CompilerAutoConfiguration {
         dependencies.ifAnyMissingClasses("grails.boot.config.GrailsAutoConfiguration").add("grails-boot");
         dependencies.ifAnyMissingClasses("grails.core.DefaultGrailsApplication").add("grails-core");
         dependencies.add("grails-web");
-        dependencies.add("grails-plugin-i18n", "grails-plugin-codecs", "grails-plugin-controllers",
-                "grails-plugin-converters", "grails-plugin-databinding", "grails-plugin-interceptors", "grails-plugin-mimetypes",
-                "grails-plugin-rest", "grails-plugin-url-mappings");
+        dependencies.add("grails-i18n", "grails-codecs", "grails-controllers",
+                "grails-converters", "grails-databinding", "grails-interceptors", "grails-mimetypes",
+                "grails-rest-transforms", "grails-url-mappings");
         dependencies.add("gsp", "plain", "jar", true);
     }
 


### PR DESCRIPTION
- Moves org.apache.grails:grails-rest-transforms to the base profile, so all profiles include it, this matches grails-forge
- Updates core plugin artifactids in GrailsCompilerAutoConfiguration.java, not sure how these were still using the old artifactids

Resolves:

./grails create-plugin testplugin
./gradlew build

```
> Task :compileGroovy FAILED
startup failed:
/Users/xxx/work/dc/tmp_2/grails-app/init/test/common/BootStrap.groovy: 3: unable to resolve class jakarta.servlet.ServletContext
 @ line 3, column 1.
   import jakarta.servlet.ServletContext
```

There are still outstanding dependency differences when generating a plugin from shell vs forge that will be ironed out for 7.0.0:  https://github.com/apache/grails-core/issues/14944