### PR TITLE
fix: remove ServletContext from generated and test BootStrap.groovy files

### DIFF
--- a/grails-data-graphql/plugin/grails-app/init/gorm/graphql/BootStrap.groovy
+++ b/grails-data-graphql/plugin/grails-app/init/gorm/graphql/BootStrap.groovy
@@ -21,7 +21,7 @@ package gorm.graphql
 
 class BootStrap {
 
-    def init = { servletContext ->
+    def init = {
     }
     def destroy = {
     }

--- a/grails-data-neo4j/examples/grails3-neo4j-hibernate/grails-app/init/BootStrap.groovy
+++ b/grails-data-neo4j/examples/grails3-neo4j-hibernate/grails-app/init/BootStrap.groovy
@@ -19,7 +19,7 @@
 
 class BootStrap {
 
-    def init = { servletContext ->
+    def init = {
     }
     def destroy = {
     }

--- a/grails-data-neo4j/examples/grails3-neo4j/grails-app/init/BootStrap.groovy
+++ b/grails-data-neo4j/examples/grails3-neo4j/grails-app/init/BootStrap.groovy
@@ -19,7 +19,7 @@
 
 class BootStrap {
 
-    def init = { servletContext ->
+    def init = {
     }
     def destroy = {
     }

--- a/grails-data-neo4j/examples/test-data-service/grails-app/init/example/BootStrap.groovy
+++ b/grails-data-neo4j/examples/test-data-service/grails-app/init/example/BootStrap.groovy
@@ -21,7 +21,7 @@ package example
 
 class BootStrap {
 
-    def init = { servletContext ->
+    def init = {
     }
     def destroy = {
     }

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -408,3 +408,11 @@ These limits can be customized using `server.tomcat.max-part-count` and `server.
 `server.tomcat.max-part-header-size` defalt is 512B
 
 https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.server.server.tomcat.max-part-count[Spring Boot Common Application Properties]
+
+===== 12.16 servletContext no longer included by default in generated Bootstrap init{}
+
+The `servletContext` is no longer included by default in the generated `Bootstrap` class. If you need access to the `servletContext`, you can inject it into your `Bootstrap` class using:
+
+```console
+ServletContext servletContext
+```

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/lang/groovy/bootStrap.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/lang/groovy/bootStrap.rocker.raw
@@ -23,11 +23,7 @@ under the License.
 
 package @project.getPackageName()
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-profiles/base/skeleton/grails-app/init/@grails.codegen.defaultPackage.path@/BootStrap.groovy
+++ b/grails-profiles/base/skeleton/grails-app/init/@grails.codegen.defaultPackage.path@/BootStrap.groovy
@@ -1,10 +1,6 @@
 package @grails.codegen.defaultPackage@
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/app1/grails-app/init/functionaltests/BootStrap.groovy
+++ b/grails-test-examples/app1/grails-app/init/functionaltests/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package functionaltests
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
         Book.withTransaction {

--- a/grails-test-examples/app2/grails-app/init/BootStrap.groovy
+++ b/grails-test-examples/app2/grails-app/init/BootStrap.groovy
@@ -17,11 +17,7 @@
  *  under the License.
  */
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/app3/grails-app/init/app3/BootStrap.groovy
+++ b/grails-test-examples/app3/grails-app/init/app3/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package app3
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/demo33/grails-app/init/demo/BootStrap.groovy
+++ b/grails-test-examples/demo33/grails-app/init/demo/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package demo
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/gorm/grails-app/init/gorm/BootStrap.groovy
+++ b/grails-test-examples/gorm/grails-app/init/gorm/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package gorm
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
         Book.withTransaction {

--- a/grails-test-examples/hibernate5/grails-data-service/grails-app/init/example/BootStrap.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service/grails-app/init/example/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package example
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/hyphenated/grails-app/init/BootStrap.groovy
+++ b/grails-test-examples/hyphenated/grails-app/init/BootStrap.groovy
@@ -17,11 +17,7 @@
  *  under the License.
  */
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/issue-11102/grails-app/init/issue11102/BootStrap.groovy
+++ b/grails-test-examples/issue-11102/grails-app/init/issue11102/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package issue11102
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/issue-698-domain-save-npe/grails-app/init/BootStrap.groovy
+++ b/grails-test-examples/issue-698-domain-save-npe/grails-app/init/BootStrap.groovy
@@ -17,11 +17,7 @@
  *  under the License.
  */
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/issue-views-182/grails-app/init/issueviews182/BootStrap.groovy
+++ b/grails-test-examples/issue-views-182/grails-app/init/issueviews182/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package issueviews182
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/micronaut/grails-app/init/micronaut/BootStrap.groovy
+++ b/grails-test-examples/micronaut/grails-app/init/micronaut/BootStrap.groovy
@@ -21,8 +21,6 @@ package micronaut
 
 class BootStrap {
 
-    ServletContext servletContext
-
     def init = {
     }
     

--- a/grails-test-examples/mongodb/base/grails-app/init/BootStrap.groovy
+++ b/grails-test-examples/mongodb/base/grails-app/init/BootStrap.groovy
@@ -18,11 +18,8 @@
  */
 
 import functional.tests.*
-import jakarta.servlet.ServletContext
 
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     	Book.DB.drop()

--- a/grails-test-examples/mongodb/database-per-tenant/grails-app/init/BootStrap.groovy
+++ b/grails-test-examples/mongodb/database-per-tenant/grails-app/init/BootStrap.groovy
@@ -17,12 +17,10 @@
  *  under the License.
  */
 
-import jakarta.servlet.ServletContext
 import org.grails.datastore.mapping.mongo.MongoDatastore
 
 class BootStrap {
 
-    ServletContext servletContext
     MongoDatastore mongoDatastore
 
     def init = {

--- a/grails-test-examples/mongodb/gson-templates/grails-app/init/BootStrap.groovy
+++ b/grails-test-examples/mongodb/gson-templates/grails-app/init/BootStrap.groovy
@@ -18,12 +18,9 @@
  */
 
 import groovy.transform.CompileStatic
-import jakarta.servlet.ServletContext
 
 @CompileStatic
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/mongodb/hibernate5/grails-app/init/BootStrap.groovy
+++ b/grails-test-examples/mongodb/hibernate5/grails-app/init/BootStrap.groovy
@@ -18,12 +18,8 @@
  */
 
 import functional.tests.*
-import jakarta.servlet.ServletContext
 
 class BootStrap {
-
-    ServletContext servletContext
-
     def init = {
     	Book.DB.drop()
     }

--- a/grails-test-examples/mongodb/test-data-service/grails-app/init/example/BootStrap.groovy
+++ b/grails-test-examples/mongodb/test-data-service/grails-app/init/example/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package example
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/plugins/issue11005/grails-app/init/issue11005/BootStrap.groovy
+++ b/grails-test-examples/plugins/issue11005/grails-app/init/issue11005/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package issue11005
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }

--- a/grails-test-examples/plugins/loadafter/grails-app/init/loadafter/BootStrap.groovy
+++ b/grails-test-examples/plugins/loadafter/grails-app/init/loadafter/BootStrap.groovy
@@ -19,11 +19,7 @@
 
 package loadafter
 
-import jakarta.servlet.ServletContext
-
 class BootStrap {
-
-    ServletContext servletContext
 
     def init = {
     }


### PR DESCRIPTION
Resolves:  https://github.com/apache/grails-core/pull/14961#issue-3300689110

`jakarta.servlet:jakarta.servlet-api` is being provided by the following:

https://github.com/apache/grails-core/blob/0c0cfe8fc1eecc4d3881dacd9106af060b24bd1c/grails-controllers/build.gradle#L41

https://github.com/apache/grails-core/blob/0c0cfe8fc1eecc4d3881dacd9106af060b24bd1c/grails-gsp/grails-web-taglib/build.gradle#L38

https://github.com/apache/grails-core/blob/0c0cfe8fc1eecc4d3881dacd9106af060b24bd1c/grails-console/build.gradle#L47

https://github.com/apache/grails-core/blob/0c0cfe8fc1eecc4d3881dacd9106af060b24bd1c/grails-testing-support-web/build.gradle#L40