### PR TITLE
Forge publish - Add workaround so that release builds do not require signing credentials

### DIFF
--- a/.github/workflows/forge-deploy-next.yml
+++ b/.github/workflows/forge-deploy-next.yml
@@ -35,7 +35,7 @@ jobs:
       - name: "🔨 Build"
         working-directory: grails-forge
         run: ./gradlew build
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
@@ -72,7 +72,7 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
@@ -82,7 +82,7 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
@@ -128,7 +128,7 @@ jobs:
       - name: "🏃 Run tests"
         working-directory: grails-forge
         run: ./gradlew grails-forge-analytics-postgres:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
@@ -138,7 +138,7 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |

--- a/.github/workflows/forge-deploy-next.yml
+++ b/.github/workflows/forge-deploy-next.yml
@@ -35,6 +35,8 @@ jobs:
       - name: "🔨 Build"
         working-directory: grails-forge
         run: ./gradlew build
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
@@ -70,6 +72,8 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -78,6 +82,8 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
           docker push ${{ env.IMAGE_NAME }}
@@ -122,6 +128,8 @@ jobs:
       - name: "🏃 Run tests"
         working-directory: grails-forge
         run: ./gradlew grails-forge-analytics-postgres:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -130,6 +138,8 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
           docker push ${{ env.IMAGE_NAME }}

--- a/.github/workflows/forge-deploy-prev-snapshot.yml
+++ b/.github/workflows/forge-deploy-prev-snapshot.yml
@@ -35,7 +35,7 @@ jobs:
       - name: "🔨 Build"
         working-directory: grails-forge
         run: ./gradlew build
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
@@ -72,7 +72,7 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
@@ -82,7 +82,7 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
@@ -128,7 +128,7 @@ jobs:
       - name: "🏃 Run tests"
         working-directory: grails-forge
         run: ./gradlew grails-forge-analytics-postgres:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
@@ -138,7 +138,7 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |

--- a/.github/workflows/forge-deploy-prev-snapshot.yml
+++ b/.github/workflows/forge-deploy-prev-snapshot.yml
@@ -35,6 +35,8 @@ jobs:
       - name: "🔨 Build"
         working-directory: grails-forge
         run: ./gradlew build
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
@@ -70,6 +72,8 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -78,6 +82,8 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
           docker push ${{ env.IMAGE_NAME }}
@@ -122,6 +128,8 @@ jobs:
       - name: "🏃 Run tests"
         working-directory: grails-forge
         run: ./gradlew grails-forge-analytics-postgres:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -130,6 +138,8 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
           docker push ${{ env.IMAGE_NAME }}

--- a/.github/workflows/forge-deploy-prev.yml
+++ b/.github/workflows/forge-deploy-prev.yml
@@ -35,7 +35,7 @@ jobs:
       - name: "🔨 Build"
         working-directory: grails-forge
         run: ./gradlew build
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
@@ -72,7 +72,7 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
@@ -82,7 +82,7 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
@@ -128,7 +128,7 @@ jobs:
       - name: "🏃 Run tests"
         working-directory: grails-forge
         run: ./gradlew grails-forge-analytics-postgres:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
@@ -138,7 +138,7 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |

--- a/.github/workflows/forge-deploy-prev.yml
+++ b/.github/workflows/forge-deploy-prev.yml
@@ -35,6 +35,8 @@ jobs:
       - name: "🔨 Build"
         working-directory: grails-forge
         run: ./gradlew build
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
@@ -70,6 +72,8 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -78,6 +82,8 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
           docker push ${{ env.IMAGE_NAME }}
@@ -122,6 +128,8 @@ jobs:
       - name: "🏃 Run tests"
         working-directory: grails-forge
         run: ./gradlew grails-forge-analytics-postgres:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -130,6 +138,8 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
           docker push ${{ env.IMAGE_NAME }}

--- a/.github/workflows/forge-deploy-release.yml
+++ b/.github/workflows/forge-deploy-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: "🧩 Assemble"
         working-directory: grails-forge
         run: ./gradlew grails-cli:assemble
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
@@ -76,7 +76,7 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
@@ -86,7 +86,7 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         env:
@@ -133,7 +133,7 @@ jobs:
         run: >
           ./gradlew
           grails-forge-analytics-postgres:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
@@ -143,7 +143,7 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         env:

--- a/.github/workflows/forge-deploy-release.yml
+++ b/.github/workflows/forge-deploy-release.yml
@@ -41,6 +41,8 @@ jobs:
       - name: "🧩 Assemble"
         working-directory: grails-forge
         run: ./gradlew grails-cli:assemble
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
@@ -74,6 +76,8 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
         env:
@@ -82,6 +86,8 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         env:
           IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:${{ needs.build.outputs.release_version }}
@@ -127,6 +133,8 @@ jobs:
         run: >
           ./gradlew
           grails-forge-analytics-postgres:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
         env:
@@ -135,6 +143,8 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         env:
           IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ needs.build.outputs.release_version }}

--- a/.github/workflows/forge-deploy-snapshot.yml
+++ b/.github/workflows/forge-deploy-snapshot.yml
@@ -35,7 +35,7 @@ jobs:
       - name: "🔨 Build"
         working-directory: grails-forge
         run: ./gradlew build
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
@@ -72,7 +72,7 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
@@ -80,7 +80,7 @@ jobs:
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
@@ -126,7 +126,7 @@ jobs:
       - name: "🏃 Run tests"
         working-directory: grails-forge
         run: ./gradlew grails-forge-analytics-postgres:test
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
@@ -134,7 +134,7 @@ jobs:
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
-        with:
+        env:
           TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |

--- a/.github/workflows/forge-deploy-snapshot.yml
+++ b/.github/workflows/forge-deploy-snapshot.yml
@@ -35,6 +35,8 @@ jobs:
       - name: "🔨 Build"
         working-directory: grails-forge
         run: ./gradlew build
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
@@ -70,12 +72,16 @@ jobs:
           ./gradlew
           grails-forge-api:test
           grails-forge-web-netty:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
         run: >
           ./gradlew
           grails-forge-web-netty:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
           docker push ${{ env.IMAGE_NAME }}
@@ -120,12 +126,16 @@ jobs:
       - name: "🏃 Run tests"
         working-directory: grails-forge
         run: ./gradlew grails-forge-analytics-postgres:test
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
         run: >
           ./gradlew
           grails-forge-analytics-postgres:dockerBuildNative
           -PdockerImageName=${{ env.IMAGE_NAME }}
+        with:
+          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         run: |
           docker push ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
When a release version is present, we require signing unless 'TEST_BUILD_REPRODUCIBLE' is set to true.  This was the fix in the last milestone, but it needs merged into 7.0.x