### PR TITLE
Hide servlet features, should be selected via --servlet instead

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootEmbeddedServlet.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootEmbeddedServlet.java
@@ -33,4 +33,9 @@ abstract class SpringBootEmbeddedServlet implements OneOfFeature, DefaultFeature
     public String getCategory() {
         return Category.SERVER;
     }
+
+    @Override
+    public boolean isVisible() {
+        return false;
+    }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootJettyFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootJettyFeature.java
@@ -58,6 +58,6 @@ public class SpringBootJettyFeature extends SpringBootEmbeddedServlet {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return selectedFeatures.stream().anyMatch(f -> f instanceof SpringBootJettyFeature) || options.getServletImpl() == ServletImpl.JETTY;
+        return options.getServletImpl() == ServletImpl.JETTY;
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootTomcatFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootTomcatFeature.java
@@ -60,6 +60,6 @@ public class SpringBootTomcatFeature extends SpringBootEmbeddedServlet {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return selectedFeatures.stream().anyMatch(f -> f instanceof SpringBootTomcatFeature) || options.getServletImpl() == ServletImpl.TOMCAT;
+        return options.getServletImpl() == ServletImpl.TOMCAT;
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootUndertowFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootUndertowFeature.java
@@ -58,6 +58,6 @@ public class SpringBootUndertowFeature extends SpringBootEmbeddedServlet {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return selectedFeatures.stream().anyMatch(f -> f instanceof SpringBootUndertowFeature) || options.getServletImpl() == ServletImpl.UNDERTOW;
+        return options.getServletImpl() == ServletImpl.UNDERTOW;
     }
 }


### PR DESCRIPTION
the servlet container should be selected
via --servlet
jetty      none       tomcat     undertow

Selecting via features does not properly override ServletImpl