### PR TITLE
Include sources from composite builds in Groovydoc

### DIFF
--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -82,13 +82,36 @@ combinedGroovydoc.configure { Groovydoc gdoc ->
                 possibleSources
             }
             .flatten()
-    gdoc.source(sources.collect { SourceSet it -> [it.allSource.srcDirs, it.allSource.srcDirs] }.flatten().findAll { File srcDir ->
-        if (!(srcDir.name in ['java', 'groovy'])) {
-            return false
-        }
 
-        srcDir.exists()
-    }.unique())
+    List<File> baseSourceDirs = sources
+            .collect { SourceSet it -> it.allSource.srcDirs }
+            .flatten()
+            .findAll { File srcDir ->
+                if (!(srcDir.name in ['java', 'groovy'])) {
+                    return false
+                }
+                srcDir.exists()
+            }
+
+    // Collect source directories from included builds (composite builds)
+    // Gradle will not provide the included build projects or source sets, so we inspect the file system
+    List<File> includedBuildSourceDirs = gradle.includedBuilds
+            .collectMany { includedBuild ->
+                def sourceDirs = []
+                includedBuild.projectDir.eachDirRecurse { File dir ->
+                    ['src/main/java', 'src/main/groovy'].each { rel ->
+                        File sourceDir = new File(dir, rel)
+                        if (sourceDir.isDirectory()) {
+                            sourceDirs << sourceDir
+                        }
+                    }
+                }
+                sourceDirs
+            }
+
+    gdoc.source(project.files((baseSourceDirs + includedBuildSourceDirs).unique()))
+    // Exclude files that are not part of the public API and cause duplicate class errors when combined with other source sets
+    gdoc.exclude('org/grails/example/**', 'org.grails.example/**', 'another/**', 'TestJava**')
 
     gdoc.classpath = files(sources.collect { SourceSet it -> it.compileClasspath.filter(File.&isDirectory) }.flatten().unique())
     gdoc.destinationDir = project.layout.buildDirectory.dir('combined-api/api').get().asFile

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -98,7 +98,7 @@ combinedGroovydoc.configure { Groovydoc gdoc ->
     List<File> includedBuildSourceDirs = gradle.includedBuilds
             .collectMany { includedBuild ->
                 def sourceDirs = []
-                includedBuild.projectDir.eachDirRecurse { File dir ->
+                includedBuild.projectDir.eachDir { File dir ->
                     ['src/main/java', 'src/main/groovy'].each { rel ->
                         File sourceDir = new File(dir, rel)
                         if (sourceDir.isDirectory()) {
@@ -110,8 +110,6 @@ combinedGroovydoc.configure { Groovydoc gdoc ->
             }
 
     gdoc.source(project.files((baseSourceDirs + includedBuildSourceDirs).unique()))
-    // Exclude files that are not part of the public API and cause duplicate class errors when combined with other source sets
-    gdoc.exclude('org/grails/example/**', 'org.grails.example/**', 'another/**', 'TestJava**')
 
     gdoc.classpath = files(sources.collect { SourceSet it -> it.compileClasspath.filter(File.&isDirectory) }.flatten().unique())
     gdoc.destinationDir = project.layout.buildDirectory.dir('combined-api/api').get().asFile

--- a/grails-doc/src/en/guide/plugins/understandingPluginLoadOrder.adoc
+++ b/grails-doc/src/en/guide/plugins/understandingPluginLoadOrder.adoc
@@ -99,23 +99,14 @@ It's not only plugin load order that you can control. You can also specify which
 [source,groovy]
 ----
 def environments = ['development', 'test', 'myCustomEnv']
-def scopes = [excludes:'war']
 ----
 
-In this example, the plugin will only load in the 'development' and 'test' environments. Nor will it be packaged into the WAR file, because it's excluded from the 'war' phase. This allows `development-only` plugins to not be packaged for production use.
+In this example, the plugin will only load in the 'development' and 'test' environments.
 
-The full list of available scopes are defined by the enum link:{api}grails/util/BuildScope.html[BuildScope], but here's a summary:
-
-* `test` - when running tests
-* `functional-test` - when running functional tests
-* `run` - for run-app and run-war
-* `war` - when packaging the application as a WAR file
-* `all` - plugin applies to all scopes (default)
-
-Both properties can be one of:
+The properties can be one of:
 
 * a string - a sole inclusion
-* a list - a list of environments or scopes to include
+* a list - a list of environments to include
 * a map - for full control, with 'includes' and/or 'excludes' keys that can have string or list values
 
 For example,

--- a/grails-doc/src/en/guide/plugins/understandingPluginLoadOrder.adoc
+++ b/grails-doc/src/en/guide/plugins/understandingPluginLoadOrder.adoc
@@ -101,7 +101,7 @@ It's not only plugin load order that you can control. You can also specify which
 def environments = ['development', 'test', 'myCustomEnv']
 ----
 
-In this example, the plugin will only load in the 'development' and 'test' environments.
+In this example, the plugin will only load in the 'development', 'test' and 'myCustomEnv' environments.
 
 The properties can be one of:
 

--- a/grails-gradle/plugins/README.md
+++ b/grails-gradle/plugins/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 Grails Gradle Plugins
 ========
 
-Latest API Docs: https://grails.github.io/grails-gradle-plugin/latest/api/
+Latest API Docs: https://docs.grails.org/latest/api/
 
 Below are the plugins that are provided by the grails-gradle-plugin dependency.
 


### PR DESCRIPTION
Updated the Groovydoc configuration to collect source directories from included (composite) builds by inspecting the file system. This ensures documentation generation includes sources from all relevant projects, and adds exclusions to prevent duplicate class errors.

Remove `grails.util.BuildScope` documentation
`grails.util.BuildScope` was removed in Grails 4