### PR TITLE
Remove grails-publish plugin from build plugins

### DIFF
--- a/grails-profiles/rest-api-plugin/profile.yml
+++ b/grails-profiles/rest-api-plugin/profile.yml
@@ -26,7 +26,6 @@ features:
 build:
     plugins:
         - org.apache.grails.gradle.grails-plugin
-        - org.apache.grails.gradle.grails-publish
     excludes:
         - org.apache.grails.gradle.grails-app
         - org.apache.grails.gradle.grails-web


### PR DESCRIPTION
The org.apache.grails.gradle.grails-publish plugin has been removed from the build plugins list in profile.yml.  None of the other plugin profiles or forge generated plugin types include this plugin