### PR TITLE
Add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Reformat code: https://github.com/apache/grails-core/pull/14925
+20c3278683f2993e23c947c409eafa978c0aefb7

--- a/gradle/rat-root-config.gradle
+++ b/gradle/rat-root-config.gradle
@@ -27,6 +27,7 @@ tasks.named('rat') {
             'CHECKSUMS', // build artifact for storing checksums for easy verification
             'PUBLISHED_ARTIFACTS', // build artifact for storing published artifacts coordinates & paths
             'licenses/**', // licenses directory excluded
+            '.git-blame-ignore-revs', // git configuration isn't code
             'grails-web-common/src/main/groovy/org/grails/web/json/JSONObject.java',
             'grails-web-common/src/main/groovy/org/grails/web/json/JSONArray.java',
             'grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java',


### PR DESCRIPTION
Commit hashes in `.git-blame-ignore-revs` will be excluded when using `git blame`.
Commit hash for code format commit added: 20c3278683f2993e23c947c409eafa978c0aefb7