### PR TITLE
grails-wrapper: Fix ClosureCompleter initialization in GradleCommand

### DIFF
--- a/grails-shell-cli/src/main/groovy/org/grails/cli/gradle/commands/GradleCommand.groovy
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/gradle/commands/GradleCommand.groovy
@@ -77,7 +77,7 @@ class GradleCommand implements ProjectCommand, Completer, ProjectContextAware {
     private void initializeCompleter() {
         if (completer == null && projectContext) {
             readTasks = new ReadGradleTasks(projectContext)
-            completer = new ClosureCompleter((Closure<Collection<String>>) readTasks.call())
+            completer = new ClosureCompleter((Closure<Collection<String>>) { readTasks.call() })
         }
     }
 

--- a/grails-shell-cli/src/main/groovy/org/grails/cli/gradle/commands/GradleCommand.groovy
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/gradle/commands/GradleCommand.groovy
@@ -77,7 +77,7 @@ class GradleCommand implements ProjectCommand, Completer, ProjectContextAware {
     private void initializeCompleter() {
         if (completer == null && projectContext) {
             readTasks = new ReadGradleTasks(projectContext)
-            completer = new ClosureCompleter((Closure<Collection<String>>) { readTasks.call() })
+            completer = new ClosureCompleter({ -> readTasks.call() } as Closure<Collection<String>>)
         }
     }
 


### PR DESCRIPTION
Revert recent changes to initializeCompleter()

I believe this will resolve the following when starting the grails-wrapper:

```
 ./grailsw --stacktrace
Updating Grails wrapper, allowed versions to update to are [RELEASE,RC,MILESTONE,SNAPSHOT]...
...A Grails snapshot version has been detected. Downloading latest snapshot.
... Using Snapshot URL: https://repository.apache.org/content/groups/public/org/apache/grails/grails-cli/7.0.0-SNAPSHOT/grails-cli-7.0.0-20250826.201132-129-all.jar
...  92% (21.88 MiB/s)
...Moving remotely downloaded jar to: C:\Users\james\.grails\wrapper\7.0.0-SNAPSHOT\grails-cli-7.0.0-SNAPSHOT-all.jar
Updated wrapper to version: 7.0.0-SNAPSHOT
]' with class 'java.util.ArrayList' to class 'groovy.lang.Closure' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: groovy.lang.Closure(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) (NOTE: Stack trace has been filtered. Use --verbose to see entire trace.)
]' with class 'java.util.ArrayList' to class 'groovy.lang.Closure' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: groovy.lang.Closure(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, St
ring, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)
        at org.grails.cli.gradle.commands.GradleCommand.initializeCompleter(GradleCommand.groovy:80)
        at org.grails.cli.gradle.commands.GradleCommand.setProjectContext(GradleCommand.groovy:53)
        at org.grails.cli.profile.AbstractProfile$_getCommands_closure7.doCall(AbstractProfile.groovy:424)
        at org.grails.cli.profile.AbstractProfile.getCommands(AbstractProfile.groovy:432)
        at org.grails.cli.profile.repository.AbstractJarProfileRepository$JarProfile.getCommands(AbstractJarProfileRepository.groovy:135)
        at org.grails.cli.profile.AbstractProfile.getCompleters(AbstractProfile.groovy:362)
        at org.grails.cli.GrailsCli.setupCompleters(GrailsCli.groovy:407)
        at org.grails.cli.GrailsCli.handleInteractiveMode(GrailsCli.groovy:389)
        at org.grails.cli.GrailsCli.execute(GrailsCli.groovy:279)
        at org.grails.cli.GrailsCli.main(GrailsCli.groovy:169)
        at org.apache.grails.cli.DelegatingShellApplication.main(DelegatingShellApplication.groovy:42)
        at grails.init.Start.main(Start.java:77)
]] reason: java.lang.InstantiationExceptionmeException: failed to invoke constructor: public groovy.lang.Closure(java.lang.Object) with arguments: [[artifactTransforms
                at org.codehaus.groovy.reflection.CachedConstructor.createException(CachedConstructor.java:96)
                at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:67)
                at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:60)
                at groovy.lang.MetaClassImpl.invokeConstructor(MetaClassImpl.java:1891)
                at groovy.lang.MetaClassImpl.invokeConstructor(MetaClassImpl.java:1679)
                at org.codehaus.groovy.runtime.InvokerHelper.invokeConstructorOf(InvokerHelper.java:676)
                at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnSAM(DefaultTypeTransformation.java:389)
                at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnNumber(DefaultTypeTransformation.java:326)
                at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(DefaultTypeTransformation.java:244)
                at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
                at org.grails.cli.gradle.commands.GradleCommand.initializeCompleter(GradleCommand.groovy:80)
                at org.grails.cli.gradle.commands.GradleCommand.setProjectContext(GradleCommand.groovy:53)
                at org.grails.cli.profile.AbstractProfile$_getCommands_closure7.doCall(AbstractProfile.groovy:424)
                at jdk.internal.reflect.GeneratedMethodAccessor14.invoke(Unknown Source)
                at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                at java.base/java.lang.reflect.Method.invoke(Method.java:569)
                at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
                at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
                at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:280)
                at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1007)
                at groovy.lang.Closure.call(Closure.java:433)
                at groovy.lang.Closure.call(Closure.java:422)
                at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2394)
                at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2379)
                at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2408)
                at org.grails.cli.profile.AbstractProfile.getCommands(AbstractProfile.groovy:432)
                at org.grails.cli.profile.repository.AbstractJarProfileRepository$JarProfile.getCommands(AbstractJarProfileRepository.groovy:135)
                at org.grails.cli.profile.AbstractProfile.getCompleters(AbstractProfile.groovy:362)
                at org.grails.cli.GrailsCli.setupCompleters(GrailsCli.groovy:407)
                at org.grails.cli.GrailsCli.handleInteractiveMode(GrailsCli.groovy:389)
                at org.grails.cli.GrailsCli.execute(GrailsCli.groovy:279)
                at org.grails.cli.GrailsCli.main(GrailsCli.groovy:169)
                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
                at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                at java.base/java.lang.reflect.Method.invoke(Method.java:569)
                at org.apache.grails.cli.DelegatingShellApplication.main(DelegatingShellApplication.groovy:42)
                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
                at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                at java.base/java.lang.reflect.Method.invoke(Method.java:569)
                ... 1 more
        Caused by: java.lang.InstantiationException
                ... 41 more
]' with class 'java.util.ArrayList' to class 'groovy.lang.Closure' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: groovy.lang.Closure(String, String, String, String, String, S
tring, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String
, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Str
ing, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, 
String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Strin
g, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, St
ring, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)
PS C:\Users\james\Downloads\demo (63)\demo> 
```