### PR TITLE
Add detailed documentation for standard Grails application profiles

### DIFF
--- a/grails-doc/src/en/guide/index.adoc
+++ b/grails-doc/src/en/guide/index.adoc
@@ -270,10 +270,10 @@ include::commandLine/creatingCustomCommands.adoc[]
 
 include::profiles.adoc[]
 
-[[defaultProfiles]]
-=== Default Grails Profiles
+[[standardProfiles]]
+=== Standard Grails Profiles
 
-include::profiles/defaultProfiles.adoc[]
+include::profiles/standardProfiles.adoc[]
 
 [[webProfile]]
 ==== Web Profile

--- a/grails-doc/src/en/guide/index.adoc
+++ b/grails-doc/src/en/guide/index.adoc
@@ -270,6 +270,41 @@ include::commandLine/creatingCustomCommands.adoc[]
 
 include::profiles.adoc[]
 
+[[defaultProfiles]]
+=== Default Grails Profiles
+
+include::profiles/defaultProfiles.adoc[]
+
+[[webProfile]]
+==== Web Profile
+
+include::profiles/webProfile.adoc[]
+
+[[restAPIProfile]]
+==== REST API Profile
+
+include::profiles/restAPIProfile.adoc[]
+
+[[pluginProfile]]
+==== Plugin Profile
+
+include::profiles/pluginProfile.adoc[]
+
+[[webPluginProfile]]
+==== Web Plugin Profile
+
+include::profiles/webPluginProfile.adoc[]
+
+[[restAPIPluginProfile]]
+==== REST API Plugin Profile
+
+include::profiles/restAPIPluginProfile.adoc[]
+
+[[profileProfile]]
+==== Profile Profile
+
+include::profiles/profileProfile.adoc[]
+
 [[creatingProfiles]]
 === Creating Profiles
 

--- a/grails-doc/src/en/guide/profiles/defaultProfiles.adoc
+++ b/grails-doc/src/en/guide/profiles/defaultProfiles.adoc
@@ -1,0 +1,58 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+Grails provides a set of default application profiles that serve as foundational templates for generating various types of projects.
+These profiles encapsulate specific commands, templates, plugins, and configurations tailored to different development needs, allowing developers to quickly generate applications or plugins with predefined structures.
+The profiles are resolved from Maven Central by default.
+
+Default profiles include `base`, `web`, `rest-api`, `plugin`, `web-plugin`, `rest-api-plugin` and `profile`. Most extend from other profiles to promote reusability and consistency.
+
+Available profiles can be listed, when not inside a Grails' project directory:
+
+[source,bash]
+----
+$ grails list-plugins
+----
+
+[source,bash]
+----
+| Available Profiles
+--------------------
+* base - The base profile extended by other profiles
+* plugin - Profile for plugins designed to work across all profiles
+* profile - A profile for creating new Grails profiles
+* rest-api - Profile for REST API applications
+* rest-api-plugin - Profile for REST API plugins
+* web - Profile for Web applications
+* web-plugin - Profile for Plugins designed for Web applications
+----
+
+The `base` profile acts as the foundational layer extended by most other profiles, providing essential skeleton directories, core dependencies, and basic commands that form the backbone of any Grails project.
+It ensures a standardized starting point without imposing specific application paradigms.
+
+For application development, the `web` profile is the default when creating a new Grails app, optimized for full-stack web applications with features like GSP views, controllers, and the asset pipeline.
+The `rest-api` profile, on the other hand, targets REST API-centric projects, emphasizing RESTful endpoints, JSON handling, and configurations suitable for backend services.
+
+The `plugin` profile is designed for creating reusable plugins that can integrate across various Grails applications.
+Similarly, the `web-plugin` profile focuses on plugins tailored specifically for web applications, inheriting from the web and plugin profiles.
+The `rest-api-plugin` profile is specialized for developing plugins that provide REST API functionality, inheriting from the rest-api and plugin profiles, enabling the creation of modular, reusable components focused on API endpoints.
+
+Lastly, the `profile` profile is intended for developers creating custom profiles.
+
+These profiles collectively enable flexible project generation while maintaining Grails' convention-over-configuration philosophy.

--- a/grails-doc/src/en/guide/profiles/pluginProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/pluginProfile.adoc
@@ -1,0 +1,93 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+To create an application using the `plugin` profile:
+
+[source, bash]
+----
+grails create-plugin myplugin
+----
+
+The above statement is equivalent to:
+
+[source, bash]
+----
+grails create-app myplugin --profile=plugin
+----
+
+To get information about the profile and available features, when not inside a Grails' project directory:
+
+[source, bash]
+----
+grails profile-info plugin
+----
+
+You will see an output similar to:
+
+[source, bash]
+----
+Profile: plugin
+--------------------
+Profile for plugins designed to work across all profiles
+
+Provided Commands:
+--------------------
+* install - Installs a plugin into the local Maven cache
+* package-plugin - Packages the plugin into a JAR file
+* publish-plugin - Publishes the plugin to the Grails central repository
+* help - Prints help information for a specific command
+* url-mappings-report - Prints out a report of the project's URL mappings
+* open - Opens a file in the project
+* gradle - Allows running of Gradle tasks
+* clean - Cleans a Grails application's compiled sources
+* compile - Compiles a Grails application
+* create-command - Creates an Application Command
+* create-domain-class - Creates a Domain Class
+* create-unit-test - Creates a unit test
+* assemble - Creates a JAR or WAR archive for production deployment
+* test-app - Runs the applications tests
+* run-command - Executes Grails commands
+* console - Runs the Grails interactive console
+* run-script - Executes Groovy scripts in a Grails context
+* stop-app - Stops the running Grails application
+* stats - Prints statistics about the project
+* plugin-info - Prints information about the given plugin
+* create-script - Creates a Grails script
+* bug-report - Creates a zip file that can be attached to issue reports for the current project
+* run-app - Runs a Grails application
+* dependency-report - Prints out the Grails application's dependencies
+* list-plugins - Lists available plugins from the Plugin Repository
+* shell - Runs the Grails interactive shell
+
+Provided Features:
+--------------------
+* asset-pipeline-plugin - Adds Asset Pipeline to a Grails Plugin for packaging
+* maven-publish - Publish Artifacts to Maven Central
+* asset-pipeline - Adds Asset Pipeline to a Grails project
+* events - Adds support for the Grails EventBus abstraction
+* geb2 - Adds Geb dependencies to run functional tests.
+* gsp - Adds support for GSP to the project
+* hibernate5 - Adds GORM for Hibernate 5 to the project
+* json-views - Adds support for JSON Views to the project
+* less-asset-pipeline - Adds LESS Transpiler Asset Pipeline to a Grails project
+* markup-views - Adds support for Markup Views to the project
+* mongodb - Adds GORM for MongoDB to the project
+* neo4j - Adds GORM for Neo4j to the project
+* rx-mongodb - Adds RxGORM for MongoDB to the project
+----

--- a/grails-doc/src/en/guide/profiles/profileProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/profileProfile.adoc
@@ -1,0 +1,94 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+To create an application using the `profile` profile:
+
+[source, bash]
+----
+grails create-profile myprofile
+----
+
+The above statement is equivalent to:
+
+[source, bash]
+----
+grails create-app myprofile --profile=profile
+----
+
+To get information about the profile and available features, when not inside a Grails' project directory:
+
+[source, bash]
+----
+grails profile-info profile
+----
+
+You will see an output similar to:
+
+[source, bash]
+----
+Profile: profile
+--------------------
+A profile for creating new Grails profiles
+
+Provided Commands:
+--------------------
+* install - Installs a profile into the local Maven cache
+* help - Prints help information for a specific command
+* url-mappings-report - Prints out a report of the project's URL mappings
+* open - Opens a file in the project
+* gradle - Allows running of Gradle tasks
+* clean - Cleans a Grails application's compiled sources
+* compile - Compiles a Grails application
+* create-command - Creates a new command for the profile
+* create-domain-class - Creates a Domain Class
+* create-unit-test - Creates a unit test
+* assemble - Creates a JAR or WAR archive for production deployment
+* test-app - Runs the applications tests
+* run-command - Executes Grails commands
+* console - Runs the Grails interactive console
+* run-script - Executes Groovy scripts in a Grails context
+* stop-app - Stops the running Grails application
+* stats - Prints statistics about the project
+* plugin-info - Prints information about the given plugin
+* create-script - Creates a Grails script
+* bug-report - Creates a zip file that can be attached to issue reports for the current project
+* run-app - Runs a Grails application
+* dependency-report - Prints out the Grails application's dependencies
+* list-plugins - Lists available plugins from the Plugin Repository
+* shell - Runs the Grails interactive shell
+* create-creator-command - Creates a new create-* command for the profile
+* create-feature - Creates a new profile feature
+* create-generator-command - Creates a new generate-* command for the profile
+* create-template - Creates a new template for the profile
+* create-gradle-command - Creates a new command that invokes Gradle for the profile
+
+Provided Features:
+--------------------
+* asset-pipeline - Adds Asset Pipeline to a Grails project
+* events - Adds support for the Grails EventBus abstraction
+* geb2 - Adds Geb dependencies to run functional tests.
+* gsp - Adds support for GSP to the project
+* hibernate5 - Adds GORM for Hibernate 5 to the project
+* json-views - Adds support for JSON Views to the project
+* less-asset-pipeline - Adds LESS Transpiler Asset Pipeline to a Grails project
+* markup-views - Adds support for Markup Views to the project
+* mongodb - Adds GORM for MongoDB to the project
+* neo4j - Adds GORM for Neo4j to the project
+* rx-mongodb - Adds RxGORM for MongoDB to the project
+----

--- a/grails-doc/src/en/guide/profiles/publishingProfiles.adoc
+++ b/grails-doc/src/en/guide/profiles/publishingProfiles.adoc
@@ -36,8 +36,8 @@ grailsPublish {
         license {
             name = 'Apache-2.0'
         }
-        title = 'My plugin title'
-        desc = 'My plugin description'
+        title = 'My profile title'
+        desc = 'My profile description'
         developers = [johndoe: 'John Doe']
     }
 ----

--- a/grails-doc/src/en/guide/profiles/restAPIPluginProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/restAPIPluginProfile.adoc
@@ -1,0 +1,99 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+To create an application using the `rest-api-plugin` profile:
+
+[source, bash]
+----
+grails create-app myplugin --profile=rest-api-plugin
+----
+
+To get information about the profile and available features, when not inside a Grails' project directory:
+
+[source, bash]
+----
+grails profile-info rest-api-plugin
+----
+
+You will see an output similar to:
+
+[source, bash]
+----
+Profile: rest-api-plugin
+--------------------
+Profile for REST API plugins
+
+Provided Commands:
+--------------------
+* help - Prints help information for a specific command
+* url-mappings-report - Prints out a report of the project's URL mappings
+* open - Opens a file in the project
+* gradle - Allows running of Gradle tasks
+* install - Installs a plugin into the local Maven cache
+* package-plugin - Packages the plugin into a JAR file
+* publish-plugin - Publishes the plugin to the Grails central repository
+* clean - Cleans a Grails application's compiled sources
+* compile - Compiles a Grails application
+* create-command - Creates an Application Command
+* create-domain-class - Creates a Domain Class
+* create-unit-test - Creates a unit test
+* assemble - Creates a JAR or WAR archive for production deployment
+* test-app - Runs the applications tests
+* run-command - Executes Grails commands
+* console - Runs the Grails interactive console
+* run-script - Executes Groovy scripts in a Grails context
+* stop-app - Stops the running Grails application
+* stats - Prints statistics about the project
+* plugin-info - Prints information about the given plugin
+* create-script - Creates a Grails script
+* bug-report - Creates a zip file that can be attached to issue reports for the current project
+* run-app - Runs a Grails application
+* dependency-report - Prints out the Grails application's dependencies
+* list-plugins - Lists available plugins from the Plugin Repository
+* shell - Runs the Grails interactive shell
+* create-controller - Creates a controller
+* create-domain-resource - Creates a domain class that represents a resource
+* create-functional-test - Creates an functional test
+* create-integration-test - Creates an integration test
+* create-interceptor - Creates an interceptor
+* create-restful-controller - Creates a REST controller
+* create-service - Creates a Service
+* generate-all - Generates a controller that performs REST operations
+* generate-controller - Generates a controller that performs REST operations
+* generate-functional-test - Generates a functional test for a controller that performs REST operations
+* generate-views - Generates a controller that performs REST operations
+* generate-unit-test - Generates a unit test for a controller that performs REST operations
+
+Provided Features:
+--------------------
+* asset-pipeline-plugin - Adds Asset Pipeline to a Grails Plugin for packaging
+* maven-publish - Publish Artifacts to Maven Central
+* asset-pipeline - Adds Asset Pipeline to a Grails project
+* events - Adds support for the Grails EventBus abstraction
+* geb2 - Adds Geb dependencies to run functional tests.
+* gsp - Adds support for GSP to the project
+* hibernate5 - Adds GORM for Hibernate 5 to the project
+* json-views - Adds support for JSON Views to the project
+* less-asset-pipeline - Adds LESS Transpiler Asset Pipeline to a Grails project
+* markup-views - Adds support for Markup Views to the project
+* mongodb - Adds GORM for MongoDB to the project
+* neo4j - Adds GORM for Neo4j to the project
+* rx-mongodb - Adds RxGORM for MongoDB to the project
+* security - Adds Spring Security REST to the project
+----

--- a/grails-doc/src/en/guide/profiles/restAPIProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/restAPIProfile.adoc
@@ -1,0 +1,94 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+To create an application using the `rest-api` profile:
+
+[source, bash]
+----
+grails create-app myapp --profile=rest-api
+----
+
+To get information about the profile and available features, when not inside a Grails' project directory:
+
+[source, bash]
+----
+grails profile-info rest-api
+----
+
+You will see an output similar to:
+
+[source, bash]
+----
+Profile: rest-api
+--------------------
+Profile for REST API applications
+
+Provided Commands:
+--------------------
+* create-controller - Creates a controller
+* create-domain-resource - Creates a domain class that represents a resource
+* create-functional-test - Creates an functional test
+* create-integration-test - Creates an integration test
+* create-interceptor - Creates an interceptor
+* create-restful-controller - Creates a REST controller
+* create-service - Creates a Service
+* help - Prints help information for a specific command
+* url-mappings-report - Prints out a report of the project's URL mappings
+* open - Opens a file in the project
+* gradle - Allows running of Gradle tasks
+* clean - Cleans a Grails application's compiled sources
+* compile - Compiles a Grails application
+* create-command - Creates an Application Command
+* create-domain-class - Creates a Domain Class
+* create-unit-test - Creates a unit test
+* assemble - Creates a JAR or WAR archive for production deployment
+* test-app - Runs the applications tests
+* run-command - Executes Grails commands
+* console - Runs the Grails interactive console
+* run-script - Executes Groovy scripts in a Grails context
+* stop-app - Stops the running Grails application
+* stats - Prints statistics about the project
+* plugin-info - Prints information about the given plugin
+* create-script - Creates a Grails script
+* bug-report - Creates a zip file that can be attached to issue reports for the current project
+* run-app - Runs a Grails application
+* dependency-report - Prints out the Grails application's dependencies
+* list-plugins - Lists available plugins from the Plugin Repository
+* shell - Runs the Grails interactive shell
+* generate-all - Generates a controller that performs REST operations
+* generate-functional-test - Generates a functional test for a controller that performs REST operations
+* generate-views - Generates a controller that performs REST operations
+* generate-unit-test - Generates a unit test for a controller that performs REST operations
+* generate-controller - Generates a controller that performs REST operations
+
+Provided Features:
+--------------------
+* security - Adds Spring Security REST to the project
+* asset-pipeline - Adds Asset Pipeline to a Grails project
+* events - Adds support for the Grails EventBus abstraction
+* geb2 - Adds Geb dependencies to run functional tests.
+* gsp - Adds support for GSP to the project
+* hibernate5 - Adds GORM for Hibernate 5 to the project
+* json-views - Adds support for JSON Views to the project
+* less-asset-pipeline - Adds LESS Transpiler Asset Pipeline to a Grails project
+* markup-views - Adds support for Markup Views to the project
+* mongodb - Adds GORM for MongoDB to the project
+* neo4j - Adds GORM for Neo4j to the project
+* rx-mongodb - Adds RxGORM for MongoDB to the project
+----

--- a/grails-doc/src/en/guide/profiles/standardProfiles.adoc
+++ b/grails-doc/src/en/guide/profiles/standardProfiles.adoc
@@ -17,11 +17,11 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-Grails provides a set of default application profiles that serve as foundational templates for generating various types of projects.
+Grails provides a set of standard application profiles that serve as foundational templates for generating various types of projects.
 These profiles encapsulate specific commands, templates, plugins, and configurations tailored to different development needs, allowing developers to quickly generate applications or plugins with predefined structures.
-The profiles are resolved from Maven Central by default.
+The standard profiles are resolved from Maven Central.
 
-Default profiles include `base`, `web`, `rest-api`, `plugin`, `web-plugin`, `rest-api-plugin` and `profile`. Most extend from other profiles to promote reusability and consistency.
+Standard profiles include `base`, `web`, `rest-api`, `plugin`, `web-plugin`, `rest-api-plugin` and `profile`. Most extend from other profiles to promote reusability and consistency.
 
 Available profiles can be listed, when not inside a Grails' project directory:
 

--- a/grails-doc/src/en/guide/profiles/standardProfiles.adoc
+++ b/grails-doc/src/en/guide/profiles/standardProfiles.adoc
@@ -27,7 +27,7 @@ Available profiles can be listed, when not inside a Grails' project directory:
 
 [source,bash]
 ----
-$ grails list-plugins
+$ grails list-profiles
 ----
 
 [source,bash]

--- a/grails-doc/src/en/guide/profiles/webPluginProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/webPluginProfile.adoc
@@ -1,0 +1,98 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+To create an application using the `web-plugin` profile:
+
+[source, bash]
+----
+grails create-web-plugin myplugin
+----
+
+The above statement is equivalent to:
+
+[source, bash]
+----
+grails create-app myplugin --profile=web-plugin
+----
+
+To get information about the profile and available features, when not inside a Grails' project directory:
+
+[source, bash]
+----
+grails profile-info web-plugin
+----
+
+You will see an output similar to:
+
+[source, bash]
+----
+Profile: web-plugin
+--------------------
+Profile for Plugins designed for Web applications
+
+Provided Commands:
+--------------------
+* help - Prints help information for a specific command
+* url-mappings-report - Prints out a report of the project's URL mappings
+* open - Opens a file in the project
+* gradle - Allows running of Gradle tasks
+* create-controller - Creates a controller
+* create-integration-test - Creates an integration test
+* create-interceptor - Creates an interceptor
+* create-service - Creates a Service
+* create-taglib - Creates a Tag Library
+* clean - Cleans a Grails application's compiled sources
+* compile - Compiles a Grails application
+* create-command - Creates an Application Command
+* create-domain-class - Creates a Domain Class
+* create-unit-test - Creates a unit test
+* assemble - Creates a JAR or WAR archive for production deployment
+* test-app - Runs the applications tests
+* run-command - Executes Grails commands
+* console - Runs the Grails interactive console
+* run-script - Executes Groovy scripts in a Grails context
+* stop-app - Stops the running Grails application
+* stats - Prints statistics about the project
+* plugin-info - Prints information about the given plugin
+* create-script - Creates a Grails script
+* bug-report - Creates a zip file that can be attached to issue reports for the current project
+* run-app - Runs a Grails application
+* dependency-report - Prints out the Grails application's dependencies
+* list-plugins - Lists available plugins from the Plugin Repository
+* shell - Runs the Grails interactive shell
+* install - Installs a plugin into the local Maven cache
+* package-plugin - Packages the plugin into a JAR file
+* publish-plugin - Publishes the plugin to the Grails central repository
+
+Provided Features:
+--------------------
+* asset-pipeline - Adds Asset Pipeline to a Grails project
+* events - Adds support for the Grails EventBus abstraction
+* geb2 - Adds Geb dependencies to run functional tests.
+* gsp - Adds support for GSP to the project
+* hibernate5 - Adds GORM for Hibernate 5 to the project
+* json-views - Adds support for JSON Views to the project
+* less-asset-pipeline - Adds LESS Transpiler Asset Pipeline to a Grails project
+* markup-views - Adds support for Markup Views to the project
+* mongodb - Adds GORM for MongoDB to the project
+* neo4j - Adds GORM for Neo4j to the project
+* rx-mongodb - Adds RxGORM for MongoDB to the project
+* asset-pipeline-plugin - Adds Asset Pipeline to a Grails Plugin for packaging
+* maven-publish - Publish Artifacts to Maven Central
+----

--- a/grails-doc/src/en/guide/profiles/webProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/webProfile.adoc
@@ -1,0 +1,93 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+To create an application using the `web` profile:
+
+[source, bash]
+----
+grails create-app myapp
+----
+
+`web` is the default profile. The above statement is equivalent to:
+
+[source, bash]
+----
+grails create-app myapp --profile=web
+----
+
+To get information about the profile and available features, when not inside a Grails' project directory:
+
+[source, bash]
+----
+grails profile-info web
+----
+
+You will see an output similar to:
+
+[source, bash]
+----
+Profile: web
+--------------------
+Profile for Web applications
+
+Provided Commands:
+--------------------
+* create-controller - Creates a controller
+* create-integration-test - Creates an integration test
+* create-interceptor - Creates an interceptor
+* create-service - Creates a Service
+* create-taglib - Creates a Tag Library
+* help - Prints help information for a specific command
+* url-mappings-report - Prints out a report of the project's URL mappings
+* open - Opens a file in the project
+* gradle - Allows running of Gradle tasks
+* clean - Cleans a Grails application's compiled sources
+* compile - Compiles a Grails application
+* create-command - Creates an Application Command
+* create-domain-class - Creates a Domain Class
+* create-unit-test - Creates a unit test
+* assemble - Creates a JAR or WAR archive for production deployment
+* test-app - Runs the applications tests
+* run-command - Executes Grails commands
+* console - Runs the Grails interactive console
+* run-script - Executes Groovy scripts in a Grails context
+* stop-app - Stops the running Grails application
+* stats - Prints statistics about the project
+* plugin-info - Prints information about the given plugin
+* create-script - Creates a Grails script
+* bug-report - Creates a zip file that can be attached to issue reports for the current project
+* run-app - Runs a Grails application
+* dependency-report - Prints out the Grails application's dependencies
+* list-plugins - Lists available plugins from the Plugin Repository
+* shell - Runs the Grails interactive shell
+
+Provided Features:
+--------------------
+* asset-pipeline - Adds Asset Pipeline to a Grails project
+* events - Adds support for the Grails EventBus abstraction
+* geb2 - Adds Geb dependencies to run functional tests.
+* gsp - Adds support for GSP to the project
+* hibernate5 - Adds GORM for Hibernate 5 to the project
+* json-views - Adds support for JSON Views to the project
+* less-asset-pipeline - Adds LESS Transpiler Asset Pipeline to a Grails project
+* markup-views - Adds support for Markup Views to the project
+* mongodb - Adds GORM for MongoDB to the project
+* neo4j - Adds GORM for Neo4j to the project
+* rx-mongodb - Adds RxGORM for MongoDB to the project
+----

--- a/grails-doc/src/en/guide/toc.yml
+++ b/grails-doc/src/en/guide/toc.yml
@@ -83,8 +83,8 @@ commandLine:
     gradlePlugins: Grails plugins for Gradle
 profiles:
   title: Application Profiles
-  defaultProfiles:
-    title: Default Profiles
+  standardProfiles:
+    title: Standard Profiles
     webProfile: Web Profile
     restAPIProfile: REST API Profile
     pluginProfile: Plugin Profile

--- a/grails-doc/src/en/guide/toc.yml
+++ b/grails-doc/src/en/guide/toc.yml
@@ -83,6 +83,14 @@ commandLine:
     gradlePlugins: Grails plugins for Gradle
 profiles:
   title: Application Profiles
+  defaultProfiles:
+    title: Default Profiles
+    webProfile: Web Profile
+    restAPIProfile: REST API Profile
+    pluginProfile: Plugin Profile
+    webPluginProfile: Web Plugin Profile
+    restAPIPluginProfile: REST API Plugin Profile
+    profileProfile: Profile Profile
   creatingProfiles: Creating Profiles
   profileInheritance: Profile Inheritance
   publishingProfiles: Publishing Profiles


### PR DESCRIPTION
Introduces new documentation sections and files for each standard Grails application profile, including web, REST API, plugin, web-plugin, rest-api-plugin, and profile profiles.

Resolves:  https://github.com/apache/grails-core/issues/14695