### PR TITLE
ci: use `grails-forge` as base dir for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: gradle
-    directories:
-      - "/"
-      - "/grails-forge"
+    directory: "/grails-forge"
     schedule:
       interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
This will hopefully resolve `grails-core` and `grails-gradle` as well.