### PR TITLE
Explicitly type render(object) to help IntelliJ ambiguous method overloading

### DIFF
--- a/grails-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -130,7 +130,7 @@ trait ResponseRenderer extends WebAttributes {
      * @param object The object to render
      */
     @Generated
-    void render(object) {
+    void render(Object object) {
         GrailsWebRequest webRequest = (GrailsWebRequest) RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
         webRequest.renderView = false


### PR DESCRIPTION
@matrei @jamesfredley Later versions of intellij show render() calls with a map as an ambiguous method call.  Testing locally, it seems that intellij prefers (Object object) instead of just (object).  What are your thoughts about making this change? It shouldn't matter for groovy / compiler, but it seems to help IntelliJ.