### PR TITLE
Update to Asset Pipeline 5.0.16

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -25,7 +25,7 @@ ext {
             'ant.version'                   : '1.10.15',
             'asciidoctor-gradle-jvm.version': '4.0.5',
             'asciidoctorj.version'          : '3.0.0',
-            'asset-pipeline-gradle.version' : '5.0.15',
+            'asset-pipeline-gradle.version' : '5.0.16',
             'byte-buddy.version'            : '1.17.7',
             'commons-text.version'          : '1.13.1',
             'directory-watcher.version'     : '0.19.1',
@@ -72,7 +72,7 @@ ext {
     ]
 
     bomDependencyVersions = [
-            'asset-pipeline-bom.version'  : '5.0.15',
+            'asset-pipeline-bom.version'  : '5.0.16',
             'bootstrap-icons.version'     : '1.13.1',
             'bootstrap.version'           : '5.3.7',
             'commons-codec.version'       : '1.18.0',

--- a/grails-forge/grails-forge-cli/src/test/groovy/org/grails/forge/cli/CommandSpec.groovy
+++ b/grails-forge/grails-forge-cli/src/test/groovy/org/grails/forge/cli/CommandSpec.groovy
@@ -70,6 +70,7 @@ class CommandSpec extends Specification {
         String[] args = builder.toString().split(' ')
         ProcessBuilder pb = new ProcessBuilder(args)
         pb.environment().put('JAVA_HOME', System.getenv('JAVA_HOME') ?: System.getProperty('java.home'))
+        pb.environment().put('GRAILS_REPO_URL', System.getenv('GRAILS_REPO_URL') ?: null)
         process = pb.directory(dir).start()
         process.consumeProcessOutputStream(output)
         process

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsDefaultPlugins.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsDefaultPlugins.java
@@ -55,7 +55,7 @@ public class GrailsDefaultPlugins implements DefaultFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        Arrays.asList("rest-transforms", "databinding", "i18n", "services", "url-mappings", "interceptors")
+        Arrays.asList("rest-transforms", "databinding", "services", "url-mappings", "interceptors")
                 .forEach((artifact) -> {
                     generatorContext.addDependency(Dependency.builder()
                             .groupId("org.apache.grails")


### PR DESCRIPTION
As a follow-up to https://github.com/apache/grails-core/pull/14953, since we depend on the asset pipeline, the coordinate change for grails-i18n broke forge.  This should resolve it once 5.0.16 is findable on maven central.