### PR TITLE
Update grails-publish-plugin version to 0.0.1-SNAPSHOT

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
             'commons-text.version'          : '1.13.1',
             'directory-watcher.version'     : '0.19.1',
             'gradle-spock.version'          : '2.3-groovy-3.0',
-            'grails-publish-plugin.version' : '0.0.1',
+            'grails-publish-plugin.version' : '0.0.1-SNAPSHOT',
             'grails-gdoc-engine.version'    : '1.0.1',
             'jansi.version'                 : '1.18',
             'javaparser-core.version'       : '3.27.0',


### PR DESCRIPTION
Changed the grails-publish-plugin version from 0.0.1 to 0.0.1-SNAPSHOT in dependencies.gradle until 0.0.1 is fully released