### PR TITLE
fix: remove leftover `grails-doc` plugin declaration

### DIFF
--- a/grails-gradle/plugins/build.gradle
+++ b/grails-gradle/plugins/build.gradle
@@ -62,12 +62,6 @@ gradlePlugin {
             id = 'org.apache.grails.gradle.grails-app'
             implementationClass = 'org.grails.gradle.plugin.core.GrailsGradlePlugin'
         }
-        grailsDoc {
-            displayName = 'Grails Doc Gradle Plugin'
-            description = 'Adds Grails doc publishing support'
-            id = 'org.apache.grails.gradle.grails-docs'
-            implementationClass = 'org.grails.gradle.plugin.doc.GrailsDocGradlePlugin'
-        }
         grailsGsp {
             displayName = 'Grails GSP Gradle Plugin'
             description = 'A plugin that adds support for compiling Groovy Server Pages (GSP)'


### PR DESCRIPTION
`grails-doc` Gradle plugin was removed in gh-14834 (59bead022ae19141df508da9be2d05cc801a0a6b).