### PR TITLE
fix: wrapper should only consider release types that are a higher priority than the wrapper version when packaged

### DIFF
--- a/grails-wrapper/build.gradle
+++ b/grails-wrapper/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     testImplementation 'org.apache.groovy:groovy-test-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.platform:junit-platform-runner'
+    // for easier setting of environment variables in tests
+    testImplementation 'uk.org.webcompere:system-stubs-core:2.1.8'
 }
 
 apply {

--- a/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
+++ b/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
@@ -16,14 +16,23 @@
  */
 package grails.init;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Assists in parsing grails versions and sorting them by priority
  */
 public class GrailsVersion implements Comparable<GrailsVersion> {
+
     private static final Pattern VERSION_PATTERN = Pattern.compile("^(\\d+)[.](\\d+)[.](\\d+)-?(.*)$");
 
     private static final Pattern RC = Pattern.compile("^RC(\\d+)$");
@@ -40,7 +49,7 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
     /**
      * @param version the grails version number
      */
-    GrailsVersion(String version) {
+    public GrailsVersion(String version) {
         this.version = version;
 
         Matcher matcher = VERSION_PATTERN.matcher(version);
@@ -62,27 +71,110 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
         if (candidateString.isEmpty()) {
             releaseType = GrailsReleaseType.RELEASE;
             candidate = null;
-        }
-        else if ((m = RC.matcher(candidateString)).matches()) {
+        } else if ((m = RC.matcher(candidateString)).matches()) {
             releaseType = GrailsReleaseType.RC;
             candidate = Integer.parseInt(m.group(1));
-        }
-        else if ((m = MILESTONE.matcher(candidateString)).matches()) {
+        } else if ((m = MILESTONE.matcher(candidateString)).matches()) {
             releaseType = GrailsReleaseType.MILESTONE;
             candidate = Integer.parseInt(m.group(1));
-        }
-        else if ((m = SNAPSHOT.matcher(candidateString)).matches()) {
+        } else if (SNAPSHOT.matcher(candidateString).matches()) {
             releaseType = GrailsReleaseType.SNAPSHOT;
             candidate = null;
-        }
-        else {
+        } else {
             throw new IllegalArgumentException("Invalid Candidate Version: " + candidateString);
         }
     }
 
+    public static LinkedHashSet<GrailsReleaseType> getAllowedReleaseTypes(GrailsVersion preferredVersion, GrailsWrapper wrapper) {
+        String raw = System.getenv("GRAILS_WRAPPER_ALLOWED_TYPES");
+        if (raw == null || raw.trim().isEmpty()) {
+            if (preferredVersion != null) {
+                //inside a grails project pull the equivalent version type or newer
+                return preferredVersion.releaseType.upTo();
+            } else {
+                String grailsVersion = wrapper.getVersion();
+                if (grailsVersion == null) {
+                    // the only time this version isn't defined is when it comes from a non-jar file, which should
+                    // only be in development of the wrapper
+                    System.out.println("Detected running from a non-jar file, assuming local grails-core development...");
+                    return new LinkedHashSet<>(List.of(GrailsReleaseType.SNAPSHOT));
+                }
+
+                GrailsVersion myVersion = new GrailsVersion(grailsVersion);
+                if (myVersion.releaseType != GrailsReleaseType.RELEASE) {
+                    return new LinkedHashSet<>(myVersion.releaseType.upTo());
+                }
+
+                // Only consider releases of this wrapper
+                return new LinkedHashSet<>(List.of(GrailsReleaseType.RELEASE));
+            }
+        }
+
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .map(input -> {
+                    try {
+                        return GrailsReleaseType.valueOf(input);
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Invalid Value in GRAILS_WRAPPER_ALLOWED_TYPES: " + input);
+                    }
+                })
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public static GrailsVersion getPreferredGrailsVersion() {
+        // Check for a properties file in case inside a grails project
+        File gradleProperties = new File("gradle.properties");
+        if (!gradleProperties.exists()) {
+            return null;
+        }
+
+        Properties properties = new Properties();
+        try (InputStream in = new FileInputStream(gradleProperties)) {
+            properties.load(in);
+        } catch (Exception e) {
+            System.err.println("Failed to load gradle.properties from " + gradleProperties);
+            e.printStackTrace();
+            System.exit(1);
+        }
+
+        if (!properties.containsKey("grailsVersion")) {
+            return null;
+        }
+
+        String grailsVersion = properties.getProperty("grailsVersion");
+        if (grailsVersion == null) {
+            String overrideGrailsVersion = System.getenv("PREFERRED_GRAILS_VERSION");
+            if (overrideGrailsVersion != null) {
+                try {
+                    return new GrailsVersion(overrideGrailsVersion);
+                } catch (Exception e) {
+                    System.out.println("An invalid Grails Version [" + overrideGrailsVersion + "] was specified in PREFERRED_GRAILS_VERSION");
+                    e.printStackTrace();
+                    System.exit(1);
+                }
+            }
+
+            System.out.println("gradle.properties does not contain grailsVersion; assuming latest Grails Version");
+            return null;
+        }
+
+        try {
+            return new GrailsVersion(grailsVersion);
+        } catch (Exception e) {
+            System.out.println("An invalid Grails Version [" + grailsVersion + "] was specified in gradle.properties");
+            e.printStackTrace();
+            System.exit(1);
+        }
+
+        return null;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         GrailsVersion that = (GrailsVersion) o;
         return Objects.equals(releaseType, that.releaseType) &&
                 Objects.equals(major, that.major) &&

--- a/grails-wrapper/src/main/java/grails/init/GrailsWrapper.java
+++ b/grails-wrapper/src/main/java/grails/init/GrailsWrapper.java
@@ -1,0 +1,82 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package grails.init;
+
+import java.lang.reflect.Method;
+import java.net.Authenticator;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
+
+import grails.proxy.SystemPropertiesAuthenticator;
+
+/**
+ * The purpose of this class is to download the expanded Grails wrapper jars into GRAILS_WRAPPER_HOME (defaults to `.grails` in the user home folder)
+ * This class is not meant to be distributed as part of SDKMAN since we'll distribute the expanded jars with it.
+ * After downloading the jars, it will delegate to the downloaded grails-cli project.
+ * <p>
+ * There are 3 ways this class can be used:
+ * 1. in testing a grails release (run from a non-project directory) - requires GRAILS_REPO_URL set to `~/.m2/repository`
+ * 2. running from a non-project directory (end user usage)
+ * 3. running from inside a grails project
+ */
+public class GrailsWrapper {
+
+    public GrailsWrapper() {
+        Authenticator.setDefault(new SystemPropertiesAuthenticator());
+    }
+
+    public void execute(String[] args) throws Exception {
+        GrailsVersion preferredGrailsVersion = GrailsVersion.getPreferredGrailsVersion();
+        LinkedHashSet<GrailsReleaseType> allowedTypes = GrailsVersion.getAllowedReleaseTypes(preferredGrailsVersion, this);
+
+        GrailsUpdater updater = new GrailsUpdater(allowedTypes, preferredGrailsVersion);
+        boolean forceUpdate = (args.length > 0 && args[0].trim().equals("update-wrapper"));
+
+        boolean updated = false;
+        String[] adjustedArgs = args;
+        if (forceUpdate || updater.needsUpdating()) {
+            String allowTypesString = allowedTypes.stream().map(GrailsReleaseType::name).collect(Collectors.joining(","));
+            System.out.printf("Updating Grails wrapper, allowed versions to update to are [%s]...%n", allowTypesString);
+
+            updated = updater.update();
+
+            // remove "update-wrapper" command argument
+            if (forceUpdate) {
+                adjustedArgs = Arrays.copyOfRange(args, 1, args.length);
+            }
+        }
+
+        if (updated) {
+            System.out.println("Updated wrapper to version: " + updater.getSelectedVersion().toString());
+        }
+
+        URLClassLoader child = new URLClassLoader(new URL[]{updater.getExecutedJarFile().toURI().toURL()});
+        Class<?> classToLoad = Class.forName("org.apache.grails.cli.DelegatingShellApplication", true, child);
+        Method main = classToLoad.getMethod("main", String[].class);
+        main.invoke(null, (Object) adjustedArgs);
+    }
+
+    /**
+     * @return the version of the packaged wrapper, if not packaged null
+     */
+    public String getVersion() {
+        return Start.class.getPackage().getImplementationVersion();
+    }
+}

--- a/grails-wrapper/src/main/java/grails/init/Start.java
+++ b/grails-wrapper/src/main/java/grails/init/Start.java
@@ -16,149 +16,16 @@
  */
 package grails.init;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.lang.reflect.Method;
-import java.net.Authenticator;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Properties;
-import java.util.stream.Collectors;
-
-import grails.proxy.SystemPropertiesAuthenticator;
-
-/**
- * The purpose of this class is to download the expanded Grails wrapper jars into GRAILS_WRAPPER_HOME (`.grails` in the project root)
- * This class is not meant to be distributed as part of SDKMAN since we'll distribute the expanded jars with it.
- * After downloading the jars, it will delegate to the downloaded grails-cli project.
- * <p>
- * There are 3 ways this class can be used:
- * 1. in testing a grails release (run from a non-project directory) - requires GRAILS_REPO_URL set to `~/.m2/repository`
- * 2. running from a non-project directory (end user usage)
- * 3. running from inside a grails project
- */
 public class Start {
 
     public static void main(String[] args) {
-        Authenticator.setDefault(new SystemPropertiesAuthenticator());
-
         try {
-            GrailsVersion preferredGrailsVersion = getPreferredGrailsVersion();
-            LinkedHashSet<GrailsReleaseType> allowedTypes = getAllowedReleaseTypes(preferredGrailsVersion);
-
-            GrailsUpdater updater = new GrailsUpdater(allowedTypes, preferredGrailsVersion);
-            boolean forceUpdate = (args.length > 0 && args[0].trim().equals("update-wrapper"));
-
-            boolean updated = false;
-            String[] adjustedArgs = args;
-            if (forceUpdate || updater.needsUpdating()) {
-                String allowTypesString = allowedTypes.stream().map(GrailsReleaseType::name).collect(Collectors.joining(","));
-                System.out.printf("Updating Grails wrapper, allowed versions to update to are [%s]...%n", allowTypesString);
-
-                updated = updater.update();
-
-                // remove "update-wrapper" command argument
-                if (forceUpdate) {
-                    adjustedArgs = Arrays.copyOfRange(args, 1, args.length);
-                }
-            }
-
-            if (updated) {
-                System.out.println("Updated wrapper to version: " + updater.getSelectedVersion().toString());
-            }
-
-            URLClassLoader child = new URLClassLoader(new URL[]{updater.getExecutedJarFile().toURI().toURL()});
-            Class<?> classToLoad = Class.forName("org.apache.grails.cli.DelegatingShellApplication", true, child);
-            Method main = classToLoad.getMethod("main", String[].class);
-            main.invoke(null, (Object) adjustedArgs);
+            GrailsWrapper wrapper = new GrailsWrapper();
+            wrapper.execute(args);
         } catch (Exception e) {
+            System.out.println("Unable to execute Grails Wrapper: " + e.getMessage());
             e.printStackTrace();
             System.exit(1);
         }
-    }
-
-    private static GrailsVersion getPreferredGrailsVersion() {
-        // Check for a properties file in case inside a grails project
-        File gradleProperties = new File("gradle.properties");
-        if (!gradleProperties.exists()) {
-            return null;
-        }
-
-        Properties properties = new Properties();
-        try (InputStream in = new FileInputStream(gradleProperties)) {
-            properties.load(in);
-        }
-        catch (Exception e) {
-            System.err.println("Failed to load gradle.properties from " + gradleProperties);
-            e.printStackTrace();
-            System.exit(1);
-        }
-
-        if (!properties.containsKey("grailsVersion")) {
-            return null;
-        }
-
-        String grailsVersion = properties.getProperty("grailsVersion");
-        if (grailsVersion == null) {
-            System.out.println("gradle.properties does not contain grailsVersion; downloading latest Grails Version");
-
-            String overrideGrailsVersion = System.getenv("PREFERRED_GRAILS_VERSION");
-            if (overrideGrailsVersion != null) {
-                try {
-                    return new GrailsVersion(overrideGrailsVersion);
-                } catch (Exception e) {
-                    System.out.println("An invalid Grails Version [" + overrideGrailsVersion + "] was specified in PREFERRED_GRAILS_VERSION");
-                    e.printStackTrace();
-                    System.exit(1);
-                }
-            }
-
-            return null;
-        }
-
-        try {
-            return new GrailsVersion(grailsVersion);
-        }
-        catch (Exception e) {
-            System.out.println("An invalid Grails Version [" + grailsVersion + "] was specified in gradle.properties");
-            e.printStackTrace();
-            System.exit(1);
-        }
-
-        return null;
-    }
-
-    private static LinkedHashSet<GrailsReleaseType> getAllowedReleaseTypes(GrailsVersion preferredVersion) {
-        String raw = System.getenv("GRAILS_WRAPPER_ALLOWED_TYPES");
-        if (raw == null || raw.trim().isEmpty()) {
-            if (preferredVersion != null) {
-                //inside a grails project pull the equivalent version type or newer
-                return preferredVersion.releaseType.upTo();
-            } else {
-                String grailsVersion = Start.class.getPackage().getImplementationVersion();
-                if (grailsVersion == null) {
-                    // the only time this version isn't defined is when it comes from a non-jar file, which should
-                    // only be in development
-                    return new LinkedHashSet<>(List.of(GrailsReleaseType.SNAPSHOT));
-                }
-
-                GrailsVersion myVersion = new GrailsVersion(grailsVersion);
-                if (myVersion.releaseType != GrailsReleaseType.RELEASE) {
-                    return new LinkedHashSet<>(List.of(GrailsReleaseType.values()));
-                }
-
-                // Only consider releases unless this wrapper
-                return new LinkedHashSet<>(List.of(GrailsReleaseType.RELEASE));
-            }
-        }
-
-        return new LinkedHashSet<>(Arrays.stream(raw.split(","))
-                .map(String::trim)
-                .map(GrailsReleaseType::valueOf)
-                .collect(Collectors.toList()));
     }
 }

--- a/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
+++ b/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
@@ -20,8 +20,150 @@ package grails.init
 
 import spock.lang.Specification
 import spock.lang.Unroll
+import uk.org.webcompere.systemstubs.SystemStubs
 
 class GrailsVersionSpec extends Specification {
+
+    def "allowed release types - specified valid"() {
+        given:
+        GrailsWrapper mockVersion = Mock(GrailsWrapper)
+
+        when:
+        Set<GrailsReleaseType> allowedTypes = null
+        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', 'SNAPSHOT, RC').execute {
+            allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
+        }
+
+        then:
+        noExceptionThrown()
+
+        and:
+        allowedTypes == [GrailsReleaseType.SNAPSHOT, GrailsReleaseType.RC] as LinkedHashSet
+
+        and:
+        0 * mockVersion._
+    }
+
+    def "allowed release types - specified invalid"() {
+        given:
+        GrailsWrapper mockVersion = Mock(GrailsWrapper)
+
+        when:
+        Set<GrailsReleaseType> allowedTypes = null
+        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', 'SNAPSHOT, FOO').execute {
+            allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
+        }
+
+        then:
+        def ie = thrown(IllegalStateException)
+        ie.message == 'Invalid Value in GRAILS_WRAPPER_ALLOWED_TYPES: FOO'
+
+        and:
+        0 * mockVersion._
+    }
+
+    def "allowed release types - with preferred version defined and allowed types override"() {
+        given:
+        GrailsWrapper mockVersion = Mock(GrailsWrapper)
+
+        and:
+        GrailsVersion preferredVersion = new GrailsVersion('7.0.0-RC1')
+
+        when:
+        Set<GrailsReleaseType> allowedTypes = null
+        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', 'SNAPSHOT, RC').execute {
+            allowedTypes = GrailsVersion.getAllowedReleaseTypes(preferredVersion, mockVersion)
+        }
+
+        then:
+        noExceptionThrown()
+
+        and: 'due to override, both are returned'
+        allowedTypes == [GrailsReleaseType.SNAPSHOT, GrailsReleaseType.RC] as LinkedHashSet
+
+        and:
+        0 * mockVersion._
+    }
+
+    def "allowed release types - with preferred version defined and no types override"() {
+        given:
+        GrailsWrapper mockVersion = Mock(GrailsWrapper)
+
+        and:
+        GrailsVersion preferredVersion = new GrailsVersion('7.0.0-M1')
+
+        when:
+        Set<GrailsReleaseType> allowedTypes = null
+        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', null).execute {
+            allowedTypes = GrailsVersion.getAllowedReleaseTypes(preferredVersion, mockVersion)
+        }
+
+        then:
+        noExceptionThrown()
+
+        and:
+        allowedTypes == [GrailsReleaseType.RELEASE, GrailsReleaseType.RC, GrailsReleaseType.MILESTONE] as LinkedHashSet
+
+        and:
+        0 * mockVersion._
+    }
+
+    def "allowed release types - no preferred version - development"() {
+        given:
+        GrailsWrapper mockVersion = Mock(GrailsWrapper) {
+            1 * getVersion() >> '7.0.0-SNAPSHOT'
+        }
+
+        when:
+        Set<GrailsReleaseType> allowedTypes = null
+        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', null).execute {
+            allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
+        }
+
+        then:
+        noExceptionThrown()
+
+        and: 'only later versions since its not snapshot'
+        allowedTypes == [GrailsReleaseType.RELEASE, GrailsReleaseType.RC, GrailsReleaseType.MILESTONE, GrailsReleaseType.SNAPSHOT] as LinkedHashSet
+    }
+
+    def "allowed release types - no preferred version - non-development for non-release"() {
+        given:
+        GrailsWrapper mockVersion = Mock(GrailsWrapper) {
+            1 * getVersion() >> '7.0.0-RC2'
+        }
+
+        when:
+        Set<GrailsReleaseType> allowedTypes = null
+        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', null).execute {
+            allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
+        }
+
+        then:
+        noExceptionThrown()
+
+        and: 'only later versions since its not snapshot'
+        allowedTypes == [GrailsReleaseType.RELEASE, GrailsReleaseType.RC] as LinkedHashSet
+    }
+
+    def "allowed release types - no preferred version - non-development for release"() {
+        given:
+        GrailsWrapper mockVersion = Mock(GrailsWrapper) {
+            1 * getVersion() >> '7.0.0'
+        }
+
+        when:
+        Set<GrailsReleaseType> allowedTypes = null
+        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', null).execute {
+            allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
+        }
+
+        then:
+        noExceptionThrown()
+
+        and: 'only later versions since its not snapshot'
+        allowedTypes == [GrailsReleaseType.RELEASE] as LinkedHashSet
+    }
 
     @Unroll
     def "grails version #version"(String version, String major, String minor, String patch, GrailsReleaseType releaseType, Integer candidate) {
@@ -87,28 +229,28 @@ class GrailsVersionSpec extends Specification {
                 new GrailsVersion('7.0.0-M1'),
                 new GrailsVersion('7.0.0-SNAPSHOT'),
         ]
-        ==
-        [
-                new GrailsVersion('7.0.0'),
-                new GrailsVersion('7.0.0-RC1'),
-                new GrailsVersion('7.0.0-M1'),
-                new GrailsVersion('7.0.0-SNAPSHOT'),
-                new GrailsVersion('7.1.1'),
-                new GrailsVersion('7.1.1-RC1'),
-                new GrailsVersion('7.1.1-M1'),
-                new GrailsVersion('7.1.1-SNAPSHOT'),
-                new GrailsVersion('8.0.0'),
-                new GrailsVersion('8.0.0-RC1'),
-                new GrailsVersion('7.1.0'),
-                new GrailsVersion('7.1.0-RC1'),
-                new GrailsVersion('7.1.0-M1'),
-                new GrailsVersion('7.1.0-SNAPSHOT'),
-                new GrailsVersion('8.0.0-M1'),
-                new GrailsVersion('8.0.0-SNAPSHOT'),
-                new GrailsVersion('7.0.1'),
-                new GrailsVersion('7.0.1-RC1'),
-                new GrailsVersion('7.0.1-M1'),
-                new GrailsVersion('7.0.1-SNAPSHOT'),
-        ].sort()
+                ==
+                [
+                        new GrailsVersion('7.0.0'),
+                        new GrailsVersion('7.0.0-RC1'),
+                        new GrailsVersion('7.0.0-M1'),
+                        new GrailsVersion('7.0.0-SNAPSHOT'),
+                        new GrailsVersion('7.1.1'),
+                        new GrailsVersion('7.1.1-RC1'),
+                        new GrailsVersion('7.1.1-M1'),
+                        new GrailsVersion('7.1.1-SNAPSHOT'),
+                        new GrailsVersion('8.0.0'),
+                        new GrailsVersion('8.0.0-RC1'),
+                        new GrailsVersion('7.1.0'),
+                        new GrailsVersion('7.1.0-RC1'),
+                        new GrailsVersion('7.1.0-M1'),
+                        new GrailsVersion('7.1.0-SNAPSHOT'),
+                        new GrailsVersion('8.0.0-M1'),
+                        new GrailsVersion('8.0.0-SNAPSHOT'),
+                        new GrailsVersion('7.0.1'),
+                        new GrailsVersion('7.0.1-RC1'),
+                        new GrailsVersion('7.0.1-M1'),
+                        new GrailsVersion('7.0.1-SNAPSHOT'),
+                ].sort()
     }
 }


### PR DESCRIPTION
@matrei had a ClassNotFoundException thrown when testing the 7.0.0-RC2 wrapper locally.  Upon researching the problem, the cause was he had an old snapshot version under the directory we download grails releases to.  The reason this was a problem is we were returning snapshot builds as eligible & the wrapper assumes snapshots are more up to date than a release.  

This line is the problem: https://github.com/apache/grails-core/blob/2cb067e0176f86bc40a17375523b5eb52503a6d3/grails-wrapper/src/main/java/grails/init/Start.java#L151 

That code should only return release types later than the version of the packaged wrapper:

      return new LinkedHashSet<>(myVersion.releaseType.upTo());
   

I wanted to add test coverage to the wrapper though, so I've refactored the helper methods for preferred version & allowed types to make this easier to test.   The test "allowed release types - no preferred version - non-development for non-release" makes sure this issue doesn't happen in the future.

With the refactoring, the jar size is 30KB, which is still smaller than the gradle wrapper size (44KB) so I'm considering the extra classes as an acceptable.