### PR TITLE
Update GitHub references and default project slug for documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 > You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead, sensitive bugs must be sent by email to security@grails.org.
 
-Grails uses GitHub to track issues in the [core framework](https://github.com/apache/grails-core/issues). Similarly, for its documentation there is a [separate tracker](https://github.com/apache/grails-doc/issues).  If you run into an issue with the project:
+Grails uses GitHub to track issues in the [core framework](https://github.com/apache/grails-core/issues) and documentation.  If you run into an issue with the project:
 
 - Open an [Issue](https://github.com/apache/grails-core/issues/new).
 - Explain the behavior you would expect and the actual behavior.

--- a/grails-gradle/docs-core/src/main/groovy/grails/doc/dropdown/CreateReleaseDropDownTask.groovy
+++ b/grails-gradle/docs-core/src/main/groovy/grails/doc/dropdown/CreateReleaseDropDownTask.groovy
@@ -93,7 +93,7 @@ abstract class CreateReleaseDropDownTask extends DefaultTask {
     CreateReleaseDropDownTask(ObjectFactory objects, Project project) {
         group = 'documentation'
         githubSlug = objects.property(String).convention(project.provider {
-            project.findProperty('githubSlug') as String ?: 'apache/grails-doc'
+            project.findProperty('githubSlug') as String ?: 'apache/grails-core'
         })
         sourceDocsDirectory = objects.directoryProperty().convention(project.layout.buildDirectory.dir('manual'))
         projectVersion = objects.property(String).convention(project.provider { project.version as String })


### PR DESCRIPTION
Updated CONTRIBUTING.md to clarify issue tracking for documentation. Changed the default githubSlug in CreateReleaseDropDownTask from 'apache/grails-doc' to 'apache/grails-core'.