### PR TITLE
build reproducibility & verification issues after testing 7.0.0-RC2

### DIFF
--- a/etc/bin/verify-keys.sh
+++ b/etc/bin/verify-keys.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+set -euo pipefail
+
+DOWNLOAD_LOCATION="${1:-downloads}"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+mkdir -p "${DOWNLOAD_LOCATION}"
+
+echo "Downloading KEYS file ..."
+curl -f -L -o "${DOWNLOAD_LOCATION}/SVN_KEYS" "https://dist.apache.org/repos/dist/release/incubator/grails/KEYS"
+echo "✅ KEYS Downloaded"
+
+echo "Comparing checked in KEYS file with SVN KEYS file"
+SVN_CHECKSUM=$(shasum -a 512 "${DOWNLOAD_LOCATION}/SVN_KEYS" | awk '{print $1}')
+GITHUB_CHECKSUM=$(shasum -a 512 "${SCRIPT_DIR}/../../KEYS" | awk '{print $1}')
+if [ "${SVN_CHECKSUM}" != "${GITHUB_CHECKSUM}" ]; then
+    echo "❌ Checksum mismatch between SVN and GitHub KEYS file"
+    exit 1
+else
+    echo "✅ Checksum matches between SVN and GitHub KEYS file"
+fi

--- a/etc/bin/verify-reproducible.sh
+++ b/etc/bin/verify-reproducible.sh
@@ -140,6 +140,7 @@ if [ -s diff.txt ]; then
       fi
 
   done < diff.txt
+  : > diff_purged.txt  # Ensure the file exists and is empty
   mv diff_purged.txt diff.txt
   rm -rf firstArtifact secondArtifact firstSource secondSource || true
 
@@ -149,6 +150,7 @@ if [ -s diff.txt ]; then
   echo "❌ Differences Found ❌"
   else
     echo "✅ Differences were resolved via decompilation. ✅"
+    exit 0
   fi
 else
   echo "✅ No Differences Found. ✅"

--- a/etc/bin/verify.sh
+++ b/etc/bin/verify.sh
@@ -37,6 +37,10 @@ cleanup() {
 }
 trap cleanup ERR
 
+echo "Verifying KEYS file ..."
+"${SCRIPT_DIR}/verify-keys.sh" "${DOWNLOAD_LOCATION}"
+echo "✅ KEYS Verified"
+
 echo "Downloading Artifacts ..."
 "${SCRIPT_DIR}/download-release-artifacts.sh" "${RELEASE_TAG}" "${DOWNLOAD_LOCATION}"
 echo "✅ Artifacts Downloaded"

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -512,6 +512,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
         for (String f in grailsAppResourceDirs) {
             grailsResourceDirs.add(project.file("grails-app/${f}"))
         }
+        // force a defined order for build reproducibility
+        grailsResourceDirs.sort { File a, File b -> a.name <=> b.name }
         grailsResourceDirs
     }
 
@@ -527,6 +529,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
         }
         grailsSourceDirs.add(project.file('src/main/groovy'))
+        // force a defined order for build reproducibility
+        grailsSourceDirs.sort { File a, File b -> a.name <=> b.name }
         grailsSourceDirs
     }
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -508,13 +508,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     @CompileStatic
     protected List<File> resolveGrailsResourceDirs(Project project) {
-        List<File> grailsResourceDirs = [project.file('src/main/resources')]
-        for (String f in grailsAppResourceDirs) {
-            grailsResourceDirs.add(project.file("grails-app/${f}"))
-        }
-        // force a defined order for build reproducibility
-        grailsResourceDirs.sort { File a, File b -> a.name <=> b.name }
-        grailsResourceDirs
+        (['src/main/resources'] + grailsAppResourceDirs.collect { 'grails-app/' + it })
+                .collect { project.file(it) }
+                .sort { it.name } // sort for build reproducibility
     }
 
     @CompileStatic
@@ -528,10 +524,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 }
             }
         }
-        grailsSourceDirs.add(project.file('src/main/groovy'))
-        // force a defined order for build reproducibility
-        grailsSourceDirs.sort { File a, File b -> a.name <=> b.name }
+
         grailsSourceDirs
+                .tap { add(project.file('src/main/groovy')) }
+                .sort { it.name } // sort for build reproducibility
     }
 
     @CompileStatic

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -137,6 +137,7 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
     @CompileStatic
     protected void configureSourcesJarTask(Project project) {
         if (!project.tasks.names.contains('sourcesJar')) {
+            project.logger.lifecycle('A sourcesJar task was not found, creating one.', project.name)
             project.tasks.register('sourcesJar', Jar).configure { Jar jarTask ->
                 jarTask.archiveClassifier.set('sources')
                 jarTask.from(SourceSets.findMainSourceSet(project).allSource)


### PR DESCRIPTION
1. reproducibility issues

@matrei noticed that he was having reproducibility issues for grails-redis when run under docker desktop.  These issues did not exist for me under orbstack or when running locally.

Debugging this, the source jars were different because the file listings inside of the source jars were different.  Specifically, the listing across source sets - sometimes grails-app/init would be first and sometimes it would be later.  

Digging into this, we do define the source / resource directories based on file system order instead of a deterministic order.  This PR sorts those to help these issues in the future (we may need to open an upstream gradle bug when using reproducibleFileOrder=true if this continues).  From what I can tell, the gradle source uses lists / linkedHashSets so as long as it's added in the same order, it's processed in the order.

2. reproducible script issues 

@matrei  noted the reproducible script was failing because after a manual diff of all files, no differences were found.  The script did not exit properly or ensure a diff file existed.  @paulk-asert  has previously mentioned these issues in prior releases but I couldn't reproduce.  Going forward this should resolve this.

3. KEYS file verification

As part of 7.0.0-RC2 we started verifying both the grails github action files & the svn files to make sure they are identical.  We now will verify the KEYS files are identical so they're always kept in sync with grails-core.