### PR TITLE
Issue-14172 Out Of Date Instructions For Creating A Plugin

### DIFF
--- a/grails-doc/src/en/guide/commandLine.adoc
+++ b/grails-doc/src/en/guide/commandLine.adoc
@@ -112,7 +112,7 @@ bootRun{
 === Non-interactive mode
 
 
-When you run a script manually and it prompts you for information, you can answer the questions and continue running the script. But when you run a script as part of an automated process, for example a continuous integration build server, there's no way to "answer" the questions. So you can pass the `\--non-interactive` switch to the script command to tell Grails to accept the default answer for any questions, for example whether to install a missing plugin.
+When you run a script manually, and it prompts you for information, you can answer the questions and continue running the script. But when you run a script as part of an automated process, for example a continuous integration build server, there's no way to "answer" the questions. So you can pass the `--non-interactive` switch to the script command to tell Grails to accept the default answer for any questions, for example whether to install a missing plugin.
 
 For example:
 

--- a/grails-doc/src/en/guide/plugins/addingDynamicMethodsAtRuntime.adoc
+++ b/grails-doc/src/en/guide/plugins/addingDynamicMethodsAtRuntime.adoc
@@ -23,7 +23,7 @@ under the License.
 
 Grails plugins let you register dynamic methods with any Grails-managed or other class at runtime. This work is done in a `doWithDynamicMethods` method.
 
-NOTE: Note that Grails 3.x features newer features such as traits that are usable from code compiled with `CompileStatic`. It is recommended that dynamic behavior is only added for cases that are not possible with traits.
+NOTE: Note that Grails 3.x and above features newer features such as traits that are usable from code compiled with `CompileStatic`. It is recommended that dynamic behavior is only added for cases that are not possible with traits.
 
 [source,groovy]
 ----

--- a/grails-doc/src/en/guide/plugins/addingMethodsAtCompileTime.adoc
+++ b/grails-doc/src/en/guide/plugins/addingMethodsAtCompileTime.adoc
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-Grails 3.0 makes it easy to add new traits to existing artefact types from a plugin. For example say you wanted to add methods for manipulating dates to controllers. This can be done by defining a trait in `src/main/groovy`:
+Grails makes it easy to add new traits to existing artefact types from a plugin. For example say you wanted to add methods for manipulating dates to controllers. This can be done by defining a trait in `src/main/groovy`:
 
 [source,groovy]
 ----

--- a/grails-doc/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
+++ b/grails-doc/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
@@ -214,7 +214,7 @@ repositories {
 implementation "org.apache.grails:grails-quartz:0.1"
 ----
 
-NOTE: In Grails 2.x plugins were packaged as ZIP files, however in Grails 3.x plugins are simple JAR files that can be added to the classpath of the IDE.
+NOTE: In Grails 2.x plugins were packaged as ZIP files, however from Grails 3.x+ plugins are simple JAR files that can be added to the classpath of the IDE.
 
 
 
@@ -350,12 +350,12 @@ jar {
 
 
 
-==== Inline Plugins in Grails 3.0
+==== Inline Plugins in Grails
 
 
-In Grails 2.x it was possible to specify inline plugins in `BuildConfig`, in Grails 3.x this functionality has been replaced by Gradle's multi-project build feature.
+In Grails 2.x it was possible to specify inline plugins in `BuildConfig`, from Grails 3.x+ this functionality has been replaced by Gradle's multi-project build feature.
 
-To set up a multi project build create an appliation and a plugin in a parent directory:
+To set up a multi project build create an application and a plugin in a parent directory:
 
 [source,groovy]
 ----
@@ -392,7 +392,7 @@ grails create-plugin <<PLUGIN NAME>>
 
 This will create a web-plugin project for the name you specify. For example running `grails create-plugin example` would create a new web-plugin project called `example`.
 
-In Grails 3.0 you should consider whether the plugin you create requires a web environment or whether the plugin can be used with other profiles. If your plugin does not require a web environment then use the "plugin" profile instead of the default "web-plugin" profile:
+In Grails you should consider whether the plugin you create requires a web environment or whether the plugin can be used with other profiles. If your plugin does not require a web environment then use the "plugin" profile instead of the default "web-plugin" profile:
 
 [source,groovy]
 ----
@@ -554,7 +554,7 @@ repositories {
 implementation "org.apache.grails:grails-quartz:0.1"
 ----
 
-NOTE: In Grails 2.x plugins were packaged as ZIP files, however in Grails 3.x plugins are simple JAR files that can be added to the classpath of the IDE.
+NOTE: In Grails 2.x plugins were packaged as ZIP files, however from Grails 3.x+ plugins are simple JAR files that can be added to the classpath of the IDE.
 
 
 
@@ -689,10 +689,10 @@ jar {
 
 
 
-==== Inline Plugins in Grails 3.0
+==== Inline Plugins in Grails
 
 
-In Grails 2.x it was possible to specify inline plugins in `BuildConfig`, in Grails 3.x this functionality has been replaced by Gradle's multi-project build feature.
+In Grails 2.x it was possible to specify inline plugins in `BuildConfig`, from Grails 3.x+ this functionality has been replaced by Gradle's multi-project build feature.
 
 To set up a multi project build create an appliation and a plugin in a parent directory:
 

--- a/grails-doc/src/en/guide/plugins/hookingIntoRuntimeConfiguration.adoc
+++ b/grails-doc/src/en/guide/plugins/hookingIntoRuntimeConfiguration.adoc
@@ -54,9 +54,9 @@ This plugin configures the Grails `messageSource` bean and a couple of other bea
 ==== Customizing the Servlet Environment
 
 
-In previous versions of Grails it was possible to dynamically modify the generated `web.xml`. In Grails 3.x there is no `web.xml` file and it is not possible to programmatically modify the `web.xml` file anymore.
+In previous versions of Grails it was possible to dynamically modify the generated `web.xml`. From Grails 3.x+ there is no `web.xml` file and it is not possible to programmatically modify the `web.xml` file anymore.
 
-However, it is possible to perform the most commons tasks of modifying the Servlet environment in Grails 3.x.
+However, it is possible to perform the most commons tasks of modifying the Servlet environment in Grails 3.x and above.
 
 
 ==== Adding New Servlets

--- a/grails-doc/src/en/guide/plugins/providingBasicArtefacts.adoc
+++ b/grails-doc/src/en/guide/plugins/providingBasicArtefacts.adoc
@@ -21,7 +21,7 @@ under the License.
 ==== Add Command Line Commands
 
 
-A plugin can add new commands to the Grails 3.0 interactive shell in one of two ways. First, using the link:{commandLineRef}create-script.html[create-script] you can create a code generation script which will become available to the application. The `create-script` command will create the script in the `src/main/scripts` directory:
+A plugin can add new commands to the Grails interactive shell in one of two ways. First, using the link:{commandLineRef}create-script.html[create-script] you can create a code generation script which will become available to the application. The `create-script` command will create the script in the `src/main/scripts` directory:
 
 [source,groovy]
 ----
@@ -90,7 +90,7 @@ The Grails version is all lower case hyphen separated and excludes the "Command"
 
 The main difference between code generation scripts and `ApplicationCommand` instances is that the latter has full access to the Grails application state and hence can be used to perform tasks that interactive with the database, call into GORM etc.
 
-In Grails 2.x Gant scripts could be used to perform both these tasks, in Grails 3.x code generation and interacting with runtime application state has been cleanly separated.
+In Grails 2.x Gant scripts could be used to perform both these tasks, from Grails 3.x+ code generation and interacting with runtime application state has been cleanly separated.
 
 
 ==== Adding a new grails-app artifact (Controller, Tag Library, Service, etc.)


### PR DESCRIPTION
The 'Creating a plugin' documentation refered specifically to Grails 3. Changed to refere to 'Grails', 'Grails 3.x+' or 'Grails 3 and above'.

Mentioned in issue-14172