### PR TITLE
Add upgrade notes for hibernate.cache.region.factory_class

### DIFF
--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -434,3 +434,40 @@ To learn more about development reloading options, please see the link:gettingSt
 ===== 12.18 grails-i18n plugin
 
 `org.apache.grails:grails-i18n` has been changed to `org.apache.grails.i18n:grails-i18n` and is provided transitively, remove `org.apache.grails:grails-i18n` and `org.grails:grails-plugin-i18n` from your dependency list
+
+===== 12.19 hibernate.cache.region.factory_class
+
+`org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory` is deprecated in Hibernate 5.6 and removed in Hibernate 6.0. Additionally, it is not compatible with hibernate-jakarta 5.6.x, which is used by Grails 7.
+
+```console
+    hibernate:
+        allow_update_outside_transaction: true
+    cache:
+        queries: false
+        use_second_level_cache: true
+        use_query_cache: false
+        region:
+        factory_class: 'org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory'
+```
+
+If your application sets `hibernate.cache.region.factory_class` to `org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory` it will add the `non-jakarta` version of `hibernate-core` to your classpath which will cause `NoClassDefFoundError` and `ClassNotFoundException` errors.
+
+You will need to change it to `jcache` and add the Ehcache dependency as follows:
+
+```console
+    hibernate:
+        allow_update_outside_transaction: true
+    cache:
+        queries: false
+        use_second_level_cache: true
+        use_query_cache: false
+        region:
+        factory_class: 'jcache'
+```
+
+```console
+    implementation 'org.ehcache:ehcache'
+```
+
+Alternatively, you can define the hibernate-ehcache dependency explicitly and adjust it to exclude `hibernate-core` and add the `jboss-transaction-api_1.3_spec` see link:upgrading.html#_12_5_hibernate_ehcache[Hibernate-ehcache]
+

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -351,13 +351,17 @@ The asset pipeline has a new https://github.com/wondrify/asset-pipeline[home]. V
 
 Updated maven coordinates:
 
-```console
+[source,groovy]
+.build.gradle
+----
 cloud.wondrify:asset-pipeline-gradle
 cloud.wondrify:asset-pipeline-grails
-```
+----
 
 Gradle plugin:
-```console
+[source,groovy]
+.build.gradle
+----
 plugins {
     id "cloud.wondrify.asset-pipeline"
 }
@@ -365,7 +369,7 @@ plugins {
 or
 
 apply plugin: "cloud.wondrify.asset-pipeline"
-```
+----
 
 ===== 12.12 API Changes
 
@@ -383,9 +387,11 @@ If you decide to use the `grails-layout` plugin, several changes have occurred:
 
 Add the following dependency to your project:
 
-```console
+[source,groovy]
+.build.gradle
+----
 implementation "org.apache.grails:grails-layout"
-```
+----
 
 Package Changes:
 
@@ -421,9 +427,10 @@ https://docs.spring.io/spring-boot/appendix/application-properties/index.html#ap
 
 The `servletContext` is no longer included by default in the generated `Bootstrap` class. If you need access to the `servletContext`, you can inject it into your `Bootstrap` class using:
 
-```console
+[source,groovy]
+----
 ServletContext servletContext
-```
+----
 
 ===== 12.17 Development Reloading
 
@@ -439,7 +446,9 @@ To learn more about development reloading options, please see the link:gettingSt
 
 `org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory` is deprecated in Hibernate 5.6 and is not compatible with `org.hibernate:hibernate-core-jakarta:{hibernate5Version}`, which is used in Grails 7.
 
-```console
+[source,yml]
+.application.yml
+----
     hibernate:
         allow_update_outside_transaction: true
     cache:
@@ -448,13 +457,15 @@ To learn more about development reloading options, please see the link:gettingSt
         use_query_cache: false
         region:
         factory_class: 'org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory'
-```
+----
 
 If your application sets `hibernate.cache.region.factory_class` to `org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory` it will add the `non-jakarta` version of `hibernate-core` to your classpath which will cause `NoClassDefFoundError` and `ClassNotFoundException` errors.
 
 You will need to change it to `jcache` and add the Ehcache dependency as follows:
 
-```console
+[source,yml]
+.application.yml
+----
     hibernate:
         allow_update_outside_transaction: true
     cache:
@@ -463,11 +474,13 @@ You will need to change it to `jcache` and add the Ehcache dependency as follows
         use_query_cache: false
         region:
         factory_class: 'jcache'
-```
+----
 
-```console
+[source,groovy]
+.build.gradle
+----
     implementation 'org.ehcache:ehcache'
-```
+----
 
 Alternatively, you can define the hibernate-ehcache dependency explicitly and adjust it to exclude `hibernate-core` and add the `jboss-transaction-api_1.3_spec` see link:upgrading.html#_12_5_hibernate_ehcache[Hibernate-ehcache]
 

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -437,7 +437,7 @@ To learn more about development reloading options, please see the link:gettingSt
 
 ===== 12.19 hibernate.cache.region.factory_class
 
-`org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory` is deprecated in Hibernate 5.6 and removed in Hibernate 6.0. Additionally, it is not compatible with hibernate-jakarta 5.6.x, which is used by Grails 7.
+`org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory` is deprecated in Hibernate 5.6 and is not compatible with `org.hibernate:hibernate-core-jakarta:{hibernate5Version}`, which is used in Grails 7.
 
 ```console
     hibernate:


### PR DESCRIPTION
Documents the deprecation and removal of org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory in Hibernate 6.0, its incompatibility with hibernate-jakarta 5.6.x, and provides guidance for updating configuration and dependencies when upgrading to Grails 7.