### PR TITLE
Remove additivity attribute from StackTrace logger

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/logging/template/logback.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/logging/template/logback.rocker.raw
@@ -39,7 +39,7 @@ under the License.
     </root>
 
     <springProfile name="development">
-        <logger name="StackTrace" level="ERROR" additivity="false" />
+        <logger name="StackTrace" level="ERROR" />
 
 <!--        <logger name="@packageName" level="DEBUG"/>-->
 

--- a/grails-profiles/base/skeleton/grails-app/conf/logback-spring.xml
+++ b/grails-profiles/base/skeleton/grails-app/conf/logback-spring.xml
@@ -18,7 +18,7 @@
     </root>
 
     <springProfile name="development">
-        <logger name="StackTrace" level="ERROR" additivity="false" />
+        <logger name="StackTrace" level="ERROR" />
 
 <!--        <logger name="Test38" level="DEBUG"/>-->
 

--- a/grails-test-examples/external-configuration/grails-app/conf/logback-spring.xml
+++ b/grails-test-examples/external-configuration/grails-app/conf/logback-spring.xml
@@ -39,7 +39,7 @@
     <logger name="grails.config.external" level="DEBUG"/>
 
     <springProfile name="development">
-        <logger name="StackTrace" level="ERROR" additivity="false"/>
+        <logger name="StackTrace" level="ERROR" />
 
         <!--        <logger name="org.demo.spock" level="DEBUG"/>-->
 

--- a/grails-test-examples/geb-gebconfig/grails-app/conf/logback-spring.xml
+++ b/grails-test-examples/geb-gebconfig/grails-app/conf/logback-spring.xml
@@ -38,7 +38,7 @@
     </root>
 
     <springProfile name="development">
-        <logger name="StackTrace" level="ERROR" additivity="false" />
+        <logger name="StackTrace" level="ERROR" />
     </springProfile>
 
 </configuration>

--- a/grails-test-examples/geb/grails-app/conf/logback-spring.xml
+++ b/grails-test-examples/geb/grails-app/conf/logback-spring.xml
@@ -38,7 +38,7 @@
     </root>
 
     <springProfile name="development">
-        <logger name="StackTrace" level="ERROR" additivity="false" />
+        <logger name="StackTrace" level="ERROR" />
 
 <!--        <logger name="org.demo.spock" level="DEBUG"/>-->
 


### PR DESCRIPTION
Prevents:  `WARN in Logger[StackTrace] - No appenders present in context [default] for logger [StackTrace]`.

The 'additivity="false"' attribute was removed from the StackTrace logger configuration in multiple logback-spring.xml files and the logback.rocker.raw template. This change simplifies the logger configuration and ensures it extends the root logger.