### PR TITLE
feature: allow disabling micronaut configuration by the grails plugin

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -68,8 +68,9 @@ class GrailsExtension {
     boolean springDependencyManagement = true
 
     /**
-     * Whether the micronaut dependencies should be auto added to the project on detection of micronaut & the platform
-     * version enforced
+     * Whether the Micronaut `annotationProcessor` dependencies should be auto-added to the project
+     * on detection of the `grails-micronaut` plugin, and the version defined by the `micronautPlatformVersion`
+     * Gradle property is enforced.
      */
     boolean micronautAutoSetup = true
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -68,6 +68,12 @@ class GrailsExtension {
     boolean springDependencyManagement = true
 
     /**
+     * Whether the micronaut dependencies should be auto added to the project on detection of micronaut & the platform
+     * version enforced
+     */
+    boolean micronautAutoSetup = true
+
+    /**
      * Configure the reloading agent
      */
     Agent agent = new Agent()

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -390,6 +390,12 @@ class GrailsGradlePlugin extends GroovyPlugin {
             if (!micronautEnabled) {
                 return
             }
+
+            GrailsExtension ge = project.extensions.getByType(GrailsExtension)
+            if (!ge.micronautAutoSetup) {
+                return
+            }
+
             project.logger.lifecycle('Micronaut Support Detected for {}', project.name)
 
             final String micronautPlatformVersion = project.properties['micronautPlatformVersion']


### PR DESCRIPTION
We know that the micronaut support could have issues due to the lack of test coverage.  This PR adds a flag that allows disabling the auto configuration in the grails plugin so that if an issue arises, one can debug it locally.