### PR TITLE
Gorm service enhancements

### DIFF
--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -54,7 +54,7 @@ class GormService<T extends GormEntity<T>> {
         resource.list(args)
     }
 
-    Long count() {
+    Long count(Map args) {
         resource.count()
     }
 

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -63,7 +63,7 @@ class GormService<T extends GormEntity<T>> {
         if (readOnly) {
             return
         }
-        ((GormEntityApi) queryForResource(id)).delete(flush: true)
+        ((GormEntityApi) get(id)).delete(flush: true)
     }
 
     @Transactional

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -46,12 +46,8 @@ class GormService<T extends GormEntity<T>> {
         resourceName = GrailsNameUtils.getPropertyName(resource)
     }
 
-    protected T queryForResource(Serializable id) {
-        resource.get(id)
-    }
-
     T get(Serializable id) {
-        queryForResource(id)
+        resource.get(id)
     }
 
     List<T> list(Map args) {

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/RestfulServiceController.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/RestfulServiceController.groovy
@@ -19,6 +19,7 @@
 
 package grails.plugin.scaffolding
 
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import grails.artefact.Artefact
 import grails.gorm.transactions.ReadOnly
@@ -49,8 +50,9 @@ class RestfulServiceController<T extends GormEntity<T>> extends RestfulControlle
     }
 
     @Override
+    @CompileDynamic
     protected Integer countResources() {
-        getService().count()
+        getService().count(params)
     }
 
     @Override

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/RestfulServiceController.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/RestfulServiceController.groovy
@@ -19,7 +19,6 @@
 
 package grails.plugin.scaffolding
 
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import grails.artefact.Artefact
 import grails.gorm.transactions.ReadOnly
@@ -50,7 +49,6 @@ class RestfulServiceController<T extends GormEntity<T>> extends RestfulControlle
     }
 
     @Override
-    @CompileDynamic
     protected Integer countResources() {
         getService().count(params)
     }


### PR DESCRIPTION
Slowing migrating this to how it was intended.

Services are kind of useless if they can't filter/query.  

GormService was originally modeled after`RestfulController<T>`, but that wasn't really necessary. 

This is another step that migrates towards making the scaffold service more useful 

My final version of GormService allows querying by params and counting by params.  Currently I am using this as a base class that I extend with a more meaningful implementation.   


# Allows this

```groovy
@Scaffold(domain = User)
class UserService {
    List<User> list(Map args) {
        args.firstName? User.findAllByFirstName(args.firstName, args) : User.list(args)
    }

    Long count(Map args) {
        args.firstName? User.countByFirstName(args.firstName) : User.count()
    }
} 

@Scaffold(RestfulServiceController<User>)
class UserController {}
```
now works and is properly paginated:
http://localhost:8080/user/index?firstName=scott 
