### PR TITLE
14977 - multiproject reloading support

### DIFF
--- a/grails-doc/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
+++ b/grails-doc/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
@@ -20,7 +20,7 @@ under the License.
 
 ==== Creating Plugins
 
-Creating a Grails plugin is a simple matter of running the command:
+Creating a Grails plugin is a simple matter of running one of the supported plugin generators:
 
 Grails Shell CLI
 [source,groovy]
@@ -120,7 +120,7 @@ Adds Quartz job scheduling features
     Closure doWithSpring()......
 ----
 
-==== Plugin Configuration
+===== Plugin Configuration
 
 A Grails plugin can be configured in one of the following files:
 
@@ -129,7 +129,7 @@ A Grails plugin can be configured in one of the following files:
 
 These files will be included in the plugin package while the `application.*` files are only used internally when developing the plugin. See <<excludedArtefacts>>.
 
-==== Reading configuration properties
+===== Reading configuration properties
 
 Instead of directly accessing Grails configuration as `grailsApplication.config.mail.hostName`, use a Spring Boot configuration bean (or a POJO) annotated with {springbootapi}org/springframework/boot/context/properties/ConfigurationProperties.html[ConfigurationProperties] annotation. Here is an example plugin configuration:
 
@@ -169,7 +169,7 @@ class MailService {
 
 Please read the {springBootReference}features/external-config.html[Spring Boot Externalized Configuration] section for more information.
 
-==== Installing Local Plugins
+===== Installing Local Plugins
 
 In order to install the Grails plugin to your local Maven, you could use Gradle https://docs.gradle.org/current/userguide/publishing_maven.html[Maven Publish] plugin. You may also need to configure the publishing extension as:
 
@@ -216,9 +216,7 @@ implementation "org.apache.grails:grails-quartz:0.1"
 
 NOTE: In Grails 2.x plugins were packaged as ZIP files, however from Grails 3.x+ plugins are simple JAR files that can be added to the classpath of the IDE.
 
-
-
-==== Plugins and Multi-Project Builds
+===== Plugins and Multi-Project Builds
 
 
 If you wish to setup a plugin as part of a multi project build then follow these steps.
@@ -267,11 +265,18 @@ grails {
 }
 ----
 
-NOTE: You can also declare the dependency within the `dependencies` block, however you will not get subproject reloading if you do this!
+NOTE: You can also declare the dependency within the `dependencies` block, however reloading will not work correctly if defined this way.
 
-*Step 4: Configure the plugin to enable reloading*
+*Step 4: (Optional) Configure the plugin for reloading
 
-In the plugin directory, add or modify the `gradle.properties` file. A new property `exploded=true` needs to be set in order for the plugin to add the exploded directories to the classpath.
+Within the `build.gradle` of the plugin, apply the gradle plugin `org.apache.grails.gradle.grails-exploded` to allow for proper reloading of the plugin:
+
+[source,groovy]
+----
+apply plugin: 'org.apache.grails.gradle.grails-exploded'
+----
+
+NOTE: This plugin ensures that development commands such as `bootRun` use the exploded classes and resources of the plugin rather than the packaged JAR file.
 
 *Step 5: Run the application*
 
@@ -309,7 +314,7 @@ Grails application running at http://localhost:8080 in environment: development
 
 
 [[excludedArtefacts]]
-==== Notes on excluded Artefacts
+===== Notes on excluded Artefacts
 
 
 Although the link:{commandLineRef}create-plugin.html[create-plugin] command creates certain files for you so that the plugin can be run as a Grails application, not all of these files are included when packaging a plugin. The following is a list of artefacts created, but not included by link:{commandLineRef}package-plugin.html[package-plugin]:
@@ -323,8 +328,7 @@ Although the link:{commandLineRef}create-plugin.html[create-plugin] command crea
 * Everything within `/src/test/\*\*`
 * SCM management files within `\*\*/.svn/\*\*` and `\*\*/CVS/\*\*`
 
-
-==== Customizing the plugin contents
+===== Customizing the plugin contents
 
 
 When developing a plugin you may create test classes and sources that are used during the development and testing of the plugin but should not be exported to the application.
@@ -348,9 +352,7 @@ jar {
 }
 ----
 
-
-
-==== Inline Plugins in Grails
+===== Inline Plugins in Grails
 
 
 In Grails 2.x it was possible to specify inline plugins in `BuildConfig`, from Grails 3.x+ this functionality has been replaced by Gradle's multi-project build feature.
@@ -374,13 +376,18 @@ Finally add a dependency in your application's `build.gradle` on the plugin:
 
 [source,groovy]
 ----
-implementation project(':myplugin')
+grails {
+    plugins {
+        implementation project(':myplugin')
+    }
+}
 ----
+
+NOTE: You can also declare the dependency within the `dependencies` block, however your subproject will not reload correctly.
 
 Using this technique you have achieved the equivalent of inline plugins from Grails 2.x.
 
-
-==== Grails Forge Creating Plugins
+===== Grails Forge Creating Plugins
 
 
 Creating a Grails plugin is a simple matter of running the command:
@@ -509,211 +516,3 @@ class MailService {
 
 Please read the {springBootReference}features/external-config.html[Spring Boot Externalized Configuration] section for more information.
 
-==== Installing Local Plugins
-
-In order to install the Grails plugin to your local Maven, you could use Gradle https://docs.gradle.org/current/userguide/publishing_maven.html[Maven Publish] plugin. You may also need to configure the publishing extension as:
-
-[source,groovy]
-----
-publishing {
-    publications {
-        maven(MavenPublication) {
-            versionMapping {
-                usage('java-api') {
-                    fromResolutionOf('runtimeClasspath')
-                }
-                usage('java-runtime') {
-                    fromResolutionResult()
-                }
-            }
-            from components.java
-        }
-    }
-}
-----
-
-NOTE: Please refer to the Gradle Maven Publish plugin documentation for up-to-date information.
-
-To make your plugin available for use in a Grails application run the `./gradlew publishToMavenLocal` command:
-
-[source,bash]
-----
-./gradlew publishToMavenLocal
-----
-
-This will install the plugin into your local Maven cache. Then to use the plugin within an application declare a dependency on the plugin in your `build.gradle` file and include `mavenLocal()` in your repositories hash:
-
-[source,groovy]
-----
-...
-repositories {
-    ...
-    mavenLocal()
-}
-...
-implementation "org.apache.grails:grails-quartz:0.1"
-----
-
-NOTE: In Grails 2.x plugins were packaged as ZIP files, however from Grails 3.x+ plugins are simple JAR files that can be added to the classpath of the IDE.
-
-
-
-==== Plugins and Multi-Project Builds
-
-
-If you wish to setup a plugin as part of a multi project build then follow these steps.
-
-*Step 1: Create the application and the plugin*
-
-Using the `grails` command create an application and a plugin:
-
-[source,groovy]
-----
-$ grails create-app myapp
-$ grails create-plugin myplugin
-----
-
-*Step 2: Create a settings.gradle file*
-
-In the same directory create a `settings.gradle` file with the following contents:
-
-[source,groovy]
-----
-include "myapp", "myplugin"
-----
-
-The directory structure should be as follows:
-
-[source,groovy]
-----
-PROJECT_DIR
-  - settings.gradle
-  - myapp
-    - build.gradle
-  - myplugin
-    - build.gradle
-----
-
-*Step 3: Declare a project dependency on the plugin*
-
-Within the `build.gradle` of the application declare a dependency on the plugin within the `plugins` block:
-
-[source,groovy]
-----
-grails {
-    plugins {
-        implementation project(':myplugin')
-    }
-}
-----
-
-NOTE: You can also declare the dependency within the `dependencies` block, however you will not get subproject reloading if you do this!
-
-*Step 4: Configure the plugin to enable reloading*
-
-In the plugin directory, add or modify the `gradle.properties` file. A new property `exploded=true` needs to be set in order for the plugin to add the exploded directories to the classpath.
-
-*Step 5: Run the application*
-
-Now run the application using the `./gradlew bootRun` command from the root of the application directory, you can use the `verbose` flag to see the Gradle output:
-
-[source,groovy]
-----
-$ cd myapp
-$ ./gradlew bootRun --verbose
-----
-
-You will notice from the Gradle output that plugins sources are built and placed on the classpath of your application:
-
-[source,groovy]
-----
-:myplugin:compileAstJava UP-TO-DATE
-:myplugin:compileAstGroovy UP-TO-DATE
-:myplugin:processAstResources UP-TO-DATE
-:myplugin:astClasses UP-TO-DATE
-:myplugin:compileJava UP-TO-DATE
-:myplugin:configScript UP-TO-DATE
-:myplugin:compileGroovy
-:myplugin:copyAssets UP-TO-DATE
-:myplugin:copyCommands UP-TO-DATE
-:myplugin:copyTemplates UP-TO-DATE
-:myplugin:processResources
-:myapp:compileJava UP-TO-DATE
-:myapp:compileGroovy
-:myapp:processResources UP-TO-DATE
-:myapp:classes
-:myapp:findMainClass
-:myapp:bootRun
-Grails application running at http://localhost:8080 in environment: development
-----
-
-
-==== Notes on excluded Artefacts
-
-
-Although the link:{commandLineRef}create-plugin.html[create-plugin] command creates certain files for you so that the plugin can be run as a Grails application, not all of these files are included when packaging a plugin. The following is a list of artefacts created, but not included by link:{commandLineRef}package-plugin.html[package-plugin]:
-
-* `grails-app/build.gradle` (although it is used to generate `dependencies.groovy`)
-* `grails-app/conf/logback.xml`
-* `grails-app/conf/logback-spring.xml`
-* `grails-app/conf/application.yml`
-* `grails-app/conf/application.groovy`
-* `grails-app/conf/spring/resources.groovy`
-* Everything within `/src/test/\*\*`
-* SCM management files within `\*\*/.svn/\*\*` and `\*\*/CVS/\*\*`
-
-
-==== Customizing the plugin contents
-
-
-When developing a plugin you may create test classes and sources that are used during the development and testing of the plugin but should not be exported to the application.
-
-To exclude test sources you need to modify the `pluginExcludes` property of the plugin descriptor AND exclude the resources inside your `build.gradle` file. For example say you have some classes under the `com.demo` package that are in your plugin source tree but should not be packaged in the application. In your plugin descriptor you should exclude these:
-
-[source,groovy]
-----
-// resources that should be loaded by the plugin once installed in the application
-  def pluginExcludes = [
-    '**/com/demo/**'
-  ]
-----
-
-And in your `build.gradle` you should exclude the compiled classes from the JAR file:
-
-[source,groovy]
-----
-jar {
-  exclude "com/demo/**/**"
-}
-----
-
-
-
-==== Inline Plugins in Grails
-
-
-In Grails 2.x it was possible to specify inline plugins in `BuildConfig`, from Grails 3.x+ this functionality has been replaced by Gradle's multi-project build feature.
-
-To set up a multi project build create an appliation and a plugin in a parent directory:
-
-[source,groovy]
-----
-$ grails create-app myapp
-$ grails create-plugin myplugin
-----
-
-Then create a `settings.gradle` file in the parent directory specifying the location of your application and plugin:
-
-[source,groovy]
-----
-include 'myapp', 'myplugin'
-----
-
-Finally add a dependency in your application's `build.gradle` on the plugin:
-
-[source,groovy]
-----
-implementation project(':myplugin')
-----
-
-Using this technique you have achieved the equivalent of inline plugins from Grails 2.x.

--- a/grails-doc/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
+++ b/grails-doc/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
@@ -18,7 +18,7 @@ under the License.
 ////
 
 
-==== Creating Plugins
+=== Creating Plugins
 
 Creating a Grails plugin is a simple matter of running one of the supported plugin generators:
 
@@ -120,7 +120,7 @@ Adds Quartz job scheduling features
     Closure doWithSpring()......
 ----
 
-===== Plugin Configuration
+==== Plugin Configuration
 
 A Grails plugin can be configured in one of the following files:
 
@@ -129,7 +129,7 @@ A Grails plugin can be configured in one of the following files:
 
 These files will be included in the plugin package while the `application.*` files are only used internally when developing the plugin. See <<excludedArtefacts>>.
 
-===== Reading configuration properties
+==== Reading configuration properties
 
 Instead of directly accessing Grails configuration as `grailsApplication.config.mail.hostName`, use a Spring Boot configuration bean (or a POJO) annotated with {springbootapi}org/springframework/boot/context/properties/ConfigurationProperties.html[ConfigurationProperties] annotation. Here is an example plugin configuration:
 
@@ -169,7 +169,7 @@ class MailService {
 
 Please read the {springBootReference}features/external-config.html[Spring Boot Externalized Configuration] section for more information.
 
-===== Installing Local Plugins
+==== Installing Local Plugins
 
 In order to install the Grails plugin to your local Maven, you could use Gradle https://docs.gradle.org/current/userguide/publishing_maven.html[Maven Publish] plugin. You may also need to configure the publishing extension as:
 
@@ -216,7 +216,7 @@ implementation "org.apache.grails:grails-quartz:0.1"
 
 NOTE: In Grails 2.x plugins were packaged as ZIP files, however from Grails 3.x+ plugins are simple JAR files that can be added to the classpath of the IDE.
 
-===== Plugins and Multi-Project Builds
+==== Plugins and Multi-Project Builds
 
 
 If you wish to setup a plugin as part of a multi project build then follow these steps.
@@ -314,7 +314,7 @@ Grails application running at http://localhost:8080 in environment: development
 
 
 [[excludedArtefacts]]
-===== Notes on excluded Artefacts
+==== Notes on excluded Artefacts
 
 
 Although the link:{commandLineRef}create-plugin.html[create-plugin] command creates certain files for you so that the plugin can be run as a Grails application, not all of these files are included when packaging a plugin. The following is a list of artefacts created, but not included by link:{commandLineRef}package-plugin.html[package-plugin]:
@@ -328,7 +328,7 @@ Although the link:{commandLineRef}create-plugin.html[create-plugin] command crea
 * Everything within `/src/test/\*\*`
 * SCM management files within `\*\*/.svn/\*\*` and `\*\*/CVS/\*\*`
 
-===== Customizing the plugin contents
+==== Customizing the plugin contents
 
 
 When developing a plugin you may create test classes and sources that are used during the development and testing of the plugin but should not be exported to the application.
@@ -352,7 +352,7 @@ jar {
 }
 ----
 
-===== Inline Plugins in Grails
+==== Inline Plugins in Grails
 
 
 In Grails 2.x it was possible to specify inline plugins in `BuildConfig`, from Grails 3.x+ this functionality has been replaced by Gradle's multi-project build feature.
@@ -387,7 +387,7 @@ NOTE: You can also declare the dependency within the `dependencies` block, howev
 
 Using this technique you have achieved the equivalent of inline plugins from Grails 2.x.
 
-===== Grails Forge Creating Plugins
+==== Grails Forge Creating Plugins
 
 
 Creating a Grails plugin is a simple matter of running the command:
@@ -476,7 +476,7 @@ Adds Quartz job scheduling features
     Closure doWithSpring()......
 ----
 
-==== Plugin Configuration
+=== Plugin Configuration
 
 Instead of directly accessing Grails configuration as `grailsApplication.config.getProperty('mail.hostName', String)`, use a Spring Boot configuration bean (or a POJO) annotated with {springbootapi}org/springframework/boot/context/properties/ConfigurationProperties.html[ConfigurationProperties] annotation. Here is an example plugin configuration:
 

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -492,3 +492,28 @@ This scenario is not supported and can lead to unexpected behavior due to the AS
 
 Starting with Grails 7, a validation error will trigger if both a Grails Application Gradle Plugin & a Grails Plugin Gradle Plugin are configured in `build.gradle` for the same Gradle Project.
 
+===== 12.21 `exploded` is supported again to enable multi-project reloading
+
+Earlier versions of Grails supported an `exploded` Gradle configuration that forced defined plugins to use class and resource files, instead of jar files, on the Grails Application runtime classpath if several conditions were true:
+
+1. the property `grails.run.active` was set
+2. the plugin project had the property `exploded` set to `true` prior to the application of the `grails-plugin` Gradle plugin
+3. plugins were added to the Grails Application project via the `plugins` block inside of the `grails` extension in `build.gradle` instead of the `dependencies` block
+4. the property `exploded` was set on the `grails` extension in `build.gradle` of the Grails Application project
+
+The `exploded` setup facilitates better class reloading behavior.
+For Grails 7, it has been simplified to the following:
+
+1. In the plugin project, apply the gradle plugin `org.apache.grails.gradle.grails-exploded`
+2. In the application project, define plugins inside of the `plugins` block of the `grails` extension in `build.gradle`:
+
+[source,groovy]
+----
+grails {
+   plugins {
+        implementation project(":my-plugin")
+   }
+}
+----
+
+NOTE: Expanded class files & resource files will only be used over the jar file if the plugin applies the gradle plugin `org.apache.grails.gradle.grails-exploded` & the plugin is a subproject of your Gradle build.

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -484,3 +484,11 @@ You will need to change it to `jcache` and add the Ehcache dependency as follows
 
 Alternatively, you can define the hibernate-ehcache dependency explicitly and adjust it to exclude `hibernate-core` and add the `jboss-transaction-api_1.3_spec` see link:upgrading.html#_12_5_hibernate_ehcache[Hibernate-ehcache]
 
+===== 12.20 A Grails project cannot be both a plugin & an Application
+
+In previous versions of Grails, it was possible to apply both the `grails-plugin` and `grails-web` Gradle plugins in `build.gradle`.
+This would force the project to be both a Grails Plugin and a Grails Application.
+This scenario is not supported and can lead to unexpected behavior due to the AST transforms.
+
+Starting with Grails 7, a validation error will trigger if both a Grails Application Gradle Plugin & a Grails Plugin Gradle Plugin are configured in `build.gradle` for the same Gradle Project.
+

--- a/grails-gradle/model/src/main/groovy/grails/util/Environment.groovy
+++ b/grails-gradle/model/src/main/groovy/grails/util/Environment.groovy
@@ -352,16 +352,6 @@ enum Environment {
     }
 
     /**
-     * This method will return true the application is run
-     *
-     * @return True if the development sources are present
-     */
-    static boolean isDevelopmentRun() {
-        Environment env = getCurrent()
-        return isDevelopmentEnvironmentAvailable() && Boolean.getBoolean(RUN_ACTIVE) && (env == Environment.DEVELOPMENT)
-    }
-
-    /**
      * Checks if the run of the app is due to spring dev-tools or not.
      * @return True if spring-dev-tools restart
      */

--- a/grails-gradle/model/src/main/groovy/grails/util/Environment.groovy
+++ b/grails-gradle/model/src/main/groovy/grails/util/Environment.groovy
@@ -82,11 +82,6 @@ enum Environment {
     public static String RELOAD_ENABLED = 'grails.reload.enabled'
 
     /**
-     * Constant indicating whether run-app or test-app was executed
-     */
-    public static String RUN_ACTIVE = 'grails.run.active'
-
-    /**
      * Whether the display of full stack traces is needed
      */
     public static String FULL_STACKTRACE = 'grails.full.stacktrace'

--- a/grails-gradle/plugins/build.gradle
+++ b/grails-gradle/plugins/build.gradle
@@ -104,6 +104,12 @@ gradlePlugin {
             id = 'org.apache.grails.gradle.grails-publish-profile'
             implementationClass = 'org.grails.gradle.plugin.profiles.GrailsProfilePublishGradlePlugin'
         }
+        grailsExploded {
+            displayName = 'Grails Exploded Plugin'
+            description = 'A plugin that configures a Grails Plugin so that its classes and resources are exploded when running bootRun from a dependent Application'
+            id = 'org.apache.grails.gradle.grails-exploded'
+            implementationClass = 'org.grails.gradle.plugin.exploded.GrailsExplodedPlugin'
+        }
     }
 }
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -22,6 +22,10 @@ import groovy.transform.CompileStatic
 
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.util.internal.ConfigureUtil
+
+import grails.util.Environment
 
 /**
  * A extension to the Gradle plugin to configure Grails settings
@@ -33,10 +37,13 @@ import org.gradle.api.Project
 class GrailsExtension {
 
     Project project
+    PluginDefiner pluginDefiner
 
     GrailsExtension(Project project) {
         this.project = project
+        this.pluginDefiner = new PluginDefiner(project)
     }
+
     /**
      * Whether to invoke native2ascii on resource bundles
      */
@@ -51,11 +58,6 @@ class GrailsExtension {
      * Whether assets should be packaged in META-INF/assets for plugins
      */
     boolean packageAssets = true
-
-    /**
-     * Whether to include subproject dependencies as directories directly on the classpath, instead of as JAR files
-     */
-    boolean exploded = true
 
     /**
      * Whether java.time.* package should be a default import package
@@ -89,15 +91,25 @@ class GrailsExtension {
         return agent
     }
 
+    DependencyHandler getPlugins() {
+        if (pluginDefiner == null) {
+            pluginDefiner = new PluginDefiner(project)
+        }
+
+        pluginDefiner
+    }
+
     /**
      * Allows defining plugins in the available scopes
      */
-    void plugins(Closure pluginDefinitions) {
-        PluginDefiner definer = new PluginDefiner(project, exploded)
-        pluginDefinitions.delegate = definer
-        pluginDefinitions.resolveStrategy = Closure.DELEGATE_FIRST
-        pluginDefinitions.call()
+    void plugins(@DelegatesTo(DependencyHandler) Closure configureClosure) {
+        if (pluginDefiner == null) {
+            pluginDefiner = new PluginDefiner(project)
+        }
+        pluginDefiner.grailsRun = developmentRun
+        ConfigureUtil.configure(configureClosure, plugins)
     }
+
     /**
      * Configuration for the reloading agent
      */
@@ -115,4 +127,12 @@ class GrailsExtension {
         List<String> jvmArgs = ['-Xverify:none']
     }
 
+    boolean isDevelopmentRun() {
+        boolean devMode = Environment.developmentEnvironmentAvailable && Environment.developmentMode
+        if (!devMode) {
+            return false
+        }
+
+        project.gradle.startParameter.taskNames.any { String taskName -> taskName in ['bootRun', 'console'] } || project.hasProperty('force.grails.exploded')
+    }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -102,11 +102,11 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     void apply(Project project) {
         // validate that only an app or a plugin is registered, and never both
-        OnlyOneGrailsPlugin marker = (OnlyOneGrailsPlugin) project.getExtensions().findByName(OnlyOneGrailsPlugin.class.name)
+        OnlyOneGrailsPlugin marker = (OnlyOneGrailsPlugin) project.getExtensions().findByName(OnlyOneGrailsPlugin.name)
         if (marker) {
             throw new GradleException("Project ${project.name} cannot be both a Grails application and a Grails plugin. Previously applied plugin: ${marker.pluginClassname}. Cannot apply: ${getClass().name}")
         }
-        project.getExtensions().add(OnlyOneGrailsPlugin.class.name, new OnlyOneGrailsPlugin(pluginClassname: getClass().name))
+        project.getExtensions().add(OnlyOneGrailsPlugin.name, new OnlyOneGrailsPlugin(pluginClassname: getClass().name))
 
         // reset the environment to ensure it is resolved again for each invocation
         Environment.reset()

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -23,6 +23,8 @@ import javax.inject.Inject
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
+import org.gradle.api.attributes.AttributeMatchingStrategy
+
 import io.spring.gradle.dependencymanagement.DependencyManagementPlugin
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
 import org.apache.tools.ant.filters.EscapeUnicode
@@ -69,6 +71,9 @@ import org.grails.build.parsing.CommandLineParser
 import org.grails.gradle.plugin.agent.AgentTasksEnhancer
 import org.grails.gradle.plugin.commands.ApplicationContextCommandTask
 import org.grails.gradle.plugin.commands.ApplicationContextScriptTask
+import org.grails.gradle.plugin.exploded.ExplodedCompatibilityRule
+import org.grails.gradle.plugin.exploded.ExplodedDisambiguationRule
+import org.grails.gradle.plugin.exploded.GrailsExplodedPlugin
 import org.grails.gradle.plugin.model.GrailsClasspathToolingModelBuilder
 import org.grails.gradle.plugin.run.FindMainClassTask
 import org.grails.gradle.plugin.util.SourceSets
@@ -155,6 +160,21 @@ class GrailsGradlePlugin extends GroovyPlugin {
         configureRunCommand(project)
 
         configureGroovyCompiler(project)
+
+        configureMatchingExplodedRules(project)
+    }
+
+    private void configureMatchingExplodedRules(Project project) {
+        /**
+         * the exploded plugin may or may not be configured for the given project, these rules ensure tasks that are considered "development"
+         * running tasks (like bootRun) will prefer the exploded variant of a plugin if it is available but still match the non-exploded variant if not.
+         */
+        project.dependencies.attributesSchema { schema ->
+            schema.attribute(GrailsExplodedPlugin.EXPLODED_ATTRIBUTE).with { AttributeMatchingStrategy details ->
+                details.compatibilityRules.add(ExplodedCompatibilityRule)
+                details.disambiguationRules.add(ExplodedDisambiguationRule)
+            }
+        }
     }
 
     private static Provider<String> getMainClassProvider(Project project) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -97,6 +97,13 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     void apply(Project project) {
+        // validate that only an app or a plugin is registered, and never both
+        OnlyOneGrailsPlugin marker = (OnlyOneGrailsPlugin) project.getExtensions().findByName(OnlyOneGrailsPlugin.class.name)
+        if (marker) {
+            throw new GradleException("Project ${project.name} cannot be both a Grails application and a Grails plugin. Previously applied plugin: ${marker.pluginClassname}. Cannot apply: ${getClass().name}")
+        }
+        project.getExtensions().add(OnlyOneGrailsPlugin.class.name, new OnlyOneGrailsPlugin(pluginClassname: getClass().name))
+
         // reset the environment to ensure it is resolved again for each invocation
         Environment.reset()
 
@@ -904,5 +911,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
             fileCollection = fileCollection + it.filter({ File file -> !file.name.startsWith('spring-boot-devtools') })
         }
         fileCollection
+    }
+
+    @CompileStatic
+    private static final class OnlyOneGrailsPlugin {
+        String pluginClassname
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -36,7 +36,6 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyResolveDetails
 import org.gradle.api.artifacts.DependencySet
-import org.gradle.api.file.Directory
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
@@ -107,7 +106,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
         // reset the environment to ensure it is resolved again for each invocation
         Environment.reset()
 
-        if (project.tasks.findByName('compileGroovy') == null) {
+        if (!project.tasks.names.contains('compileGroovy')) {
             super.apply(project)
         }
 
@@ -156,20 +155,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
         configureRunCommand(project)
 
         configureGroovyCompiler(project)
-
-        addGroovyCompilerScript('GrailsCore', project) {
-            if (!project.extensions.findByType(GrailsExtension).importJavaTime) {
-                return null
-            }
-
-            '''
-                withConfig(configuration) {
-                    imports {
-                        star 'java.time'
-                    }
-                }
-            '''.stripIndent(16)
-        }
     }
 
     private static Provider<String> getMainClassProvider(Project project) {
@@ -185,94 +170,56 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     private void configureGroovyCompiler(Project project) {
-        Provider<Directory> sourceConfigFiles = project.layout.buildDirectory.dir('groovyCompilerConfiguration')
         Provider<RegularFile> groovyCompilerConfigFile = project.layout.buildDirectory.file('grailsGroovyCompilerConfig.groovy')
-        if (!project.tasks.findByName('configureGroovyCompiler')) {
-            TaskProvider<Task> cleanGroovyConfigProvider = project.tasks.register('cleanGroovyCompilerConfig')
-            cleanGroovyConfigProvider.configure { Task task ->
-                task.group = 'build'
-                task.doFirst {
-                    sourceConfigFiles.get().asFile.deleteDir()
-                    sourceConfigFiles.get().asFile.mkdirs()
 
-                    File combinedFile = groovyCompilerConfigFile.get().asFile
-                    if (!combinedFile.exists()) {
-                        combinedFile.parentFile.mkdirs()
-                        combinedFile.createNewFile()
-                    }
-                    combinedFile.write('// Placeholder for grails metadata and other configuration')
+        project.tasks.withType(GroovyCompile).configureEach { GroovyCompile c ->
+            c.outputs.file(groovyCompilerConfigFile)
+
+            Closure<String> userScriptGenerator = getGroovyCompilerScript(c, project)
+            c.doFirst {
+                // This isn't ideal - we're performing configuration at execution time, but the alternative would be having
+                // to maintain a clean / configuration task and then gradle would want to cache those tasks.  Since the inputs
+                // to those tasks would effectively be the runtimeClasspath, dependency problems can arise if another task
+                // changes the runtimeClasspath. To prevent having to add those tasks into the dependency chain, use doFirst
+                File combinedFile = groovyCompilerConfigFile.get().asFile
+                if (!combinedFile.exists()) {
+                    combinedFile.parentFile.mkdirs()
+                    combinedFile.createNewFile()
                 }
-            }
-            // Merge the script at runtime so we don't suffer a performance penalty as part of every gradle task run
-            TaskProvider<Task> configureTaskProvider = project.tasks.register('configureGroovyCompiler')
-            configureTaskProvider.configure { Task task ->
-                task.group = 'build'
-                task.dependsOn('cleanGroovyCompilerConfig')
 
-                // Gradle will cache the output based on the directory, so we must ensure it exists
-                sourceConfigFiles.get().asFile.mkdirs()
-
-                task.inputs.dir(sourceConfigFiles)
-                task.outputs.file(groovyCompilerConfigFile)
-
-                task.doLast {
-                    List<String> scripts = sourceConfigFiles.get().asFile.listFiles({ File dir, String name ->
-                        name.endsWithIgnoreCase('groovy')
-                    } as FilenameFilter).collect { it.text }
-
-                    GroovyCompile compileTask = project.tasks.named('compileGroovy', GroovyCompile).get()
-                    if (compileTask.groovyOptions.configurationScript) {
-                        scripts << compileTask.groovyOptions.configurationScript.text
-                    }
-
-                    String combinedScripts = scripts.findResults { it?.trim() }.join('\n').trim()
-                    if (combinedScripts) {
-                        File combinedFile = groovyCompilerConfigFile.get().asFile
-                        combinedFile.parentFile.mkdirs()
-                        combinedFile.write(combinedScripts)
-                        compileTask.groovyOptions.configurationScript = combinedFile
-                    }
+                String configuredScript = null
+                if (c.groovyOptions.configurationScript) {
+                    configuredScript = c.groovyOptions.configurationScript.text?.trim() ?: null
                 }
-            }
+                String grailsScript = userScriptGenerator?.call()
 
-            // Because the gradle plugin extends the groovy plugin, this will always exist at this point
-            project.tasks.withType(GroovyCompile).configureEach {
-                it.dependsOn(configureTaskProvider, cleanGroovyConfigProvider)
+                String combinedScripts = """
+                    // Grails groovy compilation configuration to ensure ASTs are applied correctly
+                    
+                    ${grailsScript?.trim() ?: ''}
+
+                    ${configuredScript?.trim() ?: ''}
+                """
+                combinedFile.write(combinedScripts)
+                c.groovyOptions.configurationScript = combinedFile
             }
         }
     }
 
-    protected TaskProvider<Task> addGroovyCompilerScript(String uniqueScriptName, Project project, Closure scriptGenerator) {
-        String taskName = "configureGroovyCompiler${uniqueScriptName}" as String
-        if (taskName in project.tasks.names) {
-            return project.tasks.named(taskName)
+    protected Closure<String> getGroovyCompilerScript(GroovyCompile compile, Project project) {
+        GrailsExtension grails = project.extensions.findByType(GrailsExtension)
+        if (!grails.importJavaTime) {
+            return null
         }
 
-        TaskProvider<Task> configScriptTask = project.tasks.register(taskName)
-        configScriptTask.configure { Task task ->
-            task.group = 'build'
-
-            Provider<RegularFile> targetConfigFile = project.layout.buildDirectory.file("groovyCompilerConfiguration/${uniqueScriptName}Config.groovy")
-            task.outputs.file(targetConfigFile)
-            task.inputs.files(project.configurations.named('runtimeClasspath'))
-            task.dependsOn('cleanGroovyCompilerConfig')
-
-            task.doLast {
-                File file = targetConfigFile.get().asFile
-                file.delete()
-
-                String script = scriptGenerator.call(project)
-                if (script) {
-                    file.text = script
+        return { ->
+            '''withConfig(configuration) {
+                    imports {
+                        star 'java.time'
+                    }
                 }
-            }
+            '''
         }
-
-        project.tasks.named('configureGroovyCompiler').configure { Task task ->
-            task.dependsOn(configScriptTask)
-        }
-
-        return configScriptTask
     }
 
     protected void excludeDependencies(Project project) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -86,10 +86,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     public static final String APPLICATION_CONTEXT_COMMAND_CLASS = 'grails.dev.commands.ApplicationCommand'
 
-    protected static final List<String> CORE_GORM_LIBRARIES = ['async', 'core', 'simple', 'web', 'rest-client', 'gorm', 'gorm-validation', 'gorm-plugin-support', 'gorm-support', 'test-support', 'hibernate-core', 'gorm-test', 'rx', 'rx-plugin-support']
-    // NOTE: mongodb, neo4j etc. should NOT be included here so they can be independently versioned
-    protected static final List<String> CORE_GORM_PLUGINS = ['hibernate4', 'hibernate5']
-
     List<Class<Plugin>> basePluginClasses = [IntegrationTestGradlePlugin] as List<Class<Plugin>>
     List<String> excludedGrailsAppSourceDirs = ['migrations', 'assets']
     List<String> grailsAppResourceDirs = ['views', 'i18n', 'conf']

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -48,7 +48,8 @@ import org.grails.gradle.plugin.util.SourceSets
  */
 @CompileStatic
 class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
-    public static final String PLUGIN_ID = "org.apache.grails.gradle.grails-plugin"
+
+    public static final String PLUGIN_ID = 'org.apache.grails.gradle.grails-plugin'
 
     @Inject
     GrailsPluginGradlePlugin(ToolingModelBuilderRegistry registry) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -25,16 +25,10 @@ import groovy.transform.CompileStatic
 
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.language.jvm.tasks.ProcessResources
@@ -42,7 +36,6 @@ import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
-import grails.util.Environment
 import org.grails.gradle.plugin.run.FindMainClassTask
 import org.grails.gradle.plugin.util.SourceSets
 
@@ -55,6 +48,7 @@ import org.grails.gradle.plugin.util.SourceSets
  */
 @CompileStatic
 class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
+    public static final String PLUGIN_ID = "org.apache.grails.gradle.grails-plugin"
 
     @Inject
     GrailsPluginGradlePlugin(ToolingModelBuilderRegistry registry) {
@@ -99,41 +93,10 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
             }
             """ as String
         }
-
     }
 
     protected String getDefaultProfile() {
         'web-plugin'
-    }
-
-    /**
-     * Configures an exploded configuration that can be used to build the classpath of the application from subprojects that are plugins without contructing a JAR file
-     *
-     * @param project The project instance
-     */
-    protected void configureExplodedDirConfiguration(Project project) {
-        ConfigurationContainer allConfigurations = project.configurations
-        allConfigurations.register('exploded').configure {
-            Configuration runtimeConfiguration = allConfigurations.named('runtimeClasspath').get()
-            it.extendsFrom(runtimeConfiguration)
-
-            if (Environment.isDevelopmentRun() && isExploded(project)) {
-                runtimeConfiguration.artifacts.clear()
-                // add the subproject classes as outputs
-                TaskContainer allTasks = project.tasks
-
-                GroovyCompile groovyCompile = allTasks.named('compileGroovy', GroovyCompile).get()
-                ProcessResources processResources = allTasks.named('processResources', ProcessResources).get()
-
-                runtimeConfiguration.artifacts.add(new ExplodedDir(groovyCompile.destinationDir, groovyCompile, processResources))
-                it.artifacts.add(new ExplodedDir(processResources.destinationDir, groovyCompile, processResources))
-            }
-        }
-    }
-
-    @CompileDynamic
-    private boolean isExploded(Project project) {
-        Boolean.valueOf(project.properties.getOrDefault('exploded', 'false').toString())
     }
 
     @Override
@@ -308,30 +271,6 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         File groovyConfig = new File(project.projectDir, 'grails-app/conf/plugin.groovy')
         if (yamlConfig.exists() && groovyConfig.exists()) {
             throw new RuntimeException('A plugin may define a plugin.yml or a plugin.groovy, but not both')
-        }
-    }
-
-    static class ExplodedDir implements PublishArtifact {
-        final String extension = ''
-        final String type = 'dir'
-        final Date date = new Date()
-
-        final File file
-        final TaskDependency buildDependencies
-
-        ExplodedDir(File file, Object... tasks) {
-            this.file = file
-            this.buildDependencies = new DefaultTaskDependency().add(tasks)
-        }
-
-        @Override
-        String getName() {
-            file.name
-        }
-
-        @Override
-        String getClassifier() {
-            ''
         }
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -69,21 +69,6 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
 
         configureAstSources(project)
 
-        addGroovyCompilerScript('GrailsPlugin', project) {
-            """
-                withConfig(configuration) {
-                    inline(phase: 'CONVERSION') { source, context, classNode ->
-                        classNode.putNodeMetaData('projectVersion', '${project.version}')
-                        classNode.putNodeMetaData('projectName', '${project.name}')
-                        classNode.putNodeMetaData('isPlugin', 'true')
-                    }
-                }
-            """.stripIndent(16)
-        }.configure { Task task ->
-            task.inputs.property('version', project.provider { project.version.toString() })
-            task.inputs.property('name', project.provider { project.name })
-        }
-
         configureAssembleTask(project)
 
         configurePluginResources(project)
@@ -91,8 +76,30 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         configureJarTask(project)
 
         configureSourcesJarTask(project)
+    }
 
-        configureExplodedDirConfiguration(project)
+    @Override
+    protected Closure<String> getGroovyCompilerScript(GroovyCompile compile, Project project) {
+        def versionProvider = project.provider { project.version.toString() }
+        compile.inputs.property('version', versionProvider)
+
+        def projectNameProvider = project.provider { project.name }
+        compile.inputs.property('name', projectNameProvider)
+
+        Closure<String> parent = super.getGroovyCompilerScript(compile, project)
+        return { ->
+            """${parent?.call() ?: ''}
+
+            withConfig(configuration) {
+                inline(phase: 'CONVERSION') { source, context, classNode ->
+                    classNode.putNodeMetaData('projectVersion', '${versionProvider.get()}')
+                    classNode.putNodeMetaData('projectName', '${projectNameProvider.get()}')
+                    classNode.putNodeMetaData('isPlugin', 'true')
+                }
+            }
+            """ as String
+        }
+
     }
 
     protected String getDefaultProfile() {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/PluginDefiner.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/PluginDefiner.groovy
@@ -18,68 +18,50 @@
  */
 package org.grails.gradle.plugin.core
 
-import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.attributes.AttributeContainer
 
-import grails.util.BuildSettings
-import grails.util.Environment
+import org.grails.gradle.plugin.exploded.GrailsExplodedPlugin
 
 /**
- * Makes it easier to define Grails plugins and also makes them aware of the development environment so that they can be run inline without creating a JAR
- *
- * @author Graeme Rocher
- * @since 3.2
+ * Tracks Grails Plugins & handles prioritizing using the exploded variants for easier class reloading during development
  */
 @PackageScope
-class PluginDefiner {
+class PluginDefiner implements DependencyHandler, GroovyInterceptable {
 
-    final Project project
-    final exploded
+    @Delegate
+    DependencyHandler target  // IDE/types; not used for the actual calls due to interception
 
-    PluginDefiner(Project project, boolean exploded = true) {
+    private final Project project
+    boolean grailsRun
+
+    List<ProjectDependency> dependencies = []
+
+    PluginDefiner(Project project) {
         this.project = project
-        this.exploded = exploded
+        this.target = project.dependencies
     }
 
-    void methodMissing(String name, args) {
-        Object[] argArray = (Object[]) args
+    def invokeMethod(String name, Object objArgs) {
+        def argArray = (objArgs instanceof Object[]) ? objArgs : [objArgs] as Object[]
 
-        if (!argArray) {
-            throw new MissingMethodException(name, GrailsExtension, args)
-        }
-        else {
-            if (argArray[0] instanceof Map) {
-                Map notation = (Map) argArray[0]
-                if (!notation.containsKey('group')) {
-                    notation.put('group', 'org.grails.plugins')
+        def methodMethod = target.metaClass.getMetaMethod(name, argArray)
+        def result = (methodMethod ? methodMethod.invoke(target, argArray) : target.invokeMethod(name, argArray))
+
+        if (result instanceof ProjectDependency) {
+            ProjectDependency dependency = (ProjectDependency) result
+            if (grailsRun) {
+                dependency.attributes { AttributeContainer ac ->
+                    ac.attribute(GrailsExplodedPlugin.EXPLODED_ATTRIBUTE, true)
                 }
             }
-            else if (argArray[0] instanceof CharSequence) {
-                String str = argArray[0].toString()
+            dependencies << dependency
+        }
 
-                if (str.startsWith(':')) {
-                    argArray[0] = "org.grails.plugins$str".toString()
-                }
-            }
-            else if (Environment.isDevelopmentRun() && (argArray[0] instanceof ProjectDependency)) {
-                ProjectDependency pd = argArray[0]
-                project.dependencies.add(name, project.files(new File(pd.dependencyProject.projectDir, BuildSettings.BUILD_RESOURCES_PATH)))
-            }
-            project.dependencies.add(name, *argArray)
-        }
-    }
-
-    @CompileStatic
-    Dependency project(String path) {
-        if (Environment.isDevelopmentRun()) {
-            project.dependencies.project(path: path, configuration: 'exploded')
-        }
-        else {
-            project.dependencies.project(path: path)
-        }
+        return result
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedCompatibilityRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedCompatibilityRule.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.attributes.CompatibilityCheckDetails
  * 2. attribute matches desired value
  */
 class ExplodedCompatibilityRule implements AttributeCompatibilityRule<Boolean> {
+
     @Override
     void execute(CompatibilityCheckDetails<Boolean> details) {
         if (details.getConsumerValue() == null) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedCompatibilityRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedCompatibilityRule.groovy
@@ -1,0 +1,20 @@
+package org.grails.gradle.plugin.exploded
+
+import org.gradle.api.attributes.AttributeCompatibilityRule
+import org.gradle.api.attributes.CompatibilityCheckDetails
+
+/**
+ * Compatible if:
+ * 1. attribute not defined
+ * 2. attribute matches desired value
+ */
+class ExplodedCompatibilityRule implements AttributeCompatibilityRule<Boolean> {
+    @Override
+    void execute(CompatibilityCheckDetails<Boolean> details) {
+        if (details.getConsumerValue() == null) {
+            details.compatible()
+        } else if (details.getProducerValue() == details.getConsumerValue()) {
+            details.compatible()
+        }
+    }
+}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedCompatibilityRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedCompatibilityRule.groovy
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.grails.gradle.plugin.exploded
 
 import org.gradle.api.attributes.AttributeCompatibilityRule

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedDisambiguationRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedDisambiguationRule.groovy
@@ -1,0 +1,18 @@
+package org.grails.gradle.plugin.exploded
+
+import org.gradle.api.attributes.AttributeDisambiguationRule
+import org.gradle.api.attributes.MultipleCandidatesDetails
+
+/**
+ * If true, then it's the closest match, otherwise not the closest. Prioritizes the exploded variant
+ */
+class ExplodedDisambiguationRule implements AttributeDisambiguationRule<Boolean> {
+    @Override
+    void execute(MultipleCandidatesDetails<Boolean> details) {
+        if (details.candidateValues.contains(Boolean.TRUE)) {
+            details.closestMatch(Boolean.TRUE)
+        } else {
+            details.closestMatch(Boolean.FALSE)
+        }
+    }
+}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedDisambiguationRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedDisambiguationRule.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.attributes.MultipleCandidatesDetails
  * If true, then it's the closest match, otherwise not the closest. Prioritizes the exploded variant
  */
 class ExplodedDisambiguationRule implements AttributeDisambiguationRule<Boolean> {
+
     @Override
     void execute(MultipleCandidatesDetails<Boolean> details) {
         if (details.candidateValues.contains(Boolean.TRUE)) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedDisambiguationRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/ExplodedDisambiguationRule.groovy
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.grails.gradle.plugin.exploded
 
 import org.gradle.api.attributes.AttributeDisambiguationRule

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/GrailsExplodedPlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/GrailsExplodedPlugin.groovy
@@ -1,0 +1,87 @@
+package org.grails.gradle.plugin.exploded
+
+import javax.inject.Inject
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ConfigurablePublishArtifact
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationVariant
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.compile.GroovyCompile
+import org.gradle.language.jvm.tasks.ProcessResources
+
+import org.grails.gradle.plugin.core.GrailsExtension
+import org.grails.gradle.plugin.core.GrailsPluginGradlePlugin
+
+/**
+ * Configures a Grails Plugin so that its classes and resources are exploded when running bootRun from a dependent Grails Application
+ */
+@CompileStatic
+class GrailsExplodedPlugin implements Plugin<Project> {
+    public static final String PLUGIN_ID = 'org.apache.grails.gradle.grails-exploded'
+    public static final String EXPLODED_VARIANT_NAME = 'exploded'
+    public static final Attribute EXPLODED_ATTRIBUTE = Attribute.of('grails.plugin.exploded', Boolean)
+
+    private ObjectFactory objects
+
+    @Inject
+    GrailsExplodedPlugin(ObjectFactory objects) {
+        this.objects = objects
+    }
+
+    @Override
+    void apply(Project project) {
+        project.pluginManager.withPlugin(GrailsPluginGradlePlugin.PLUGIN_ID) {
+            project.logger.info('Project {} will be exploded for bootRuns', project.name)
+
+            GrailsExtension grails = project.extensions.findByType(GrailsExtension)
+            Objects.requireNonNull(grails, 'GrailsExtension should be applied by the `grails-plugin` Gradle plugin.')
+
+            if (grails.developmentRun) {
+                project.logger.lifecycle('bootRun detected - exploding plugin {}', project.name)
+                project.configurations.named('runtimeElements').configure { Configuration runtimeElements ->
+                    runtimeElements.outgoing.variants.create(EXPLODED_VARIANT_NAME) { ConfigurationVariant v ->
+                        v.attributes { AttributeContainer ac ->
+                            // copy values from runtimeElements
+                            runtimeElements.attributes.keySet().each { Attribute<?> key ->
+                                Attribute<Object> typedKey = (Attribute<Object>) key
+                                Object value = runtimeElements.attributes.getAttribute(typedKey)
+                                if (value != null) {
+                                    ac.attribute(typedKey, value)
+                                }
+                            }
+
+                            // add our additional attribute
+                            ac.attribute(EXPLODED_ATTRIBUTE, true)
+
+                            def groovyCompileProvider = project.tasks.named('compileGroovy', GroovyCompile)
+                            def processResourcesProvider = project.tasks.named('processResources', ProcessResources)
+
+                            def groovyDir = groovyCompileProvider.get().destinationDirectory.get().asFile
+                            def resourcesDir = processResourcesProvider.get().destinationDir
+
+                            v.artifact(groovyDir) { ConfigurablePublishArtifact a ->
+                                a.type = ArtifactTypeDefinition.DIRECTORY_TYPE
+                                a.extension = ''
+                                a.classifier = ''
+                                a.builtBy(groovyCompileProvider, processResourcesProvider)
+                            }
+                            v.artifact(resourcesDir) { ConfigurablePublishArtifact a ->
+                                a.type = ArtifactTypeDefinition.DIRECTORY_TYPE
+                                a.extension = ''
+                                a.classifier = ''
+                                a.builtBy(groovyCompileProvider, processResourcesProvider)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/GrailsExplodedPlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/GrailsExplodedPlugin.groovy
@@ -24,6 +24,7 @@ import org.grails.gradle.plugin.core.GrailsPluginGradlePlugin
  */
 @CompileStatic
 class GrailsExplodedPlugin implements Plugin<Project> {
+
     public static final String PLUGIN_ID = 'org.apache.grails.gradle.grails-exploded'
     public static final String EXPLODED_VARIANT_NAME = 'exploded'
     public static final Attribute EXPLODED_ATTRIBUTE = Attribute.of('grails.plugin.exploded', Boolean)

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/GrailsExplodedPlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/exploded/GrailsExplodedPlugin.groovy
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.grails.gradle.plugin.exploded
 
 import javax.inject.Inject

--- a/grails-profiles/base/commands/run-app.groovy
+++ b/grails-profiles/base/commands/run-app.groovy
@@ -33,8 +33,6 @@ try {
         arguments << "-D${key}=$value".toString()
     }
 
-    arguments << "-Dgrails.run.active=true"
-
     if(port) {
         arguments << "-Dgrails.server.port=$port"
     }

--- a/grails-profiles/base/commands/test-app.groovy
+++ b/grails-profiles/base/commands/test-app.groovy
@@ -58,8 +58,6 @@ runTests = { List args ->
         additionalArguments << "-D${key}=$value".toString()
     }
 
-    additionalArguments << "-Dgrails.run.active=true"
-
     try {
         gradle."${args.join(' ')}"(*additionalArguments)
         addStatus "Tests PASSED"

--- a/grails-test-examples/exploded/build.gradle
+++ b/grails-test-examples/exploded/build.gradle
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+version = '0.1'
+group = 'exploded'
+
+apply plugin: 'org.apache.grails.gradle.grails-web'
+
+// The grails-gsp Gradle plugin is not needed for running the functional tests.
+// It is applied as a smoke test to check that compiling gsp
+// for production does not fail during build task.
+apply plugin: 'org.apache.grails.gradle.grails-gsp'
+
+dependencies {
+    implementation platform(project(':grails-bom'))
+
+    implementation 'org.apache.grails:grails-dependencies-starter-web'
+    implementation 'com.h2database:h2'
+    if (System.getenv('SITEMESH3_TESTING_ENABLED') == 'true') {
+        implementation 'org.apache.grails:grails-sitemesh3'
+    } else {
+        implementation 'org.apache.grails:grails-layout'
+    }
+
+    implementation 'org.apache.grails:grails-data-hibernate5'
+    implementation 'org.apache.grails:grails-cache'
+
+    runtimeOnly 'org.apache.grails:grails-scaffolding'
+    runtimeOnly 'org.apache.grails:grails-fields'
+
+    testImplementation 'org.apache.grails:grails-testing-support-web'
+    testImplementation 'org.apache.grails:grails-testing-support-datamapping'
+
+    console 'org.apache.grails:grails-console'
+
+    integrationTestImplementation testFixtures('org.apache.grails:grails-geb')
+}
+
+grails {
+    plugins {
+        implementation project(':grails-test-examples-plugins-exploded')
+    }
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
+}

--- a/grails-test-examples/exploded/grails-app/conf/application.yml
+++ b/grails-test-examples/exploded/grails-app/conf/application.yml
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+grails:
+  profile: web
+  codegen:
+    defaultPackage: exploded
+info:
+  app:
+    name: '@info.app.name@'
+    version: '@info.app.version@'
+    grailsVersion: '@info.app.grailsVersion@'
+spring:
+  groovy:
+    template:
+      check-template-location: false
+
+---
+grails:
+  mime:
+    disable:
+      accept:
+        header:
+          userAgents:
+            - Gecko
+            - WebKit
+            - Presto
+            - Trident
+    types:
+      all: '*/*'
+      atom: application/atom+xml
+      css: text/css
+      csv: text/csv
+      form: application/x-www-form-urlencoded
+      html:
+        - text/html
+        - application/xhtml+xml
+      js: text/javascript
+      json:
+        - application/json
+        - text/json
+      multipartForm: multipart/form-data
+      rss: application/rss+xml
+      text: text/plain
+      hal:
+        - application/hal+json
+        - application/hal+xml
+      xml:
+        - text/xml
+        - application/xml
+  urlmapping:
+    cache:
+      maxsize: 1000
+  controllers:
+    defaultScope: singleton
+  converters:
+    encoding: UTF-8
+  hibernate:
+    cache:
+      queries: false
+  views:
+    default:
+      codec: html
+    gsp:
+      encoding: UTF-8
+      htmlcodec: xml
+      codecs:
+        expression: html
+        scriptlets: html
+        taglib: none
+        staticparts: none
+
+---
+dataSource:
+  pooled: true
+  jmxExport: true
+  driverClassName: org.h2.Driver
+  username: sa
+  password:
+
+environments:
+  development:
+    dataSource:
+      dbCreate: create-drop
+      url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+  test:
+    dataSource:
+      dbCreate: update
+      url: jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+  production:
+    dataSource:
+      dbCreate: update
+      url: jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+      properties:
+        jmxEnabled: true
+        initialSize: 5
+        maxActive: 50
+        minIdle: 5
+        maxIdle: 25
+        maxWait: 10000
+        maxAge: 600000
+        timeBetweenEvictionRunsMillis: 5000
+        minEvictableIdleTimeMillis: 60000
+        validationQuery: SELECT 1
+        validationQueryTimeout: 3
+        validationInterval: 15000
+        testOnBorrow: true
+        testWhileIdle: true
+        testOnReturn: false
+        jdbcInterceptors: ConnectionState
+        defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED

--- a/grails-test-examples/exploded/grails-app/conf/logback.xml
+++ b/grails-test-examples/exploded/grails-app/conf/logback.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+
+-->
+<configuration>
+
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter"/>
+    <conversionRule conversionWord="wex"
+                    class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint}
+                %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/grails-test-examples/exploded/grails-app/conf/spring/resources.groovy
+++ b/grails-test-examples/exploded/grails-app/conf/spring/resources.groovy
@@ -1,0 +1,22 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+// Place your Spring DSL code here
+beans = {
+}

--- a/grails-test-examples/exploded/grails-app/controllers/exploded/UrlMappings.groovy
+++ b/grails-test-examples/exploded/grails-app/controllers/exploded/UrlMappings.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+class UrlMappings {
+
+    static mappings = {
+        "/$controller/$action?/$id?(.$format)?" {
+
+        }
+
+        "/"(view: "/index")
+        "500"(view: '/error')
+        "404"(view: '/notFound')
+    }
+}

--- a/grails-test-examples/exploded/grails-app/init/exploded/Application.groovy
+++ b/grails-test-examples/exploded/grails-app/init/exploded/Application.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+import grails.boot.GrailsApp
+import grails.boot.config.GrailsAutoConfiguration
+
+class Application extends GrailsAutoConfiguration {
+    static void main(String[] args) {
+        GrailsApp.run(Application, args)
+    }
+}

--- a/grails-test-examples/exploded/grails-app/init/exploded/BootStrap.groovy
+++ b/grails-test-examples/exploded/grails-app/init/exploded/BootStrap.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+class BootStrap {
+
+    def init = {
+    }
+
+    def destroy = {
+    }
+}

--- a/grails-test-examples/exploded/grails-app/views/error.gsp
+++ b/grails-test-examples/exploded/grails-app/views/error.gsp
@@ -1,0 +1,50 @@
+<%--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  --%>
+<!doctype html>
+<html>
+<head>
+    <title><g:if env="development">Grails Runtime Exception</g:if><g:else>Error</g:else></title>
+    <meta name="layout" content="main">
+    <g:if env="development"><asset:stylesheet src="errors.css"/></g:if>
+</head>
+
+<body>
+<g:if env="development">
+    <g:if test="${Throwable.isInstance(exception)}">
+        <g:renderException exception="${exception}"/>
+    </g:if>
+    <g:elseif test="${request.getAttribute('jakarta.servlet.error.exception')}">
+        <g:renderException exception="${request.getAttribute('jakarta.servlet.error.exception')}"/>
+    </g:elseif>
+    <g:else>
+        <ul class="errors">
+            <li>An error has occurred</li>
+            <li>Exception: ${exception}</li>
+            <li>Message: ${message}</li>
+            <li>Path: ${path}</li>
+        </ul>
+    </g:else>
+</g:if>
+<g:else>
+    <ul class="errors">
+        <li>An error has occurred</li>
+    </ul>
+</g:else>
+</body>
+</html>

--- a/grails-test-examples/exploded/grails-app/views/index.gsp
+++ b/grails-test-examples/exploded/grails-app/views/index.gsp
@@ -1,0 +1,147 @@
+<%--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  --%>
+<!doctype html>
+<html>
+<head>
+    <meta name="layout" content="main"/>
+    <title>Welcome to Grails</title>
+    <style type="text/css" media="screen">
+    #status {
+        background-color: #eee;
+        border: .2em solid #fff;
+        margin: 2em 2em 1em;
+        padding: 1em;
+        width: 12em;
+        float: left;
+        -moz-box-shadow: 0px 0px 1.25em #ccc;
+        -webkit-box-shadow: 0px 0px 1.25em #ccc;
+        box-shadow: 0px 0px 1.25em #ccc;
+        -moz-border-radius: 0.6em;
+        -webkit-border-radius: 0.6em;
+        border-radius: 0.6em;
+    }
+
+    #status ul {
+        font-size: 0.9em;
+        list-style-type: none;
+        margin-bottom: 0.6em;
+        padding: 0;
+    }
+
+    #status li {
+        line-height: 1.3;
+    }
+
+    #status h1 {
+        text-transform: uppercase;
+        font-size: 1.1em;
+        margin: 0 0 0.3em;
+    }
+
+    #page-body {
+        margin: 2em 1em 1.25em 18em;
+    }
+
+    h2 {
+        margin-top: 1em;
+        margin-bottom: 0.3em;
+        font-size: 1em;
+    }
+
+    p {
+        line-height: 1.5;
+        margin: 0.25em 0;
+    }
+
+    #controller-list ul {
+        list-style-position: inside;
+    }
+
+    #controller-list li {
+        line-height: 1.3;
+        list-style-position: inside;
+        margin: 0.25em 0;
+    }
+
+    @media screen and (max-width: 480px) {
+        #status {
+            display: none;
+        }
+
+        #page-body {
+            margin: 0 1em 1em;
+        }
+
+        #page-body h1 {
+            margin-top: 0;
+        }
+    }
+    </style>
+</head>
+
+<body>
+<a href="#page-body" class="skip"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+
+<div id="status" role="complementary">
+    <h1>Application Status</h1>
+    <ul>
+        <li>Environment: ${grails.util.Environment.current.name}</li>
+        <li>App profile: ${grailsApplication.config.grails?.profile}</li>
+        <li>App version: <g:meta name="info.app.version"/></li>
+        <li>Grails version: <g:meta name="info.app.grailsVersion"/></li>
+        <li>Groovy version: ${GroovySystem.getVersion()}</li>
+        <li>JVM version: ${System.getProperty('java.version')}</li>
+        <li>Reloading active: ${grails.util.Environment.reloadingAgentEnabled}</li>
+    </ul>
+
+    <h1>Artefacts</h1>
+    <ul>
+        <li>Controllers: ${grailsApplication.controllerClasses.size()}</li>
+        <li>Domains: ${grailsApplication.domainClasses.size()}</li>
+        <li>Services: ${grailsApplication.serviceClasses.size()}</li>
+        <li>Tag Libraries: ${grailsApplication.tagLibClasses.size()}</li>
+    </ul>
+
+    <h1>Installed Plugins</h1>
+    <ul>
+        <g:each var="plugin" in="${applicationContext.getBean('pluginManager').allPlugins}">
+            <li>${plugin.name} - ${plugin.version}</li>
+        </g:each>
+    </ul>
+</div>
+
+<div id="page-body" role="main">
+    <h1>Welcome to Grails</h1>
+
+    <p>Congratulations, you have successfully started your first Grails application! At the moment
+    this is the default page, feel free to modify it to either redirect to a controller or display whatever
+    content you may choose. Below is a list of controllers that are currently deployed in this application,
+    click on each to execute its default action:</p>
+
+    <div id="controller-list" role="navigation">
+        <h2>Available Controllers:</h2>
+        <ul>
+            <g:each var="c" in="${grailsApplication.controllerClasses.sort { it.fullName }}">
+                <li class="controller"><g:link controller="${c.logicalPropertyName}">${c.fullName}</g:link></li>
+            </g:each>
+        </ul>
+    </div>
+</div>
+</body>
+</html>

--- a/grails-test-examples/exploded/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/exploded/grails-app/views/layouts/main.gsp
@@ -1,0 +1,40 @@
+<%--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  --%>
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title><g:layoutTitle default="Grails"/></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <asset:stylesheet src="application.css"/>
+    <asset:javascript src="application.js"/>
+
+    <g:layoutHead/>
+</head>
+
+<body>
+<div id="grailsLogo" role="banner"><a href="https://grails.apache.org"><asset:image src="grails_logo.png"
+                                                                                    alt="Grails"/></a></div>
+<g:layoutBody/>
+<div class="footer" role="contentinfo"></div>
+
+<div id="spinner" class="spinner" style="display:none;"><g:message code="spinner.alt" default="Loading&hellip;"/></div>
+</body>
+</html>

--- a/grails-test-examples/exploded/grails-app/views/notFound.gsp
+++ b/grails-test-examples/exploded/grails-app/views/notFound.gsp
@@ -1,0 +1,29 @@
+<%--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  --%>
+<!doctype html>
+<html>
+<head>
+    <title>Page Not Found</title>
+    <meta name="layout" content="main">
+</head>
+
+<body>
+<p>Page Not Found</p>
+</body>
+</html>

--- a/grails-test-examples/exploded/src/integration-test/groovy/exploded/LoadAfterSpec.groovy
+++ b/grails-test-examples/exploded/src/integration-test/groovy/exploded/LoadAfterSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+import grails.plugin.geb.ContainerGebSpec
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class LoadAfterSpec extends ContainerGebSpec {
+
+    void "Basic test to prove reloading worked"() {
+        when:
+        go('/login/auth')
+
+        then:
+        title == "My Plugin Login Auth"
+    }
+}

--- a/grails-test-examples/plugins/exploded/build.gradle
+++ b/grails-test-examples/plugins/exploded/build.gradle
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+version = '0.1-SNAPSHOT'
+group = 'com.example.grails.plugins'
+
+apply plugin: 'java-library'
+apply plugin: 'org.apache.grails.gradle.grails-plugin'
+apply plugin: 'org.apache.grails.gradle.grails-gsp'
+apply plugin: 'org.apache.grails.gradle.grails-exploded'
+
+dependencies {
+    implementation platform(project(':grails-bom'))
+
+    if (System.getenv('SITEMESH3_TESTING_ENABLED') == 'true') {
+        api 'org.apache.grails:grails-sitemesh3'
+    } else {
+        api 'org.apache.grails:grails-layout'
+    }
+    api 'org.apache.grails:grails-dependencies-starter-web'
+    api 'com.h2database:h2'
+    api 'jakarta.servlet:jakarta.servlet-api'
+
+    implementation "org.apache.grails:grails-spring-security:$grailsSpringSecurityVersion"
+
+    console 'org.apache.grails:grails-console'
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
+}

--- a/grails-test-examples/plugins/exploded/grails-app/conf/application.yml
+++ b/grails-test-examples/plugins/exploded/grails-app/conf/application.yml
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+grails:
+  profile: web-plugin
+  codegen:
+    defaultPackage: exploded
+  gorm:
+    reactor:
+      # Whether to translate GORM events into Reactor events
+      # Disabled by default for performance reasons
+      events: false
+info:
+  app:
+    name: '@info.app.name@'
+    version: '@info.app.version@'
+    grailsVersion: '@info.app.grailsVersion@'
+spring:
+  main:
+    banner-mode: "off"
+  groovy:
+    template:
+      check-template-location: false
+
+# Spring Actuator Endpoints are Disabled by Default
+endpoints:
+  enabled: false
+  jmx:
+    enabled: true
+
+---
+grails:
+  mime:
+    disable:
+      accept:
+        header:
+          userAgents:
+            - Gecko
+            - WebKit
+            - Presto
+            - Trident
+    types:
+      all: '*/*'
+      atom: application/atom+xml
+      css: text/css
+      csv: text/csv
+      form: application/x-www-form-urlencoded
+      html:
+        - text/html
+        - application/xhtml+xml
+      js: text/javascript
+      json:
+        - application/json
+        - text/json
+      multipartForm: multipart/form-data
+      pdf: application/pdf
+      rss: application/rss+xml
+      text: text/plain
+      hal:
+        - application/hal+json
+        - application/hal+xml
+      xml:
+        - text/xml
+        - application/xml
+  urlmapping:
+    cache:
+      maxsize: 1000
+  controllers:
+    defaultScope: singleton
+  converters:
+    encoding: UTF-8
+  views:
+    default:
+      codec: html
+    gsp:
+      encoding: UTF-8
+      htmlcodec: xml
+      codecs:
+        expression: html
+        scriptlets: html
+        taglib: none
+        staticparts: none
+endpoints:
+  jmx:
+    unique-names: true

--- a/grails-test-examples/plugins/exploded/grails-app/conf/logback.xml
+++ b/grails-test-examples/plugins/exploded/grails-app/conf/logback.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+
+-->
+<configuration>
+
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter"/>
+    <conversionRule conversionWord="wex"
+                    class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint}
+                %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/grails-test-examples/plugins/exploded/grails-app/controllers/exploded/LoginController.groovy
+++ b/grails-test-examples/plugins/exploded/grails-app/controllers/exploded/LoginController.groovy
@@ -1,0 +1,27 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+class LoginController {
+
+    def auth() {
+        [pageTitle: "My Plugin Login Auth"]
+    }
+}

--- a/grails-test-examples/plugins/exploded/grails-app/controllers/exploded/UrlMappings.groovy
+++ b/grails-test-examples/plugins/exploded/grails-app/controllers/exploded/UrlMappings.groovy
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+class UrlMappings {
+
+    static mappings = {
+        "/$controller/$action?/$id?(.$format)?" {
+            constraints {
+                // apply constraints here
+            }
+        }
+
+        "/"(view: "/index")
+        "500"(view: '/error')
+        "404"(view: '/notFound')
+    }
+}

--- a/grails-test-examples/plugins/exploded/grails-app/init/exploded/Application.groovy
+++ b/grails-test-examples/plugins/exploded/grails-app/init/exploded/Application.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+import grails.boot.GrailsApp
+import grails.boot.config.GrailsAutoConfiguration
+
+class Application extends GrailsAutoConfiguration {
+    static void main(String[] args) {
+        GrailsApp.run(Application, args)
+    }
+}

--- a/grails-test-examples/plugins/exploded/grails-app/init/exploded/BootStrap.groovy
+++ b/grails-test-examples/plugins/exploded/grails-app/init/exploded/BootStrap.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+class BootStrap {
+
+    def init = {
+    }
+
+    def destroy = {
+    }
+}

--- a/grails-test-examples/plugins/exploded/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/plugins/exploded/grails-app/views/layouts/main.gsp
@@ -1,0 +1,70 @@
+<%--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  --%>
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <title>
+    <g:layoutTitle default="Grails"/>
+    </title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <asset:link rel="icon" href="favicon.ico" type="image/x-ico"/>
+
+    <asset:stylesheet src="application.css"/>
+
+    <g:layoutHead/>
+</head>
+
+<body>
+
+<div class="navbar navbar-default navbar-static-top" role="navigation">
+    <div class="container">
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/#">
+                <asset:image src="grails.svg" alt="Grails Logo"/>
+            </a>
+        </div>
+
+        <div class="navbar-collapse collapse" aria-expanded="false" style="height: 0.8px;">
+            <ul class="nav navbar-nav navbar-right">
+                <g:pageProperty name="page.nav"/>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<g:layoutBody/>
+
+<div class="footer" role="contentinfo"></div>
+
+<div id="spinner" class="spinner" style="display:none;">
+    <g:message code="spinner.alt" default="Loading&hellip;"/>
+</div>
+
+<asset:javascript src="application.js"/>
+
+</body>
+</html>

--- a/grails-test-examples/plugins/exploded/grails-app/views/login/auth.gsp
+++ b/grails-test-examples/plugins/exploded/grails-app/views/login/auth.gsp
@@ -1,0 +1,31 @@
+<%--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  --%>
+<!doctype html>
+<html>
+<head>
+    <meta name="layout" content="main"/>
+    <title>${pageTitle}</title>
+</head>
+
+<body>
+<div>
+    <p>My Plugin Login Page</p>
+</div>
+</body>
+</html>

--- a/grails-test-examples/plugins/exploded/src/main/groovy/exploded/ExplodedGrailsPlugin.groovy
+++ b/grails-test-examples/plugins/exploded/src/main/groovy/exploded/ExplodedGrailsPlugin.groovy
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package exploded
+
+import grails.plugins.*
+
+class ExplodedGrailsPlugin extends Plugin {
+
+    def title = "Exploded Plugin"
+    def author = "Your name"
+    def authorEmail = ""
+    def description = '''\
+Brief summary/description of the plugin.
+'''
+    def profiles = ['web']
+
+    def loadAfter = ['springSecurityCore']
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -349,6 +349,7 @@ include(
         'grails-test-examples-app2',
         'grails-test-examples-app3',
         'grails-test-examples-external-configuration',
+        'grails-test-examples-exploded',
         'grails-test-examples-datasources',
         'grails-test-examples-namespaces',
         'grails-test-examples-geb',
@@ -368,6 +369,7 @@ include(
         'grails-test-examples-plugins-loadafter',
         'grails-test-examples-plugins-issue11005',
         'grails-test-examples-issue-11767',
+        'grails-test-examples-plugins-exploded',
         'grails-test-examples-plugins-issue-11767',
         'grails-test-examples-cache',
         'grails-test-examples-scaffolding',
@@ -379,6 +381,7 @@ project(':grails-test-examples-app1').projectDir = file('grails-test-examples/ap
 project(':grails-test-examples-app2').projectDir = file('grails-test-examples/app2')
 project(':grails-test-examples-app3').projectDir = file('grails-test-examples/app3')
 project(':grails-test-examples-external-configuration').projectDir = file('grails-test-examples/external-configuration')
+project(':grails-test-examples-exploded').projectDir = file('grails-test-examples/exploded')
 project(':grails-test-examples-datasources').projectDir = file('grails-test-examples/datasources')
 project(':grails-test-examples-geb').projectDir = file('grails-test-examples/geb')
 project(':grails-test-examples-geb-gebconfig').projectDir = file('grails-test-examples/geb-gebconfig')
@@ -398,6 +401,7 @@ project(':grails-test-examples-plugins-loadsecond').projectDir = file('grails-te
 project(':grails-test-examples-plugins-loadafter').projectDir = file('grails-test-examples/plugins/loadafter')
 project(':grails-test-examples-plugins-issue11005').projectDir = file('grails-test-examples/plugins/issue11005')
 project(':grails-test-examples-issue-11767').projectDir = file('grails-test-examples/issue-11767')
+project(':grails-test-examples-plugins-exploded').projectDir = file('grails-test-examples/plugins/exploded')
 project(':grails-test-examples-plugins-issue-11767').projectDir = file('grails-test-examples/plugins/issue-11767')
 project(':grails-test-examples-cache').projectDir = file('grails-test-examples/cache')
 project(':grails-test-examples-scaffolding').projectDir = file('grails-test-examples/scaffolding')


### PR DESCRIPTION
While multiproject reloading was possible before Grails 6, it was rather difficult to configure, the following had to be done: 

1. the property `grails.run.active` was set
2. the plugin project had the property `exploded` set to `true` prior to the application of the `grails-plugin` Gradle plugin
3. plugins were added to the Grails Application project via the `plugins` block inside of the `grails` extension in `build.gradle` instead of the `dependencies` block
4. the property `exploded` was set on the `grails` extension in `build.gradle` of the Grails Application project

This PR cleans up this process by adding a new gradle plugin `org.apache.grails.gradle.grails-exploded`, now the following has to be true for reloading to work: 

1. In the plugin project, apply the gradle plugin `org.apache.grails.gradle.grails-exploded`
2. In the application project, define plugins inside of the `plugins` block of the `grails` extension in `build.gradle`:

As part of this PR, I have also: 

1. cleaned up old variables on GrailsGradlePlugin that are no longer used since we adopted the grails-bom
2. moved the groovy compilation configuration back into compileGroovy.  

For the groovy compile configuration changes, the core issue is we need to be sure a non-cached version of the configuration file is generated whenever groovy would recompile / not cache.  The issue is to do this we need to depend on the runtimeClasspath - if the build changes we need to rerun, if the project switches from application to a plugin we need to rerun, if the project name changes rerun, if the version changes rerun, etc.  This means that any task that interacts with the runtime classpath, now needs to declare a dependency on our customization task.  This really makes the build fragile and is the reason I've moved the configuration back into doFirst { }.  When gradle changes the configuration to be provider based, I think we can revisit this.