### PR TITLE
Add 'migrations' to grailsAppResourceDirs resolve duplicates

### DIFF
--- a/grails-data-hibernate5/dbmigration/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
+++ b/grails-data-hibernate5/dbmigration/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
@@ -65,8 +65,6 @@ import liquibase.lockservice.LockService
 import liquibase.lockservice.LockServiceFactory
 import liquibase.parser.ChangeLogParserFactory
 import liquibase.resource.ClassLoaderResourceAccessor
-import liquibase.resource.CompositeResourceAccessor
-import liquibase.resource.FileSystemResourceAccessor
 import liquibase.resource.ResourceAccessor
 import liquibase.statement.core.RawSqlStatement
 import liquibase.structure.core.Catalog

--- a/grails-data-hibernate5/dbmigration/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
+++ b/grails-data-hibernate5/dbmigration/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
@@ -65,6 +65,8 @@ import liquibase.lockservice.LockService
 import liquibase.lockservice.LockServiceFactory
 import liquibase.parser.ChangeLogParserFactory
 import liquibase.resource.ClassLoaderResourceAccessor
+import liquibase.resource.CompositeResourceAccessor
+import liquibase.resource.FileSystemResourceAccessor
 import liquibase.resource.ResourceAccessor
 import liquibase.statement.core.RawSqlStatement
 import liquibase.structure.core.Catalog
@@ -197,7 +199,12 @@ trait DatabaseMigrationCommand {
     }
 
     ResourceAccessor createResourceAccessor() {
-        new ClassLoaderResourceAccessor()
+        // Avoid duplicates when migrations have been copied to the classpath
+        if (Thread.currentThread().contextClassLoader?.getResource(changeLogFile.name)) {
+            return new CompositeResourceAccessor(new ClassLoaderResourceAccessor())
+        } else {
+            return new CompositeResourceAccessor(new FileSystemResourceAccessor(changeLogLocation))
+        }
     }
 
     void withDatabase(Map<String, String> dataSourceConfig = null, @ClosureParams(value = SimpleType, options = 'liquibase.database.Database') Closure closure) {

--- a/grails-data-hibernate5/dbmigration/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
+++ b/grails-data-hibernate5/dbmigration/src/main/groovy/org/grails/plugins/databasemigration/command/DatabaseMigrationCommand.groovy
@@ -199,10 +199,7 @@ trait DatabaseMigrationCommand {
     }
 
     ResourceAccessor createResourceAccessor() {
-        new CompositeResourceAccessor(
-            new FileSystemResourceAccessor(changeLogLocation),
-            new ClassLoaderResourceAccessor())
-
+        new ClassLoaderResourceAccessor()
     }
 
     void withDatabase(Map<String, String> dataSourceConfig = null, @ClosureParams(value = SimpleType, options = 'liquibase.database.Database') Closure closure) {

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/databaseMigration/gettingStarted.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/databaseMigration/gettingStarted.adoc
@@ -47,20 +47,6 @@ dependencies {
 }
 ----
 
-You should also tell Gradle about the migrations folder. If using Grails 4 or above, make sure the configuration below is BEFORE the
-`dependencies` configuration, so that the `sourceSets` declaration takes effect.
-
-[source,groovy,subs="attributes"]
-----
-sourceSets {
-    main {
-        resources {
-            srcDir 'grails-app/migrations'
-        }
-    }
-}
-----
-
 *Typical initial workflow*
 
 Next you'll need to create an initial changelog. You can use Liquibase XML or the plugin's Groovy DSL for individual files. You can even mix and match; Groovy files can include other Groovy files and Liquibase XML files (but XML files can't include Groovy files).

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -528,6 +528,8 @@ NOTE: Expanded class files & resource files will only be used over the jar file 
 It is no longer necessary to add the `grails-app/migrations` directory to the `main` sourceSet in order for the Database Migration Plugin to find your changelogs.
 This is now done automatically by the `org.apache.grails.gradle.grails-plugin` Gradle plugin.
 
+The following code can be removed from your `build.gradle` file:
+
 [source,groovy]
 .build.gradle
 ----

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -522,3 +522,20 @@ grails {
 ----
 
 NOTE: Expanded class files & resource files will only be used over the jar file if the plugin applies the gradle plugin `org.apache.grails.gradle.grails-exploded` & the plugin is a subproject of your Gradle build.
+
+===== 12.22 Database Migration Plugin migrations directory in the main sourceSet
+
+It is no longer necessary to add the `grails-app/migrations` directory to the `main` sourceSet in order for the Database Migration Plugin to find your changelogs.
+This is now done automatically by the `org.apache.grails.gradle.grails-plugin` Gradle plugin.
+
+[source,groovy]
+.build.gradle
+----
+sourceSets {
+    main {
+        resources {
+            srcDir 'grails-app/migrations'
+        }
+    }
+}
+----

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -92,7 +92,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     List<Class<Plugin>> basePluginClasses = [IntegrationTestGradlePlugin] as List<Class<Plugin>>
     List<String> excludedGrailsAppSourceDirs = ['migrations', 'assets']
-    List<String> grailsAppResourceDirs = ['views', 'i18n', 'conf']
+    List<String> grailsAppResourceDirs = ['views', 'i18n', 'conf', 'migrations']
     private final ToolingModelBuilderRegistry registry
 
     @Inject


### PR DESCRIPTION
The 'migrations' directory is now included in grailsAppResourceDirs, allowing it to be treated as a resource directory alongside 'views', 'i18n', and 'conf'.

resolves:  https://github.com/apache/grails-core/issues/15078

The underlying issue, which also appears to be true for Grails 6, is that /grails-app/migrations/* are not added to /build/resources/main or the generated war/jar

Due to:  https://github.com/apache/grails-core/issues/15077, the following is required to test on Windows

```
tasks.named('assetCompile').configure {
    enabled = false
}
```

