### PR TITLE
Add argfile support to JavaExec tasks to fix long classpaths

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -54,6 +54,7 @@ import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.testing.Test
 import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.process.JavaForkOptions
+import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 
 import org.springframework.boot.gradle.dsl.SpringBootExtension
@@ -576,6 +577,24 @@ class GrailsGradlePlugin extends GroovyPlugin {
         String grailsEnvSystemProperty = System.getProperty(Environment.KEY)
         tasks.withType(Test).each(systemPropertyConfigurer.curry(grailsEnvSystemProperty ?: Environment.TEST.getName()))
         tasks.withType(JavaExec).each(systemPropertyConfigurer.curry(grailsEnvSystemProperty ?: Environment.DEVELOPMENT.getName()))
+
+        // Mitigate command line length issues when launching Java processes (e.g., assetCompile) using argfile approach
+        tasks.withType(JavaExec).configureEach { JavaExec execTask ->
+            execTask.doFirst {
+                try {
+                    String cp = execTask.classpath?.asPath ?: ''
+                    if (cp) {
+                        File argsFile = new File(project.layout.buildDirectory.get().asFile, "tmp${File.separator}javaexec-args${File.separator}${execTask.name}.args")
+                        argsFile.parentFile.mkdirs()
+                        argsFile.text = "-cp\n\"${cp}\""
+                        execTask.setClasspath(project.files())
+                        execTask.jvmArgumentProviders.add(new ClasspathArgfileProvider(argsFile))
+                    }
+                } catch (Throwable ignored) {
+                    // If anything goes wrong, continue without the argsFile
+                }
+            }
+        }
     }
 
     protected void configureConsoleTask(Project project) {
@@ -883,5 +902,15 @@ class GrailsGradlePlugin extends GroovyPlugin {
     @CompileStatic
     private static final class OnlyOneGrailsPlugin {
         String pluginClassname
+    }
+
+    @CompileStatic
+    static final class ClasspathArgfileProvider implements CommandLineArgumentProvider {
+        final File argsFile
+        ClasspathArgfileProvider(File file) { this.argsFile = file }
+        @Override
+        Iterable<String> asArguments() {
+            return ["@${argsFile.absolutePath}".toString()]
+        }
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -578,20 +578,22 @@ class GrailsGradlePlugin extends GroovyPlugin {
         tasks.withType(Test).each(systemPropertyConfigurer.curry(grailsEnvSystemProperty ?: Environment.TEST.getName()))
         tasks.withType(JavaExec).each(systemPropertyConfigurer.curry(grailsEnvSystemProperty ?: Environment.DEVELOPMENT.getName()))
 
-        // Mitigate command line length issues when launching Java processes (e.g., assetCompile) using argfile approach
+        // Mitigate command line length issues when launching Java processes (e.g., assetCompile) using argsfile approach
         tasks.withType(JavaExec).configureEach { JavaExec execTask ->
             execTask.doFirst {
-                try {
-                    String cp = execTask.classpath?.asPath ?: ''
-                    if (cp) {
-                        File argsFile = new File(project.layout.buildDirectory.get().asFile, "tmp${File.separator}javaexec-args${File.separator}${execTask.name}.args")
-                        argsFile.parentFile.mkdirs()
-                        argsFile.text = "-cp\n\"${cp}\""
-                        execTask.setClasspath(project.files())
-                        execTask.jvmArgumentProviders.add(new ClasspathArgfileProvider(argsFile))
+                if (execTask.name !in ['bootRun', 'bootTestRun']) { // Skip bootRun and bootTestRun tasks as they handle classpaths differently
+                    try {
+                        String cp = execTask.classpath?.asPath ?: ''
+                        if (cp) {
+                            File argsFile = new File(project.layout.buildDirectory.get().asFile, "tmp${File.separator}javaexec-args${File.separator}${execTask.name}.args")
+                            argsFile.parentFile.mkdirs()
+                            argsFile.text = "-cp\n\"${cp}\""
+                            execTask.setClasspath(project.files())
+                            execTask.jvmArgumentProviders.add(new ClasspathArgfileProvider(argsFile))
+                        }
+                    } catch (Throwable ignored) {
+                        // If anything goes wrong, continue without the argsFile
                     }
-                } catch (Throwable ignored) {
-                    // If anything goes wrong, continue without the argsFile
                 }
             }
         }


### PR DESCRIPTION
Resolves:  https://github.com/apache/grails-core/issues/15077 and https://github.com/wondrify/asset-pipeline/issues/393 - `could not be started because the command line exceed operating system limits.`

Introduces an argfile approach for JavaExec tasks to mitigate command line length issues, particularly when launching Java processes with long classpaths (e.g., assetCompile). Adds a ClasspathArgfileProvider to supply the classpath via an argument file, improving reliability on systems with command line length limits.

We had attempted to fix this on https://github.com/wondrify/asset-pipeline/pull/401/files, but grails-gradle-plugins changes were still required and consolidating it here will address this issue for any Gradle JavaExec task. 

