### PR TITLE
Test JDK 25 support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21, 24 ]
+        java: [ 17, 21, 25 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21, 24 ]
+        java: [ 17, 21, 25 ]
     runs-on: ubuntu-24.04
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
@@ -31,9 +31,7 @@ import java.util.stream.Collectors;
 public enum JdkVersion {
     JDK_17(17),
     JDK_21(21),
-    // 24 is the current non-LTS release and will be replaced by 25 (LTS) in Sep 2025
-    // Spring Framework 6.2.x and Spring Boot 3.5.x will support 25
-    JDK_24(24);
+    JDK_25(25);
 
     public static final JdkVersion DEFAULT_OPTION = JDK_17;
 

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootVirtualThreadsSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootVirtualThreadsSpec.groovy
@@ -38,7 +38,7 @@ class SpringBootVirtualThreadsSpec extends BeanContextSpec implements CommandOut
 
     void "test spring boot virtual threads enabled for JDK 24+, when optional feature selected"() {
         when:
-        GeneratorContext commandContext = buildGeneratorContext(['spring-boot-virtual-threads'], new Options(TestFramework.DEFAULT_OPTION, JdkVersion.JDK_24))
+        GeneratorContext commandContext = buildGeneratorContext(['spring-boot-virtual-threads'], new Options(TestFramework.DEFAULT_OPTION, JdkVersion.JDK_25))
 
         then:
         commandContext.configuration.get('spring.threads.virtual.enabled'.toString()) == true

--- a/grails-gradle/bom/build.gradle
+++ b/grails-gradle/bom/build.gradle
@@ -36,7 +36,6 @@ ext {
 
 dependencies {
     api platform(gradleBomPlatformDependencies['spring-boot-bom']), {
-        exclude group: 'org.apache.groovy'
         exclude group: 'org.spockframework'
         exclude group: 'com.fasterxml.jackson'
     }

--- a/grails-gradle/common/build.gradle
+++ b/grails-gradle/common/build.gradle
@@ -32,10 +32,7 @@ ext {
 dependencies {
     compileOnly platform(project(':grails-gradle-bom'))
 
-    // compile with the Groovy version provided by Gradle
-    // to ensure build compatibility with Gradle, currently Groovy 3.0.x
-    // see: https://docs.gradle.org/current/userguide/compatibility.html#groovy
-    compileOnly 'org.codehaus.groovy:groovy'
+    compileOnly 'org.apache.groovy:groovy'
 
     testImplementation platform(project(':grails-gradle-bom'))
     testImplementation 'org.slf4j:slf4j-simple'

--- a/grails-gradle/docs-core/build.gradle
+++ b/grails-gradle/docs-core/build.gradle
@@ -41,10 +41,8 @@ dependencies {
 
     gradleConf gradleApi()
 
-    // grails-docs classes are used in Gradle builds,
-    // so we must compile with Groovy 3 until Gradle upgrades to Groovy 4.
-    compileOnly 'org.codehaus.groovy:groovy'
-    compileOnly 'org.codehaus.groovy:groovy-ant'
+    compileOnly 'org.apache.groovy:groovy'
+    compileOnly 'org.apache.groovy:groovy-ant'
 
     api 'org.apache.commons:commons-text'
     api 'org.slf4j:jcl-over-slf4j'

--- a/grails-gradle/model/build.gradle
+++ b/grails-gradle/model/build.gradle
@@ -37,12 +37,8 @@ ext {
 dependencies {
     implementation platform(project(':grails-gradle-bom'))
 
-    // compile grails-gradle-model with the Groovy version provided by Gradle
-    // to ensure build compatibility with Gradle, currently Groovy 3.0.x
-    // when used by grails-gradle-plugin
-    // see: https://docs.gradle.org/current/userguide/compatibility.html#groovy
-    compileOnly 'org.codehaus.groovy:groovy'
-    compileOnly 'org.codehaus.groovy:groovy-xml'
+    compileOnly 'org.apache.groovy:groovy'
+    compileOnly 'org.apache.groovy:groovy-xml'
 
     testImplementation 'org.codehaus.groovy:groovy-test-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'


### PR DESCRIPTION
Replaces JDK 24 with JDK 25 in the build matrix, JdkVersion enum, and related tests to align with latest LTS and Spring Boot compatibility.