### PR TITLE
15048 - feature: reproducible gorm service implementations

### DIFF
--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/transform/ServiceTransformation.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/transform/ServiceTransformation.groovy
@@ -185,7 +185,7 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
 
         List<FieldNode> propertiesFields = []
         if (isAbstractClass) {
-            List<PropertyNode> properties = classNode.getProperties()
+            List<PropertyNode> properties = classNode.getProperties().sort { it.name }
             for (PropertyNode pn in properties) {
                 ClassNode propertyType = pn.type
                 if (hasAnnotation(propertyType, Service) && propertyType != classNode && Modifier.isPublic(pn.modifiers) && pn.getterBlock == null && pn.setterBlock == null) {
@@ -193,12 +193,12 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
                     VariableExpression fieldVar = varX(field)
                     propertiesFields.add(field)
                     pn.setGetterBlock(
-                        block(
-                            ifS(equalsNullX(fieldVar),
-                                assignX(fieldVar, callX(varX('datastore'), 'getService', classX(propertyType.plainNodeReference)))
-                            ),
-                            returnS(fieldVar)
-                        )
+                            block(
+                                    ifS(equalsNullX(fieldVar),
+                                            assignX(fieldVar, callX(varX('datastore'), 'getService', classX(propertyType.plainNodeReference)))
+                                    ),
+                                    returnS(fieldVar)
+                            )
                     )
                 }
             }
@@ -209,6 +209,8 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
             }
 
         }
+
+        propertiesFields.sort(true) { it.name } // ensure a consistent order of processing fields
 
         if (isInterface || isAbstractClass) {
             // create a new class to represent the implementation
@@ -260,11 +262,14 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
             weaveTraitWithGenerics(impl, getTraitClass(), targetDomainClass)
 
             List<MethodNode> abstractMethods = findAllUnimplementedAbstractMethods(classNode)
+            abstractMethods.sort(true) { it.name } // ensure a consistent order of processing methods
+
             Iterable<ServiceImplementer> implementers = findServiceImplementors(annotationNode)
 
             // first go through the existing implemented methods and just enhance them
             if (!isInterface) {
-                for (MethodNode existing in classNode.methods) {
+                def sortedMethods = classNode.methods.sort(true) { it.name }
+                for (MethodNode existing in (sortedMethods)) {
                     int modifiers = existing.modifiers
                     if (!Modifier.isAbstract(modifiers) && Modifier.isPublic(modifiers) && !existing.isStatic()) {
                         for (ServiceImplementer implementer in implementers) {
@@ -281,7 +286,6 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
 
             // go through the abstract methods and implement them
             for (MethodNode method in abstractMethods) {
-
                 // find an implementer that implements the method
                 MethodNode methodImpl = null
                 for (ServiceImplementer implementer in implementers) {
@@ -372,7 +376,7 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
             loadAnnotationDefined(annotationNode, 'implementers', finalImplementers, ServiceImplementer)
 
             Iterable<ServiceImplementerAdapter> adapters = load(ServiceImplementerAdapter)
-            List<ServiceImplementerAdapter> finalAdapters = adapters.toList()
+            List<ServiceImplementerAdapter> finalAdapters = adapters.toList().sort { it.class.name }
             loadAnnotationDefined(annotationNode, 'adapters', finalAdapters, ServiceImplementerAdapter)
 
             if (!finalAdapters.isEmpty()) {


### PR DESCRIPTION
Fixes #15048  , but I think the AclIdentityObject in spring security will still differ after this change. From local testing, the closures are generated in the same order - we can confirm this as part of the next release.