### PR TITLE
First Step in optimizing GSP Performance on Grails 7. Safe small optimizations to start

### DIFF
--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
@@ -130,14 +130,19 @@ public abstract class GroovyPage extends Script {
         throw new IllegalStateException("Setting out in page isn't allowed.");
     }
 
-    public void initRun(Writer target, OutputContext outputContext, GroovyPageMetaInfo metaInfo) {
-        OutputEncodingStackAttributes.Builder attributesBuilder = new OutputEncodingStackAttributes.Builder();
+    public void initCommonRun(GroovyPageMetaInfo metaInfo) {
         if (metaInfo != null) {
+            setHtmlParts(metaInfo.getHtmlParts());
+            setHtmlPartsSet(metaInfo.getHtmlPartsSet());
             setJspTags(metaInfo.getJspTags());
             setJspTagLibraryResolver(metaInfo.getJspTagLibraryResolver());
             setGspTagLibraryLookup(metaInfo.getTagLibraryLookup());
-            setHtmlParts(metaInfo.getHtmlParts());
             setPluginContextPath(metaInfo.getPluginPath());
+        }
+    }
+    public void initRun(Writer target, OutputContext outputContext, GroovyPageMetaInfo metaInfo) {
+        OutputEncodingStackAttributes.Builder attributesBuilder = new OutputEncodingStackAttributes.Builder();
+        if (metaInfo != null) {
             attributesBuilder.outEncoder(metaInfo.getOutEncoder());
             attributesBuilder.staticEncoder(metaInfo.getStaticEncoder());
             attributesBuilder.expressionEncoder(metaInfo.getExpressionEncoder());
@@ -508,6 +513,14 @@ public abstract class GroovyPage extends Script {
     }
 
     /**
+     * Shorthand for printHtmlPart to reduce class size
+     * @param partNumber
+     */
+    public final void h(final int partNumber) {
+        staticOut.write(htmlParts[partNumber]);
+    }
+
+    /**
      * Sets the JSP tags used by this GroovyPage instance
      *
      * @param jspTags The JSP tags used
@@ -527,14 +540,10 @@ public abstract class GroovyPage extends Script {
 
     public void setHtmlParts(String[] htmlParts) {
         this.htmlParts = htmlParts;
-        this.htmlPartsSet = new HashSet<>();
-        if (htmlParts != null) {
-            for (String htmlPart : htmlParts) {
-                if (htmlPart != null) {
-                    htmlPartsSet.add(System.identityHashCode(htmlPart));
-                }
-            }
-        }
+    }
+
+    public void setHtmlPartsSet(Set<Integer> htmlPartsSet) {
+        this.htmlPartsSet = htmlPartsSet;
     }
 
     public final OutputEncodingStack getOutputStack() {

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
@@ -211,6 +211,8 @@ public abstract class GroovyPage extends Script {
 
     public void cleanup() {
         outputStack.pop(true);
+       // setBinding(new Binding());
+
     }
 
     public final void createClosureForHtmlPart(int partNumber, int bodyClosureIndex) {

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
@@ -83,6 +83,7 @@ public abstract class GroovyPage extends Script {
     public static final String LINK_NAMESPACE = "link";
     public static final String TEMPLATE_NAMESPACE = "tmpl";
     public static final String PAGE_SCOPE = "pageScope";
+    private OutputEncodingStackAttributes.Builder attributesBuilder;
 
     public static final Collection<String> RESERVED_NAMES = CollectionUtils.newSet(
             OUT,
@@ -130,7 +131,12 @@ public abstract class GroovyPage extends Script {
     }
 
     public void initCommonRun(GroovyPageMetaInfo metaInfo) {
+        attributesBuilder = new OutputEncodingStackAttributes.Builder();
         if (metaInfo != null) {
+            attributesBuilder.outEncoder(metaInfo.getOutEncoder());
+            attributesBuilder.staticEncoder(metaInfo.getStaticEncoder());
+            attributesBuilder.expressionEncoder(metaInfo.getExpressionEncoder());
+            attributesBuilder.defaultTaglibEncoder(metaInfo.getTaglibEncoder());
             setHtmlParts(metaInfo.getHtmlParts());
             setHtmlPartsSet(metaInfo.getHtmlPartsSet());
             setJspTags(metaInfo.getJspTags());
@@ -138,20 +144,16 @@ public abstract class GroovyPage extends Script {
             setGspTagLibraryLookup(metaInfo.getTagLibraryLookup());
             setPluginContextPath(metaInfo.getPluginPath());
         }
+        attributesBuilder.allowCreate(true).autoSync(false).pushTop(true);
+        attributesBuilder.inheritPreviousEncoders(false);
     }
 
     public void initRun(Writer target, OutputContext outputContext, GroovyPageMetaInfo metaInfo) {
-        OutputEncodingStackAttributes.Builder attributesBuilder = new OutputEncodingStackAttributes.Builder();
         if (metaInfo != null) {
-            attributesBuilder.outEncoder(metaInfo.getOutEncoder());
-            attributesBuilder.staticEncoder(metaInfo.getStaticEncoder());
-            attributesBuilder.expressionEncoder(metaInfo.getExpressionEncoder());
-            attributesBuilder.defaultTaglibEncoder(metaInfo.getTaglibEncoder());
             applyModelFieldsFromBinding(metaInfo.getModelFields());
         }
-        attributesBuilder.allowCreate(true).topWriter(target).autoSync(false).pushTop(true);
         attributesBuilder.outputContext(outputContext);
-        attributesBuilder.inheritPreviousEncoders(false);
+        attributesBuilder.topWriter(target);
         outputStack = OutputEncodingStack.currentStack(attributesBuilder.build());
 
         out = outputStack.getOutWriter();
@@ -211,8 +213,6 @@ public abstract class GroovyPage extends Script {
 
     public void cleanup() {
         outputStack.pop(true);
-       // setBinding(new Binding());
-
     }
 
     public final void createClosureForHtmlPart(int partNumber, int bodyClosureIndex) {

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -140,6 +139,7 @@ public abstract class GroovyPage extends Script {
             setPluginContextPath(metaInfo.getPluginPath());
         }
     }
+
     public void initRun(Writer target, OutputContext outputContext, GroovyPageMetaInfo metaInfo) {
         OutputEncodingStackAttributes.Builder attributesBuilder = new OutputEncodingStackAttributes.Builder();
         if (metaInfo != null) {

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
@@ -22,7 +22,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
+import java.lang.ref.SoftReference;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLConnection;
@@ -67,14 +70,17 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
     private static final Log LOG = LogFactory.getLog(GroovyPageMetaInfo.class);
     private TagLibraryLookup tagLibraryLookup;
     private TagLibraryResolver jspTagLibraryResolver;
+    private ThreadLocal<SoftReference<GroovyPage>> pageInstance = new ThreadLocal<>();
 
     private boolean precompiledMode = false;
     private Class<?> pageClass;
+    private Constructor<?> pageClassConstructor;
     private long lastModified;
     private InputStream groovySource;
     private String contentType;
     private int[] lineNumbers;
     private String[] htmlParts;
+    private Set<Integer> htmlPartsSet;
     @SuppressWarnings("rawtypes")
     private Map jspTags = Collections.emptyMap();
     private GroovyPagesException compilationException;
@@ -115,6 +121,11 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
         this();
         precompiledMode = true;
         this.pageClass = pageClass;
+        try {
+            this.pageClassConstructor = pageClass.getConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
         contentType = (String) ReflectionUtils.getField(ReflectionUtils.findField(pageClass, GroovyPageParser.CONSTANT_NAME_CONTENT_TYPE), null);
         jspTags = (Map) ReflectionUtils.getField(ReflectionUtils.findField(pageClass, GroovyPageParser.CONSTANT_NAME_JSP_TAGS), null);
         lastModified = (Long) ReflectionUtils.getField(ReflectionUtils.findField(pageClass, GroovyPageParser.CONSTANT_NAME_LAST_MODIFIED), null);
@@ -282,8 +293,26 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
         return pageClass;
     }
 
+    public GroovyPage getPageClassInstance() throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        SoftReference<GroovyPage> pageSoftRef = pageInstance.get();
+
+        GroovyPage pageCacheEntry = pageSoftRef != null ? pageSoftRef.get() : null;
+        if(pageCacheEntry == null) {
+            LOG.info("Loading Page: " + pageClass.getName());
+            pageCacheEntry = (GroovyPage) pageClassConstructor.newInstance();
+            pageCacheEntry.initCommonRun(this);
+            pageInstance.set(new SoftReference<>(pageCacheEntry));
+        }
+        return pageCacheEntry;
+    }
+
     public void setPageClass(Class<?> pageClass) {
         this.pageClass = pageClass;
+        try {
+            this.pageClassConstructor = pageClass.getConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
         initializePluginPath();
     }
 
@@ -359,6 +388,18 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
 
     public void setHtmlParts(String[] htmlParts) {
         this.htmlParts = htmlParts;
+        this.htmlPartsSet = new HashSet<>();
+        if (htmlParts != null) {
+            for (String htmlPart : htmlParts) {
+                if (htmlPart != null) {
+                    htmlPartsSet.add(System.identityHashCode(htmlPart));
+                }
+            }
+        }
+    }
+
+    Set<Integer> getHtmlPartsSet() {
+        return this.htmlPartsSet;
     }
 
     public void applyLastModifiedFromResource(Resource resource) {

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
@@ -308,11 +308,13 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
 
     public void setPageClass(Class<?> pageClass) {
         this.pageClass = pageClass;
+
         try {
             this.pageClassConstructor = pageClass.getConstructor();
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
+        pageInstance.set(null);
         initializePluginPath();
     }
 

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
@@ -297,12 +297,15 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
         SoftReference<GroovyPage> pageSoftRef = pageInstance.get();
 
         GroovyPage pageCacheEntry = pageSoftRef != null ? pageSoftRef.get() : null;
-        if (pageCacheEntry == null) {
-            LOG.info("Loading Page: " + pageClass.getName());
+        if (!isModelFieldsMode() && pageCacheEntry == null) {
             pageCacheEntry = (GroovyPage) pageClassConstructor.newInstance();
             pageCacheEntry.initCommonRun(this);
             pageInstance.set(new SoftReference<>(pageCacheEntry));
+        } else {
+            pageCacheEntry = (GroovyPage) pageClassConstructor.newInstance();
+            pageCacheEntry.initCommonRun(this);
         }
+
         return pageCacheEntry;
     }
 

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
@@ -144,8 +144,7 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
 
         try {
             readHtmlData();
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException("Problem reading html data for page class " + pageClass, e);
         }
     }
@@ -228,8 +227,7 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
                     htmlParts[i] = input.readUTF();
                 }
             }
-        }
-        finally {
+        } finally {
             IOUtils.closeQuietly(input);
         }
     }
@@ -250,8 +248,7 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
             for (int i = 0; i < arrayLen; i++) {
                 lineNumbers[i] = input.readInt();
             }
-        }
-        finally {
+        } finally {
             IOUtils.closeQuietly(input);
         }
     }
@@ -299,7 +296,7 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
         if (pageCacheEntry == null) {
             pageCacheEntry = (GroovyPage) pageClassConstructor.newInstance();
             pageCacheEntry.initCommonRun(this);
-            if(!isModelFieldsMode()) {
+            if (!isModelFieldsMode()) {
                 pageInstance.set(new SoftReference<>(pageCacheEntry));
             }
         }
@@ -354,8 +351,7 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
         if (lineNumbers == null) {
             try {
                 readLineNumbers();
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 LOG.warn("Problem reading precompiled linenumbers", e);
             }
         }
@@ -437,22 +433,18 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
             urlc.setDoInput(false);
             urlc.setDoOutput(false);
             last = urlc.getLastModified();
-        }
-        catch (FileNotFoundException fnfe) {
+        } catch (FileNotFoundException fnfe) {
             last = -1;
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             last = -1;
-        }
-        finally {
+        } finally {
             if (urlc != null) {
                 try {
                     InputStream is = urlc.getInputStream();
                     if (is != null) {
                         is.close();
                     }
-                }
-                catch (IOException e) {
+                } catch (IOException e) {
                     // ignore
                 }
             }

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
@@ -295,17 +295,14 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
 
     public GroovyPage getPageClassInstance() throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         SoftReference<GroovyPage> pageSoftRef = pageInstance.get();
-
         GroovyPage pageCacheEntry = pageSoftRef != null ? pageSoftRef.get() : null;
-        if (!isModelFieldsMode() && pageCacheEntry == null) {
+        if (pageCacheEntry == null) {
             pageCacheEntry = (GroovyPage) pageClassConstructor.newInstance();
             pageCacheEntry.initCommonRun(this);
-            pageInstance.set(new SoftReference<>(pageCacheEntry));
-        } else {
-            pageCacheEntry = (GroovyPage) pageClassConstructor.newInstance();
-            pageCacheEntry.initCommonRun(this);
+            if(!isModelFieldsMode()) {
+                pageInstance.set(new SoftReference<>(pageCacheEntry));
+            }
         }
-
         return pageCacheEntry;
     }
 

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
@@ -297,7 +297,7 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
         SoftReference<GroovyPage> pageSoftRef = pageInstance.get();
 
         GroovyPage pageCacheEntry = pageSoftRef != null ? pageSoftRef.get() : null;
-        if(pageCacheEntry == null) {
+        if (pageCacheEntry == null) {
             LOG.info("Loading Page: " + pageClass.getName());
             pageCacheEntry = (GroovyPage) pageClassConstructor.newInstance();
             pageCacheEntry.initCommonRun(this);

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
@@ -44,7 +44,6 @@ import org.grails.taglib.encoder.OutputContextLookup;
  * @since 0.5
  */
 public class GroovyPageWritable implements Writable {
-    //get SLF4J logger instead
     private static final Logger LOG = LoggerFactory.getLogger(GroovyPageWritable.class);
     private static final String GSP_NONE_CODEC_NAME = "none";
     private GroovyPageMetaInfo metaInfo;

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
@@ -26,13 +26,10 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
 import groovy.lang.Binding;
 import groovy.lang.Writable;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import grails.util.Environment;
 import org.grails.taglib.AbstractTemplateVariableBinding;
 import org.grails.taglib.TemplateVariableBinding;
@@ -47,7 +44,8 @@ import org.grails.taglib.encoder.OutputContextLookup;
  * @since 0.5
  */
 public class GroovyPageWritable implements Writable {
-    private static final Log LOG = LogFactory.getLog(GroovyPageWritable.class);
+    //get SLF4J logger instead
+    private static final Logger LOG = LoggerFactory.getLogger(GroovyPageWritable.class);
     private static final String GSP_NONE_CODEC_NAME = "none";
     private GroovyPageMetaInfo metaInfo;
     private OutputContextLookup outputContextLookup;
@@ -125,9 +123,7 @@ public class GroovyPageWritable implements Writable {
                 // only try to set content type when evaluating top level GSP
                 boolean contentTypeAlreadySet = outputContext.isContentTypeAlreadySet();
                 if (!contentTypeAlreadySet) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Writing output with content type: " + metaInfo.getContentType());
-                    }
+                    LOG.debug("Writing output with content type: {}", metaInfo.getContentType());
                     outputContext.setContentType(metaInfo.getContentType()); // must come before response.getWriter()
                 }
             }
@@ -139,7 +135,9 @@ public class GroovyPageWritable implements Writable {
 
             GroovyPage page = null;
             try {
-                page = (GroovyPage) metaInfo.getPageClass().newInstance();
+
+                page = metaInfo.getPageClassInstance();
+
             } catch (Exception e) {
                 throw new GroovyPagesException("Problem instantiating page class", e);
             }
@@ -294,4 +292,6 @@ public class GroovyPageWritable implements Writable {
             in.close();
         }
     }
+
+
 }

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
@@ -26,11 +26,15 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import groovy.lang.Binding;
 import groovy.lang.Writable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import grails.util.Environment;
+
 import org.grails.taglib.AbstractTemplateVariableBinding;
 import org.grails.taglib.TemplateVariableBinding;
 import org.grails.taglib.encoder.OutputContext;
@@ -291,6 +295,4 @@ public class GroovyPageWritable implements Writable {
             in.close();
         }
     }
-
-
 }

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
@@ -101,8 +101,7 @@ public class GroovyPageWritable implements Writable {
             // Set it to TEXT
             outputContext.setContentType(GROOVY_SOURCE_CONTENT_TYPE); // must come before response.getOutputStream()
             writeGroovySourceToResponse(metaInfo, out);
-        }
-        else {
+        } else {
             // Set it to HTML by default
             if (metaInfo.getCompilationException() != null) {
                 throw metaInfo.getCompilationException();
@@ -150,9 +149,8 @@ public class GroovyPageWritable implements Writable {
 
             try {
                 page.run();
-            }
-            finally {
-                if(existingBinding!=null) {
+            } finally {
+                if (existingBinding != null) {
                     page.setBinding(existingBinding);
                 }
                 page.cleanup();
@@ -223,13 +221,12 @@ public class GroovyPageWritable implements Writable {
             Reader reader = new InputStreamReader(in, "UTF-8");
             char[] buf = new char[8192];
 
-            for (;;) {
+            for (; ; ) {
                 int read = reader.read(buf);
                 if (read <= 0) break;
                 out.write(buf, 0, read);
             }
-        }
-        finally {
+        } finally {
             out.close();
             in.close();
         }
@@ -252,8 +249,7 @@ public class GroovyPageWritable implements Writable {
         try {
             try {
                 in.reset();
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 // ignore
             }
             BufferedReader reader = new BufferedReader(new InputStreamReader(in, "UTF-8"));
@@ -291,8 +287,7 @@ public class GroovyPageWritable implements Writable {
                 out.write(line);
                 out.write('\n');
             }
-        }
-        finally {
+        } finally {
             out.close();
             in.close();
         }

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import grails.util.Environment;
-
 import org.grails.taglib.AbstractTemplateVariableBinding;
 import org.grails.taglib.TemplateVariableBinding;
 import org.grails.taglib.encoder.OutputContext;

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
@@ -134,15 +134,15 @@ public class GroovyPageWritable implements Writable {
             if (hasRequest) {
                 outputContext.setBinding(binding);
             }
-
+            Binding existingBinding = null;
             GroovyPage page = null;
             try {
-
                 page = metaInfo.getPageClassInstance();
-
+                existingBinding = page.getBinding();
             } catch (Exception e) {
                 throw new GroovyPagesException("Problem instantiating page class", e);
             }
+
             page.setBinding(binding);
             binding.setOwner(page);
 
@@ -152,6 +152,9 @@ public class GroovyPageWritable implements Writable {
                 page.run();
             }
             finally {
+                if(existingBinding!=null) {
+                    page.setBinding(existingBinding);
+                }
                 page.cleanup();
                 if (hasRequest) {
                     if (newParentCreated) {

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPagesTemplateEngine.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPagesTemplateEngine.java
@@ -419,6 +419,27 @@ public class GroovyPagesTemplateEngine extends ResourceAwareTemplateEngine imple
     }
 
     /**
+     * Creates a Template using the given text for the Template and the given name. The name
+     * of the template is required
+     *
+     * @param txt The URI of the page to create the template for
+     * @param pageName The name of the page being parsed
+     * @param cache If the template should be cached
+     *
+     * @return The Template instance
+     * @throws CompilationFailedException
+     * @throws IOException Thrown if an IO exception occurs creating the Template
+     */
+    public Template createTemplate(String txt, String pageName, boolean cache) throws IOException {
+        Assert.hasLength(txt, "Argument [txt] cannot be null or blank");
+        Assert.hasLength(pageName, "Argument [pageName] cannot be null or blank");
+
+        return createTemplate(new ByteArrayResource(txt.getBytes(StandardCharsets.UTF_8), pageName), pageName, cache);
+    }
+
+    /**
+     * Creates a Template using the given text for the Template and the given name. The name
+    /**
      * Creates a Template for the given file
      *
      * @param file The File to use to construct the template with

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
@@ -30,14 +30,9 @@ import groovy.transform.CompileStatic
 import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.Phases
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.apache.commons.logging.LogFactory
+import org.slf4j.LoggerFactory
 import org.slf4j.Logger
-
 import org.springframework.core.CollectionFactory
-
 import grails.config.ConfigMap
 import org.apache.grails.gradle.common.PropertyFileUtils
 import org.grails.config.CodeGenConfig

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
@@ -31,8 +31,10 @@ import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.Phases
 
-import org.apache.commons.logging.Log
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.logging.LogFactory
+import org.slf4j.Logger
 
 import org.springframework.core.CollectionFactory
 
@@ -42,9 +44,12 @@ import org.grails.config.CodeGenConfig
 import org.grails.gsp.GroovyPageMetaInfo
 import org.grails.gsp.compiler.transform.GroovyPageInjectionOperation
 import org.grails.taglib.encoder.OutputEncodingSettings
-
+import org.grails.gsp.GroovyPage
 /**
- * Used to compile GSP files into a specified target directory.
+ * Used to compile GSP files into a specified target directory. The compiler creates 3 files per page.
+ * Firstly, it generates a {@link GroovyPage} derived class which is then compiled to a .class file.
+ * It also will generate a "_html.data" and a "_linenumbers.data" file which contain the static HTML parts of the page.
+ * These are read at runtime by the {@link org.grails.gsp.GroovyPagesTemplateEngine} class.
  *
  * @author Graeme Rocher
  * @since 1.2
@@ -52,7 +57,7 @@ import org.grails.taglib.encoder.OutputEncodingSettings
 @CompileStatic
 class GroovyPageCompiler {
 
-    private static final Log LOG = LogFactory.getLog(GroovyPageCompiler)
+    private static final Logger LOG = LoggerFactory.getLogger(GroovyPageCompiler)
 
     private Map compileGSPRegistry = [:]
     private Object mutexObject = new Object()
@@ -238,7 +243,6 @@ class GroovyPageCompiler {
                 CompilationUnit unit = new CompilationUnit(compilerConfig, null, classLoader)
                 unit.addPhaseOperation(operation, Phases.CANONICALIZATION)
                 unit.addSource(gspgroovyfile.name, gsptarget.toString())
-                // unit.addSource(gspgroovyfile)
                 unit.compile()
             }
         }

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
@@ -40,6 +40,7 @@ import org.grails.gsp.GroovyPageMetaInfo
 import org.grails.gsp.compiler.transform.GroovyPageInjectionOperation
 import org.grails.taglib.encoder.OutputEncodingSettings
 import org.grails.gsp.GroovyPage
+
 /**
  * Used to compile GSP files into a specified target directory. The compiler creates 3 files per page.
  * Firstly, it generates a {@link GroovyPage} derived class which is then compiled to a .class file.
@@ -83,8 +84,8 @@ class GroovyPageCompiler {
     }
 
     /**
-    * Compiles the given GSP pages and returns a Map of URI to classname mappings
-    */
+     * Compiles the given GSP pages and returns a Map of URI to classname mappings
+     */
     Map compile() {
         if (srcFiles && targetDir && viewsDir) {
             if (!generatedGroovyPagesDirectory) {
@@ -100,8 +101,7 @@ class GroovyPageCompiler {
                     if (f.exists()) {
                         if (f.name.endsWith('.yml')) {
                             codeGenConfig.loadYml(f)
-                        }
-                        else if (f.name.endsWith('.groovy')) {
+                        } else if (f.name.endsWith('.groovy')) {
                             codeGenConfig.loadGroovy(f)
                         }
                     }
@@ -206,8 +206,7 @@ class GroovyPageCompiler {
         String fullClassName
         if (packageName) {
             fullClassName = packageName + '.' + className
-        }
-        else {
+        } else {
             fullClassName = className
         }
 
@@ -225,11 +224,11 @@ class GroovyPageCompiler {
                 gpp.generateGsp(gsptarget)
                 gsptarget.flush()
                 // write static html parts to data file (read from classpath at runtime)
-                File htmlDataFile = new File(new File(targetDir, packageDir),  className + GroovyPageMetaInfo.HTML_DATA_POSTFIX)
+                File htmlDataFile = new File(new File(targetDir, packageDir), className + GroovyPageMetaInfo.HTML_DATA_POSTFIX)
                 htmlDataFile.parentFile.mkdirs()
                 gpp.writeHtmlParts(htmlDataFile)
                 // write linenumber mapping info to data file
-                File lineNumbersDataFile = new File(new File(targetDir, packageDir),  className + GroovyPageMetaInfo.LINENUMBERS_DATA_POSTFIX)
+                File lineNumbersDataFile = new File(new File(targetDir, packageDir), className + GroovyPageMetaInfo.LINENUMBERS_DATA_POSTFIX)
                 gpp.writeLineNumbers(lineNumbersDataFile)
 
                 // register viewuri -> classname mapping
@@ -240,8 +239,7 @@ class GroovyPageCompiler {
                 unit.addSource(gspgroovyfile.name, gsptarget.toString())
                 unit.compile()
             }
-        }
-        else {
+        } else {
             compileGSPResults[viewuri] = fullClassName
         }
 
@@ -270,8 +268,7 @@ class GroovyPageCompiler {
             if (ch == '/') {
                 nextMustBeStartChar = true
                 sb.append(ch)
-            }
-            else {
+            } else {
                 // package or class name cannot start with a number
                 if (nextMustBeStartChar && !Character.isJavaIdentifierStart(ch)) {
                     sb.append('_')

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageParser.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageParser.java
@@ -66,7 +66,10 @@ import org.grails.taglib.encoder.OutputEncodingSettings;
 /**
  * NOTE: Based on work done by the GSP standalone project (https://gsp.dev.java.net/).
  * <p>
- * Parsing implementation for GSP files
+ * Parsing implementation for GSP files. This class is responsible for parsing .gsp extension files
+ * and converting them to Groovy source code that extends the {@link GroovyPage} base class. It also gathers
+ * taglib references and html parts (contants with no modification) and writes them to a separate file.
+ * For improved debugging, line number references are also stored for easier exception tracing.
  *
  * @author Troy Heninger
  * @author Graeme Rocher
@@ -643,7 +646,7 @@ public class GroovyPageParser implements Tokens {
     }
 
     private void htmlPartPrintlnRaw(int partNumber) {
-        out.print("printHtmlPart(");
+        out.print("h(");
         out.print(String.valueOf(partNumber));
         out.print(")");
         out.println();

--- a/grails-gsp/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
+++ b/grails-gsp/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
@@ -233,7 +233,8 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
                 if (key == null && GrailsStringUtils.isBlank(var) && it != null) {
                     key = GrailsNameUtils.getPropertyName(it.getClass());
                 }
-                Map itmap = (Map) b.clone();
+                Map itmap = new LinkedHashMap<String,Object>();
+                itmap.putAll(b);
 
                 if (GrailsStringUtils.isNotBlank(var)) {
                     itmap.put(var, it);

--- a/grails-gsp/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
+++ b/grails-gsp/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
@@ -88,8 +88,9 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
     public void afterPropertiesSet() throws Exception {
         if (scaffoldingTemplateGenerator != null) {
             // use reflection to locate method (would cause cyclic dependency otherwise)
-            generateViewMethod = ReflectionUtils.findMethod(scaffoldingTemplateGenerator.getClass(), "generateView", new Class<?>[] {
-                GrailsDomainClass.class, String.class, Writer.class});
+            generateViewMethod = ReflectionUtils.findMethod(scaffoldingTemplateGenerator.getClass(), "generateView", new Class<?>[]{
+                GrailsDomainClass.class, String.class, Writer.class
+            });
         }
     }
 
@@ -131,12 +132,12 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
 
     // required for binary compatibility: GRAILS-11598
     private Template findAndCacheTemplate(Object controller, GrailsWebRequest webRequest, GroovyPageBinding pageScope, String templateName,
-            String contextPath, String pluginName, String uri) throws IOException {
+                                          String contextPath, String pluginName, String uri) throws IOException {
         return findAndCacheTemplate(controller, pageScope, templateName, contextPath, pluginName, uri);
     }
 
     private Template findAndCacheTemplate(Object controller, TemplateVariableBinding pageScope, String templateName,
-            String contextPath, String pluginName, final String uri) throws IOException {
+                                          String contextPath, String pluginName, final String uri) throws IOException {
 
         String templatePath = GrailsStringUtils.isNotEmpty(contextPath) ? GrailsResourceUtils.appendPiecesForUri(contextPath, templateName) : templateName;
         final GroovyPageScriptSource scriptSource;
@@ -152,8 +153,7 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
         } else {
             if (pluginName != null) {
                 cacheKey = contextPath + pluginName + scriptSource.getURI();
-            }
-            else {
+            } else {
                 cacheKey = scriptSource.getURI();
             }
         }
@@ -204,7 +204,7 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
                 }, true, null);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private void makeTemplate(GrailsWebRequest webRequest, Template t, Map<String, Object> attrs, Object body, Writer out) throws IOException {
 
         Writer newOut = wrapWriterWithEncoder(webRequest, attrs, out);
@@ -220,8 +220,7 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
         if (attrs.containsKey("bean")) {
             if (GrailsStringUtils.isNotBlank(var)) {
                 b.put(var, attrs.get("bean"));
-            }
-            else {
+            } else {
                 b.put("it", attrs.get("bean"));
             }
         }
@@ -233,13 +232,12 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
                 if (key == null && GrailsStringUtils.isBlank(var) && it != null) {
                     key = GrailsNameUtils.getPropertyName(it.getClass());
                 }
-                Map itmap = new LinkedHashMap<String,Object>();
+                Map itmap = new LinkedHashMap<String, Object>();
                 itmap.putAll(b);
 
                 if (GrailsStringUtils.isNotBlank(var)) {
                     itmap.put(var, it);
-                }
-                else {
+                } else {
                     itmap.put("it", it);
                     itmap.put(key, it);
                 }
@@ -316,12 +314,12 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
         scaffoldingTemplateGenerator = generator;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void setScaffoldedActionMap(Map map) {
         scaffoldedActionMap = map;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void setControllerToScaffoldedDomainClassMap(Map map) {
         controllerToScaffoldedDomainClassMap = map;
     }

--- a/grails-gsp/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
+++ b/grails-gsp/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
@@ -212,7 +212,7 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
         out = newOut;
 
         String var = getStringValue(attrs, "var");
-        Map b = new LinkedHashMap<String, Object>();
+        LinkedHashMap<String, Object> b = new LinkedHashMap<>();
         b.put("body", body);
         if (attrs.get("model") instanceof Map) {
             b.putAll((Map) attrs.get("model"));
@@ -233,8 +233,8 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
                 if (key == null && GrailsStringUtils.isBlank(var) && it != null) {
                     key = GrailsNameUtils.getPropertyName(it.getClass());
                 }
-                Map itmap = new LinkedHashMap<String, Object>();
-                itmap.putAll(b);
+                Map itmap = (Map) b.clone();
+
                 if (GrailsStringUtils.isNotBlank(var)) {
                     itmap.put(var, it);
                 }

--- a/grails-gsp/plugin/src/test/groovy/org/grails/gsp/compiler/tags/GroovyEachParseTests.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/gsp/compiler/tags/GroovyEachParseTests.groovy
@@ -42,11 +42,11 @@ public Object run() {
 Writer out = getOut()
 Writer expressionOut = getExpressionOut()
 
-printHtmlPart(0)
+h(0)
 for( t in evaluate('"blah"', 2, it) { return "blah" } ) {
-printHtmlPart(0)
+h(0)
 }
-printHtmlPart(0)
+h(0)
 }""" + GSP_FOOTER
         ), trimAndRemoveCR(output.toString()))
         assertEquals("\n", output.htmlParts[0])
@@ -64,7 +64,7 @@ public Object run() {
 Writer out = getOut()
 Writer expressionOut = getExpressionOut()
 
-printHtmlPart(0)
+h(0)
 for( t in evaluate('"blah"', 1, it) { return "blah" } ) {
 }
 }""" + GSP_FOOTER
@@ -86,15 +86,15 @@ public Object run() {
 Writer out = getOut()
 Writer expressionOut = getExpressionOut()
 
-printHtmlPart(0)
+h(0)
 loop:{
 int i = 0
 for( t in evaluate('"blah"', 2, it) { return "blah" } ) {
-printHtmlPart(0)
+h(0)
 i++
 }
 }
-printHtmlPart(0)
+h(0)
 }""" + GSP_FOOTER
         ), trimAndRemoveCR(output.toString()))
         assertEquals("\n", output.htmlParts[0])

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/pages/ParseSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/pages/ParseSpec.groovy
@@ -69,7 +69,7 @@ public static final String TAGLIB_CODEC = 'none'
                 'public Object run() {\n' +
                 'Writer out = getOut()\n' +
                 'Writer expressionOut = getExpressionOut()\n' +
-                'printHtmlPart(0)\n' +
+                'h(0)\n' +
                 '}\n' + GSP_FOOTER
 
         when:
@@ -122,7 +122,7 @@ public static final String TAGLIB_CODEC = 'none'
                 'public Object run() {\n' +
                 'Writer out = getOut()\n' +
                 'Writer expressionOut = getExpressionOut()\n' +
-                'printHtmlPart(0)\n' +
+                'h(0)\n' +
                 '}\n' + GSP_FOOTER
 
         // Sanity check the string loaded OK as unicode - it won't look right if you output it, default stdout is not UTF-8
@@ -157,7 +157,7 @@ public static final String TAGLIB_CODEC = 'none'
                 'public Object run() {\n' +
                 'Writer out = getOut()\n' +
                 'Writer expressionOut = getExpressionOut()\n' +
-                'printHtmlPart(0)\n' +
+                'h(0)\n' +
                 '}\n' + GSP_FOOTER
 
         when:
@@ -189,9 +189,9 @@ public static final String TAGLIB_CODEC = 'none'
                 'public Object run() {\n' +
                 'Writer out = getOut()\n' +
                 'Writer expressionOut = getExpressionOut()\n' +
-                'printHtmlPart(0)\n' +
+                'h(0)\n' +
                 GroovyPage.EXPRESSION_OUT_STATEMENT + ".print(evaluate('uri', 3, it) { return uri })\n" +
-                'printHtmlPart(1)\n' +
+                'h(1)\n' +
                 '}\n' + GSP_FOOTER;
 
         when:
@@ -239,7 +239,7 @@ public static final String TAGLIB_CODEC = 'none'
                 'public Object run() {\n' +
                 'Writer out = getOut()\n' +
                 'Writer expressionOut = getExpressionOut()\n' +
-                'printHtmlPart(0)\n' +
+                'h(0)\n' +
                 '}\n' + GSP_FOOTER
 
         when:
@@ -259,12 +259,12 @@ public static final String TAGLIB_CODEC = 'none'
                 'public Object run() {\n' +
                 'Writer out = getOut()\n' +
                 'Writer expressionOut = getExpressionOut()\n' +
-                'printHtmlPart(0)\n' +
+                'h(0)\n' +
                 'createTagBody(1, {->\n' +
                 "invokeTag('captureMeta','grailsLayout',1,['gsp_sm_xmlClosingForEmptyTag':evaluate('\"/\"', 1, it) { return \"/\" },'name':evaluate('\"SomeName\"', 1, it) { return \"SomeName\" },'content':evaluate('\"\${grailsApplication.config.myFirstConfig}/something/\${someVar}\"', 1, it) { return \"\${grailsApplication.config.myFirstConfig}/something/\${someVar}\" }],-1)\n" +
                 '})\n' +
                 "invokeTag('captureHead','grailsLayout',1,[:],1)\n" +
-                'printHtmlPart(1)\n' +
+                'h(1)\n' +
                 '}\n' + GSP_FOOTER
 
         when:

--- a/grails-testing-support-web/src/main/groovy/grails/testing/web/GrailsWebUnitTest.groovy
+++ b/grails-testing-support-web/src/main/groovy/grails/testing/web/GrailsWebUnitTest.groovy
@@ -228,7 +228,7 @@ trait GrailsWebUnitTest implements GrailsUnitTest {
     void applyTemplate(StringWriter sw, String template, Map params = [:]) {
         def engine = applicationContext.getBean(GroovyPagesTemplateEngine)
 
-        def t = engine.createTemplate(template, 'test_' + System.currentTimeMillis())
+        def t = engine.createTemplate(template, 'test_' + System.currentTimeMillis(),false)
         renderTemplateToStringWriter(sw, t, params)
     }
 

--- a/grails-testing-support-web/src/main/groovy/grails/testing/web/GrailsWebUnitTest.groovy
+++ b/grails-testing-support-web/src/main/groovy/grails/testing/web/GrailsWebUnitTest.groovy
@@ -189,8 +189,7 @@ trait GrailsWebUnitTest implements GrailsUnitTest {
         final attributes = webRequest.attributes
         if (args.template) {
             uri = attributes.getTemplateUri(args.template as String, request)
-        }
-        else if (args.view) {
+        } else if (args.view) {
             uri = attributes.getViewUri(args.view as String, request)
         }
         if (uri != null) {
@@ -228,7 +227,7 @@ trait GrailsWebUnitTest implements GrailsUnitTest {
     void applyTemplate(StringWriter sw, String template, Map params = [:]) {
         def engine = applicationContext.getBean(GroovyPagesTemplateEngine)
 
-        def t = engine.createTemplate(template, 'test_' + System.currentTimeMillis(),false)
+        def t = engine.createTemplate(template, 'test_' + System.currentTimeMillis(), false)
         renderTemplateToStringWriter(sw, t, params)
     }
 


### PR DESCRIPTION
I have been asked to take a look at Grails GSP Performance. This is an older codebase and I was able to identify some low hanging fruit to start this journey that is pretty safe for release.

There are multiple parts that need to be considered with GSP performance. The differences in cold start performance in development mode as well as production mode rendering.

Cold start involves compiler overhead. This means any changes in groovy4 compiler performance @paulk-asert can have a significant impact in this area. Fortunately, from what I can tell, there does not seem to be a huge difference in performance here in my testing.

I am aware that the compiler (since groovy 3) runs slower on LARGE files. In an effort to reduce file size, I have shorthanded `printHtmlParts(Integer)` to `h(Integer)` when the gsp is first being converted to a `groovy` file. This should help with just scanning and size for the compilation process.

I have also started swapping out commons logging with `SLF4J`. Why you may ask? There are several spots where there are wrapped if statements if `debugEnabled`. This is no longer necessary on `SLF4J` and simply reads better.

I also have started adding javadoc headers to some of the GSP classes so it is easier to follow what is going on in the code. As this is not the easiest to read through.

## Big Optimizations

Whenever a page or partial is rendered, a new instance of `GroovyPage` is created. This is never cached even though 99% of the class is thread safe (except for the OutputStack). We have made changes in the already cached `GroovyPageMetaInfo` class that now instantiates a `ThreadLocal` cache of the page. In addition, the `Constructor` pointer is also cached for concurrent access to reduce reflection overhead. There is an excessive amount of operations that are performed before a page is rendered in the `GroovyPage#initRun()`. I have moved some of this out into `initCommonRun()` that only needs to be run per instance, as opposed to per execution of the pages `run()`. This can be taken farther by a lot but did not want to create high risk issues to start. The other big move was to create the `htmlPartsSet` in the meta info class instead of during construction of each groovy page instance.

Making this change shows approximately 30% in overhead reduction.

### Test Scenarios

**First Scenario: Render 10,000 nested template renders in a `<g:each>` of a row:**

Render Time after a few warmups BEFORE Changes: 200ms avg
Render Time after a few warmups AFTER Changes: 150ms avg

**Second Scenario: Render 10,000 nested template renders using `<g:render collection=''>`**
Render Time after a few warmups BEFORE Changes: 63ms avg
Render Time after a few warmups AFTER Changes: 40ms avg

**Third Scenario: Render LARGE HTML Page (lots of html parts)**

Render Time after a few warmups BEFORE Changes: 2ms avg
Render Time after a few warmups AFTER Changes: 1ms avg 

These Tests were run on an M3 Max Macbook Pro . I would imagine even more gains on different hardware.


### What's next.

We need to aim to further reduce the instantiation logic within `GroovyPage` it's a short lived object that needs to be super quick to instantiate. There are common singleton reference classes that are associated at the start like `TagLibraryLookup` that should be removed.

We need to shorten this pipeline overall. There are a lot more spots I can see that need optimized and will continue to dig farther. The TagLibraryLookup could also stand a rethink, but that is for another day.

I would appreciate any thoughts on this PR and look forward to hearing if this improves overall performance for others.