### PR TITLE
Include dependencies in POM and publish Gradle module JSON

### DIFF
--- a/grails-dependencies/assets/build.gradle
+++ b/grails-dependencies/assets/build.gradle
@@ -26,7 +26,7 @@ version = projectVersion
 group = 'org.apache.grails'
 
 ext {
-    skipJavaComponent = true
+    skipJavaComponent = false
     pomDescription = 'A meta-project that aggregates all Grails assets files under one place.'
 }
 

--- a/grails-dependencies/starter-web/build.gradle
+++ b/grails-dependencies/starter-web/build.gradle
@@ -26,7 +26,7 @@ version = projectVersion
 group = 'org.apache.grails'
 
 ext {
-    skipJavaComponent = true
+    skipJavaComponent = false
     pomDescription = 'A meta-project that aggregates all web, non-test, non-database Grails dependencies.'
 }
 

--- a/grails-dependencies/test/build.gradle
+++ b/grails-dependencies/test/build.gradle
@@ -26,7 +26,7 @@ version = projectVersion
 group = 'org.apache.grails'
 
 ext {
-    skipJavaComponent = true
+    skipJavaComponent = false
     pomDescription = 'A meta-project that aggregates all non-data test dependencies that will be commonly used in Grails applications.'
 }
 


### PR DESCRIPTION
Set skipJavaComponent to false in assets, starter-web, and test build.gradle files to include Java component configuration in these Grails meta-projects.

The publication must be a proper Java component to publish the Gradle module json file.

Resolves:  https://github.com/apache/grails-core/issues/15110