### PR TITLE
7.0.0-RC2 BUG FIX - @AutoTimestamp Mongo Persistence

### DIFF
--- a/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/engine/codecs/PersistentEntityCodec.groovy
+++ b/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/engine/codecs/PersistentEntityCodec.groovy
@@ -64,7 +64,6 @@ import org.grails.datastore.mapping.engine.internal.MappingUtils
 import org.grails.datastore.mapping.model.EmbeddedPersistentEntity
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.datastore.mapping.model.PersistentProperty
-import org.grails.datastore.mapping.model.config.GormProperties
 import org.grails.datastore.mapping.model.types.Association
 import org.grails.datastore.mapping.model.types.Embedded
 import org.grails.datastore.mapping.model.types.EmbeddedCollection
@@ -248,12 +247,6 @@ class PersistentEntityCodec extends BsonPersistentEntityCodec {
                     EntityPersister.incrementEntityVersion(access)
                 }
 
-            }
-            else {
-                // schedule lastUpdated if necessary
-                if (entity.getPropertyByName(GormProperties.LAST_UPDATED) != null) {
-                    dirtyProperties.add(GormProperties.LAST_UPDATED)
-                }
             }
 
             for (propertyName in dirtyProperties) {

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEvent;
+import org.springframework.util.ReflectionUtils;
 
 import grails.gorm.annotation.AutoTimestamp;
 import org.grails.datastore.gorm.timestamp.DefaultTimestampProvider;
@@ -39,6 +40,7 @@ import org.grails.datastore.gorm.timestamp.TimestampProvider;
 import org.grails.datastore.mapping.config.Entity;
 import org.grails.datastore.mapping.config.Settings;
 import org.grails.datastore.mapping.core.Datastore;
+import org.grails.datastore.mapping.dirty.checking.DirtyCheckable;
 import org.grails.datastore.mapping.engine.EntityAccess;
 import org.grails.datastore.mapping.engine.event.AbstractPersistenceEvent;
 import org.grails.datastore.mapping.engine.event.AbstractPersistenceEventListener;
@@ -148,10 +150,25 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
     public boolean beforeUpdate(PersistentEntity entity, EntityAccess ea) {
         Set<String> props = getLastUpdatedPropertyNames(entity.getName());
         if (props != null) {
+            Object entityObject = ea.getEntity();
+            boolean isDirtyCheckable = entityObject instanceof DirtyCheckable;
+
+            // For dirty-checking datastores (e.g., MongoDB), only set autotimestamp if entity has dirty properties
+            if (isDirtyCheckable) {
+                List<String> dirtyPropertyNames = ((DirtyCheckable) entityObject).listDirtyPropertyNames();
+                if (dirtyPropertyNames.isEmpty()) {
+                    return true;
+                }
+            }
+
             for (String prop : props) {
                 Class<?> lastUpdateType = ea.getPropertyType(prop);
                 Object timestamp = timestampProvider.createTimestamp(lastUpdateType);
                 ea.setProperty(prop, timestamp);
+                // Mark property as dirty for datastores that use dirty checking (e.g., MongoDB)
+                if (isDirtyCheckable) {
+                    ((DirtyCheckable) entityObject).markDirty(prop);
+                }
             }
         }
         return true;
@@ -167,18 +184,6 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
         return properties == null ? null : properties.orElse(null);
     }
 
-    private static Field getFieldFromHierarchy(Class<?> entity, String fieldName) {
-        Class<?> clazz = entity;
-        while (clazz != null) {
-            try {
-                return clazz.getDeclaredField(fieldName);
-            } catch (NoSuchFieldException e) {
-                clazz = clazz.getSuperclass();
-            }
-        }
-        return null;
-    }
-
     protected void storeDateCreatedAndLastUpdatedInfo(PersistentEntity persistentEntity) {
         if (persistentEntity.isInitialized()) {
             ClassMapping<?> classMapping = persistentEntity.getMapping();
@@ -190,13 +195,15 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
                     } else if (property.getName().equals(DATE_CREATED_PROPERTY)) {
                         storeTimestampAvailability(entitiesWithDateCreated, persistentEntity, property);
                     } else {
-                        Field field = getFieldFromHierarchy(persistentEntity.getJavaClass(), property.getName());
-                        if (field != null && field.isAnnotationPresent(AutoTimestamp.class)) {
-                            AutoTimestamp autoTimestamp = field.getAnnotation(AutoTimestamp.class);
-                            if (autoTimestamp.value() == AutoTimestamp.EventType.UPDATED) {
-                                storeTimestampAvailability(entitiesWithLastUpdated, persistentEntity, property);
-                            } else {
-                                storeTimestampAvailability(entitiesWithDateCreated, persistentEntity, property);
+                        Field field = ReflectionUtils.findField(persistentEntity.getJavaClass(), property.getName());
+                        if (field != null) {
+                            if (field.isAnnotationPresent(AutoTimestamp.class)) {
+                                AutoTimestamp autoTimestamp = field.getAnnotation(AutoTimestamp.class);
+                                if (autoTimestamp.value() == AutoTimestamp.EventType.UPDATED) {
+                                    storeTimestampAvailability(entitiesWithLastUpdated, persistentEntity, property);
+                                } else {
+                                    storeTimestampAvailability(entitiesWithDateCreated, persistentEntity, property);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### This really needs to go out in 7.0.0 as it is currently completely broken

This is the isolated part of PR #15118 that fixes #15120 

All it does is mark properties annotated with @AutoTimestamp dirty so they are guaranteed to be saved during updates.

To see existing non behavior: 
```
git clone --depth 1 --single-branch https://github.com/codeconsole/mongo-test mongo-test-RC2 && cd mongo-test-RC2 && ./gradlew bootRun
```
Create and Edit to see modified not updated after edit save.
http://localhost:8080/user/create
http://localhost:8080/user/edit/1

The checkout grails-core fix branch and publish it to mavenLocal
```
git clone --depth 1 --branch 7.0.x-autotimestamp-mongo-fix https://github.com/codeconsole/grails-core grails-core-autotimestamp-mongo-fix && cd grails-core-autotimestamp-mongo-fix && ./gradlew pTML
```

You can verify fix on MongoDb
```
git clone --depth 1 --branch mongodb-mavenLocal-7.0.0-SNAPSHOT https://github.com/codeconsole/mongo-test mongo-test-mongo-SNAPSHOT && cd mongo-test-mongo-SNAPSHOT && ./gradlew bootRun --args='--server.port=8081'
```

http://localhost:8081/user/create
http://localhost:8081/user/edit/1

You can verify fix also works on Hibernate
```
git clone --depth 1 --branch h2-mavenLocal-7.0.0-SNAPSHOT https://github.com/codeconsole/mongo-test mongo-test-hibernate-SNAPSHOT && cd mongo-test-hibernate-SNAPSHOT && ./gradlew bootRun --args='--server.port=8082'
```

http://localhost:8082/user/create
http://localhost:8082/user/edit/1