### PR TITLE
Update documentation links to grails.apache.org/docs

### DIFF
--- a/.github/vote_templates/announce.txt
+++ b/.github/vote_templates/announce.txt
@@ -2,7 +2,7 @@ The Apache Grails community is pleased to announce the release of Apache Grails 
 
 Grails is a powerful Groovy-based web application framework for the JVM built on top of Spring Boot that has many plugins to further extend its functionality.
 
-This release another milestone on our journey to a final 7.0 release. Users are encouraged to try the milestone to provide early feedback. Detailed upgrade instructions are available here: https://docs.grails.org/${VERSION}/guide/upgrading.html
+This release another milestone on our journey to a final 7.0 release. Users are encouraged to try the milestone to provide early feedback. Detailed upgrade instructions are available here: https://grails.apache.org/docs/${VERSION}/guide/upgrading.html
 
 The release notes are available here:
 <blog post link>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 First off, thanks for taking the time to contribute! ❤️
 
-Grails is an open source project with an active community and we rely heavily on that community to help make Grails better. As such, there are various ways in which people can contribute to Grails. One of these is by [writing useful plugins](https://docs.grails.org/latest/guide/plugins.html) and making them publicly available.
+Grails is an open source project with an active community and we rely heavily on that community to help make Grails better. As such, there are various ways in which people can contribute to Grails. One of these is by [writing useful plugins](https://grails.apache.org/docs/latest/guide/plugins.html) and making them publicly available.
 
 All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
 
@@ -49,7 +49,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://docs.grails.org/latest/).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://grails.apache.org/docs/latest/).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/apache/grails-core/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
@@ -63,7 +63,7 @@ If you then still feel the need to ask a question and need clarification, we rec
 
 ## I Want to Write a Grails Plugin
 
-[Grails Plugins](https://docs.grails.org/latest/guide/plugins.html) are similar to a Grails Application project, but they include a plugin descriptor and package shared functionality for other Grails Applications to use.  More information can be found [here](https://docs.grails.org/latest/guide/plugins.html#creatingAndInstallingPlugins).
+[Grails Plugins](https://grails.apache.org/docs/latest/guide/plugins.html) are similar to a Grails Application project, but they include a plugin descriptor and package shared functionality for other Grails Applications to use.  More information can be found [here](https://grails.apache.org/docs/latest/guide/plugins.html#creatingAndInstallingPlugins).
 
 ## I Want to Contribute
 
@@ -79,7 +79,7 @@ If you then still feel the need to ask a question and need clarification, we rec
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://docs.grails.org/latest/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://grails.apache.org/docs/latest/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/apache/grails-coreissues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
@@ -116,7 +116,7 @@ This section guides you through submitting an enhancement suggestion for Grails,
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the [documentation](https://docs.grails.org/latest/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Read the [documentation](https://grails.apache.org/docs/latest/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
 - Perform a [search](https://github.com/apache/grails-core/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
@@ -193,9 +193,9 @@ By default, Grails forks a JVM to run the application. The `-debug-jvm` argument
 
 ### Improving The Documentation
 
-There are many aspects to [Grail's documentation](https://docs.grails.org/)
-- [API](https://docs.grails.org/latest/api/) documentation in the code itself via javadoc & groovydoc.
-- [The Grails User Guide](https://docs.grails.org/latest/guide/single.html) from the `grails-doc` project in this
+There are many aspects to [Grail's documentation](https://grails.apache.org/docs/)
+- [API](https://grails.apache.org/docs/latest/api/) documentation in the code itself via javadoc & groovydoc.
+- [The Grails User Guide](https://grails.apache.org/docs/latest/guide/single.html) from the `grails-doc` project in this
   repository.
 - Various how-to [Guides](https://guides.grails.org/index.html) from
   the [grails-guides](https://github.com/grails-guides) Organization.

--- a/INSTALL
+++ b/INSTALL
@@ -1,7 +1,7 @@
 Grails Installation Guide
 =======================
 
-Grails is a powerful Groovy-based web application framework for the JVM built on top of Spring Boot that has many plugins to further extend its functionality. The full documentation for how to install Grails via different mechanisms and use it can be found at `https://docs.grails.org/latest`.  This document specifically covers the basic building and installation of Grails from a source distribution.
+Grails is a powerful Groovy-based web application framework for the JVM built on top of Spring Boot that has many plugins to further extend its functionality. The full documentation for how to install Grails via different mechanisms and use it can be found at `https://grails.apache.org/docs/latest`.  This document specifically covers the basic building and installation of Grails from a source distribution.
 
 How to use the source distribution
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Apache Grails
 
-[![Documentation](https://img.shields.io/badge/Documentation-595959)](https://docs.grails.org)
+[![Documentation](https://img.shields.io/badge/Documentation-595959)](https://grails.apache.org/docs/)
 [![Develocity](https://img.shields.io/badge/Develocity-06A0CE?logo=Gradle&labelColor=06A0CE)](https://ge.grails.org/scans)
 [![CI](https://github.com/apache/grails-core/actions/workflows/gradle.yml/badge.svg?event=push)](https://github.com/apache/grails-core/actions/workflows/gradle.yml)
 [![Groovy Joint Validation Build](https://github.com/apache/grails-core/actions/workflows/groovy-joint-workflow.yml/badge.svg?event=push)](https://github.com/apache/grails-core/actions/workflows/groovy-joint-workflow.yml)
@@ -38,7 +38,7 @@ Please see the [INSTALL](INSTALL) document for instructions on how to build, use
 
 ## Getting help
 
-- Check the [Documentation](https://docs.grails.org/) for your preferred Apache Grails version.
+- Check the [Documentation](https://grails.apache.org/docs/) for your preferred Apache Grails version.
 - Check for a [Grails Guide](https://github.com/grails-guides/).
 - Ask questions on the [Grails User Mailing List](https://lists.apache.org/list.html?users@grails.apache.org)
 - Submit an issue: [Grails Issues](https://github.com/apache/grails-core/issues)
@@ -73,13 +73,13 @@ To create an Apache Grails Application with the wrapper follow these steps:
 3. Run the wrapper command `grailsw -t forge create-app` to create a new Apache Grails Application.
 
 Please note, that the wrapper supports either the legacy `Apache Grails Shell` or the newer `Apache Grails Forge` CLI.
-For more detailed information about it, see the [documentation](https://docs.grails.org/snapshot/index.html).
+For more detailed information about it, see the [documentation](https://grails.apache.org/docs/snapshot/index.html).
 
 #### Wrapper - Running Commands inside a Apache Grails Project
 
 For running commands, the Grails Wrapper will always pull the Apache Grails version from `gradle.properties` and ignore
 any environment variables. Type `grailsw -t shell help` to see the available commands. For more detailed information
-about it, see the [documentation](https://docs.grails.org/snapshot/index.html).
+about it, see the [documentation](https://grails.apache.org/docs/snapshot/index.html).
 
 ### grails-shell-cli
 
@@ -110,7 +110,7 @@ Once your Apache Grails Application is created, you can start it with the comman
 
     ./gradlew bootRun
 
-For further information, please consult the [documentation](https://docs.grails.org).
+For further information, please consult the [documentation](https://grails.apache.org/docs/).
 
 ## Licensing
 

--- a/grails-data-docs/guide-rx/src/main/docs/gettingStarted/CRUD.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/gettingStarted/CRUD.adoc
@@ -79,7 +79,7 @@ Book.get(id)
     }
 ----
 
-The `switchMap` transforms an `Observable` and converts the result into another `Observable`. However, this is not the most efficient way to perform updates as you can use https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#whereQueries[where queries] to update an instance without retrieving it:
+The `switchMap` transforms an `Observable` and converts the result into another `Observable`. However, this is not the most efficient way to perform updates as you can use https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#whereQueries[where queries] to update an instance without retrieving it:
 
 
 [source,groovy]

--- a/grails-data-docs/guide-rx/src/main/docs/gettingStarted/creatingDomainClasses.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/gettingStarted/creatingDomainClasses.adoc
@@ -44,4 +44,4 @@ NOTE: The type is provided as a generic argument to the `RxMongoEntity` trait. T
 
 In addition, for MongoDB an `id` of type `ObjectId` is required.
 
-For more information on domain modelling in GORM, take a look at the https://docs.grails.org/latest/guide/GORM.html#domainClasses[GORM user guide] on the subject.
+For more information on domain modelling in GORM, take a look at the https://grails.apache.org/docs/latest/guide/GORM.html#domainClasses[GORM user guide] on the subject.

--- a/grails-data-docs/guide-rx/src/main/docs/introduction.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/introduction.adoc
@@ -19,7 +19,7 @@ under the License.
 
 == Introduction
 
-https://docs.grails.org/lastest/grails-data/[GORM], the object mapping technology built into the Grails framework, has traditionally been a primarily blocking API.
+https://grails.apache.org/docs/lastest/grails-data/[GORM], the object mapping technology built into the Grails framework, has traditionally been a primarily blocking API.
 
 Async features were added in GORM 4, however these are merely a way to isolate your blocking operations onto a different thread and not a truly non-blocking implementation.
 

--- a/grails-data-docs/guide-rx/src/main/docs/querying/dynamicFinders.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/querying/dynamicFinders.adoc
@@ -18,7 +18,7 @@ under the License.
 ////
 
 === Dynamic Finders
-Although _Where queries_ are preferred, _Dynamic finders_ are another option for simple queries and are also very expressive. The https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#finders[syntax for Dynamic finders is described in the GORM user guide]. The major difference in RxGORM is that all dynamic finders return an `rx.Observable`:
+Although _Where queries_ are preferred, _Dynamic finders_ are another option for simple queries and are also very expressive. The https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#finders[syntax for Dynamic finders is described in the GORM user guide]. The major difference in RxGORM is that all dynamic finders return an `rx.Observable`:
 
 [source,groovy]
 ----

--- a/grails-data-docs/guide-rx/src/main/docs/querying/index.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/querying/index.adoc
@@ -20,10 +20,10 @@ under the License.
 == Querying
 RxGORM supports all the typical ways of querying that you are used to with GORM including:
 
-* https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#finders[Dynamic finders]
-* https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#whereQueries[Where queries]
-* https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#detachedCriteria[Detached Criteria]
-* https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#criteria[Criteria queries]
+* https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#finders[Dynamic finders]
+* https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#whereQueries[Where queries]
+* https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#detachedCriteria[Detached Criteria]
+* https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#criteria[Criteria queries]
 
 The major difference is that all query operations return an `Observable`. In this section we will go through the various ways you can query for GORM objects.
 

--- a/grails-data-docs/guide-rx/src/main/docs/querying/whereQueries.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/querying/whereQueries.adoc
@@ -56,4 +56,4 @@ Book.where { title == 'The Stand' }
     }
 ----
 
-For more information on the syntax of where queries see the https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#whereQueries[relevant section in the GORM documentation].
+For more information on the syntax of where queries see the https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#whereQueries[relevant section in the GORM documentation].

--- a/grails-data-docs/guide-whats-new/src/main/docs/index.adoc
+++ b/grails-data-docs/guide-whats-new/src/main/docs/index.adoc
@@ -57,4 +57,4 @@ GORM 8 addresses known issues from previous versions, providing a more reliable 
 
 GORM 8 offers a powerful ORM solution for Java-based applications. Leverage the latest Java, Gradle, Hibernate, MongoDB, Neo4J, and Spring versions to build robust data-centric applications. GORM 8 provides a unified API for simplified data access and management, supporting traditional SQL databases, NoSQL data stores like MongoDB, and graph databases like Neo4J.
 
-For comprehensive changes and in-depth information about GORM 8, explore the official GitHub repository and release notes. Get started with GORM 8 and explore its full capabilities in the https://docs.grails.org/latest/grails-data/[GORM Documentation].
+For comprehensive changes and in-depth information about GORM 8, explore the official GitHub repository and release notes. Get started with GORM 8 and explore its full capabilities in the https://grails.apache.org/docs/latest/grails-data/[GORM Documentation].

--- a/grails-data-graphql/docs/src/main/docs/guide/gettingStarted.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/gettingStarted.adoc
@@ -19,7 +19,7 @@ under the License.
 
 == Standalone Projects
 
-For standalone projects, it is up to the developer how and when the schema gets created. A mapping context is required to create a schema. The mapping context is available on all link:{gormapi}/org/grails/datastore/mapping/core/Datastore.html#getMappingContext()[datastore implementations]. See the link:https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#outsideGrails#outsideGrails[GORM documentation] for information on creating a datastore.
+For standalone projects, it is up to the developer how and when the schema gets created. A mapping context is required to create a schema. The mapping context is available on all link:{gormapi}/org/grails/datastore/mapping/core/Datastore.html#getMappingContext()[datastore implementations]. See the link:https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#outsideGrails#outsideGrails[GORM documentation] for information on creating a datastore.
 
 The example below is the simplest way possible to generate a schema.
 
@@ -66,7 +66,7 @@ Just by adding the `graphql = true` property on your domain, full CRUD capabilit
 
 Imagine you are building an API for a Conference. A talk can be presented
 by a single speaker. A speaker can have many talks within the conference.
-A typical one-to-many relationship which in https://docs.grails.org/latest/grails-data/[GORM]
+A typical one-to-many relationship which in https://grails.apache.org/docs/latest/grails-data/[GORM]
 could be expressed with:
 
 [source, groovy]
@@ -84,4 +84,4 @@ include::{sourcedir}/examples/grails-docs-app/grails-app/domain/demo/Talk.groovy
 ----
 
 
-TIP: GORM GraphQL plugin supports https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#outsideGrails#derivedProperties[Derived Properties] as illustrated in the previous example; `name` is derived property which concatenates `firstName` and `lastName`
+TIP: GORM GraphQL plugin supports https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#outsideGrails#derivedProperties[Derived Properties] as illustrated in the previous example; `name` is derived property which concatenates `firstName` and `lastName`

--- a/grails-data-graphql/docs/src/main/docs/guide/types.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/types.adoc
@@ -70,7 +70,7 @@ TIP: If you need to customize more than 1 manager, only a single bean needs to b
 
 Once you have access to the manager, registration of your own type is easy. In this example a type is being registered to handle a Mongo `ObjectId`. The type will be used to do conversion of arguments in GraphQL.
 
-NOTE: This process only handles how an ObjectId will be created from either Java arguments, or arguments passed inline in the GraphQL query or mutation. For Grails applications, the process of rendering the ObjectID as json is handled by link:https://docs.grails.org/latest/guide/theWebLayer.html#gson[JSON views]. To supply behavior for how an ObjectId is rendered, see the documentation for json views. For standalone projects, you are responsible for any conversions that may need to happen.
+NOTE: This process only handles how an ObjectId will be created from either Java arguments, or arguments passed inline in the GraphQL query or mutation. For Grails applications, the process of rendering the ObjectID as json is handled by link:https://grails.apache.org/docs/latest/guide/theWebLayer.html#gson[JSON views]. To supply behavior for how an ObjectId is rendered, see the documentation for json views. For standalone projects, you are responsible for any conversions that may need to happen.
 
 [source,groovy]
 ----

--- a/grails-data-hibernate5/README.md
+++ b/grails-data-hibernate5/README.md
@@ -15,14 +15,14 @@ limitations under the License.
 -->
 
 # GORM for Hibernate 5
-This project implements [GORM](https://docs.grails.org/latest/grails-data/) for the Hibernate 5.
+This project implements [GORM](https://grails.apache.org/docs/latest/grails-data/) for the Hibernate 5.
 
 For more information see the following links:
 
-* [Documentation](https://docs.grails.org/latest/grails-data/hibernate5/manual)
-* [API Reference](https://docs.grails.org/latest/api)
+* [Documentation](https://grails.apache.org/docs/latest/grails-data/hibernate5/manual)
+* [API Reference](https://grails.apache.org/docs/latest/api)
 
 For the current development version see the following links:
 
-* [Development Snapshot Documentation](https://docs.grails.org/snapshot/grails-data/hibernate5/manual)
-* [Development Snapshot API Reference](https://docs.grails.org/snapshot/api)
+* [Development Snapshot Documentation](https://grails.apache.org/docs/snapshot/grails-data/hibernate5/manual)
+* [Development Snapshot API Reference](https://grails.apache.org/docs/snapshot/api)

--- a/grails-data-hibernate5/dbmigration/README.md
+++ b/grails-data-hibernate5/dbmigration/README.md
@@ -51,14 +51,14 @@ One popular approach is to have a root changelog named changelog.groovy (or chan
 
 ## Documentation
 
-* Latest https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#databaseMigration
-* Snapshot: https://docs.grails.org/snapshot/grails-data/hibernate5/manual/index.html#databaseMigration
+* Latest https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#databaseMigration
+* Snapshot: https://grails.apache.org/docs/snapshot/grails-data/hibernate5/manual/index.html#databaseMigration
 * Grails 2: https://grails.github.io/grails-database-migration/1.4.0/
 * Grails 3 (Hibernate 4): https://grails.github.io/grails-database-migration/2.0.x/index.html
 * Grails 3/4 (Hibernate 5): https://grails.github.io/grails-database-migration/3.0.x/index.html
 * Grails 5 (Hibernate 5): https://grails.github.io/grails-database-migration/4.0.x/index.html
 * Grails 6 (Hibernate 5): https://grails.github.io/grails-database-migration/5.0.x/index.html
-* Grails 7 (Hibernate 5): https://docs.grails.org/7.0.x/grails-data/hibernate5/manual/index.html#databaseMigration
+* Grails 7 (Hibernate 5): https://grails.apache.org/docs/7.0.x/grails-data/hibernate5/manual/index.html#databaseMigration
 
 ## Package distribution
 

--- a/grails-data-hibernate5/dbmigration/src/main/groovy/org/grails/plugins/databasemigration/DatabaseMigrationGrailsPlugin.groovy
+++ b/grails-data-hibernate5/dbmigration/src/main/groovy/org/grails/plugins/databasemigration/DatabaseMigrationGrailsPlugin.groovy
@@ -44,7 +44,7 @@ class DatabaseMigrationGrailsPlugin extends Plugin {
     def author = 'Kazuki YAMAMOTO'
     def authorEmail = ''
     def description = 'Grails Database Migration Plugin'
-    def documentation = 'https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#databaseMigration'
+    def documentation = 'https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#databaseMigration'
     def license = 'APACHE'
     def scm = [url: 'https://github.com/apache/grails-core']
 

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/domainClasses/gormAssociation/manyToOneAndOneToOne.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/domainClasses/gormAssociation/manyToOneAndOneToOne.adoc
@@ -209,7 +209,7 @@ void clearReviews(Book book) {
 }
 ----
 
-Alternatively you could leverage https://docs.grails.org/latest/ref/Database%20Mapping/cascade.html[cascade] behaviour.
+Alternatively you could leverage https://grails.apache.org/docs/latest/ref/Database%20Mapping/cascade.html[cascade] behaviour.
 
 [source,groovy]
 ----

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/introduction.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/introduction.adoc
@@ -21,7 +21,7 @@ GORM is a data access framework with multiple backend implementations that allow
 
 There are currently several implementations of GORM. This documentation covers the original implementation of GORM which is based on the Hibernate ORM. Below you can find links to the other implementations:
 
-* https://docs.grails.org/latest/grails-data/mongodb/manual/[GORM for MongoDB]
+* https://grails.apache.org/docs/latest/grails-data/mongodb/manual/[GORM for MongoDB]
 * https://gorm.grails.org/latest/neo4j/manual[GORM for Neo4j]
 * https://gorm.grails.org/latest/cassandra/manual[GORM for Cassandra]
 * https://gorm.grails.org/latest/rx/manual[RxGORM for MongoDB]

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/learningMore.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/learningMore.adoc
@@ -17,4 +17,4 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-The full documentation for GORM for Hibernate can be found in the https://docs.grails.org/latest/grails-data/[Grails User Guide], this documentation serves to explain how to get started with GORM for Hibernate with or without Grails and to document release notes.
+The full documentation for GORM for Hibernate can be found in the https://grails.apache.org/docs/latest/grails-data/[Grails User Guide], this documentation serves to explain how to get started with GORM for Hibernate with or without Grails and to document release notes.

--- a/grails-data-hibernate5/grails-plugin/src/main/groovy/grails/plugin/hibernate/HibernateGrailsPlugin.groovy
+++ b/grails-data-hibernate5/grails-plugin/src/main/groovy/grails/plugin/hibernate/HibernateGrailsPlugin.groovy
@@ -52,7 +52,7 @@ class HibernateGrailsPlugin extends Plugin {
     def author = 'Grails Core Team'
     def title = 'Hibernate 5 for Grails'
     def description = 'Provides integration between Grails and Hibernate 5 through GORM'
-    def documentation = 'https://docs.grails.org/latest/grails-data/'
+    def documentation = 'https://grails.apache.org/docs/latest/grails-data/'
 
     def observe = ['domainClass']
     def loadAfter = ['controllers', 'domainClass']

--- a/grails-data-mongodb/README.md
+++ b/grails-data-mongodb/README.md
@@ -15,15 +15,15 @@ limitations under the License.
 -->
 
 # GORM for MongoDB
-This project implements [GORM](https://docs.grails.org/latest/grails-data/) for the MongoDB Document Database.
+This project implements [GORM](https://grails.apache.org/docs/latest/grails-data/) for the MongoDB Document Database.
 
 For more information see the following links:
 
-* [Documentation](https://docs.grails.org/latest/grails-data/mongodb/manual/)
-* [API](https://docs.grails.org/latest/api)
+* [Documentation](https://grails.apache.org/docs/latest/grails-data/mongodb/manual/)
+* [API](https://grails.apache.org/docs/latest/api)
 
 For the current development version see the following links:
 
-* [Snapshot Documentation](https://docs.grails.org/snapshot/grails-data/mongodb/manual/)
-* [Snapshot API](https://docs.grails.org/snapshot/api)
+* [Snapshot Documentation](https://grails.apache.org/docs/snapshot/grails-data/mongodb/manual/)
+* [Snapshot API](https://grails.apache.org/docs/snapshot/api)
 

--- a/grails-data-mongodb/docs/src/docs/asciidoc/introduction/compatibility.adoc
+++ b/grails-data-mongodb/docs/src/docs/asciidoc/introduction/compatibility.adoc
@@ -18,7 +18,7 @@ under the License.
 ////
 
 === Compatibility with GORM for Hibernate
-This implementation tries to be as compatible as possible with GORM for Hibernate. In general you can refer to the https://docs.grails.org/latest/grails-data/[GORM documentation] and the "Domain Classes" section of the https://docs.grails.org/latest/[reference guide] (see the right nav) for usage information.
+This implementation tries to be as compatible as possible with GORM for Hibernate. In general you can refer to the https://grails.apache.org/docs/latest/grails-data/[GORM documentation] and the "Domain Classes" section of the https://grails.apache.org/docs/latest/[reference guide] (see the right nav) for usage information.
 
 The following key features are supported by GORM for Mongo:
 

--- a/grails-data-mongodb/docs/src/docs/asciidoc/querying/queryingBasics.adoc
+++ b/grails-data-mongodb/docs/src/docs/asciidoc/querying/queryingBasics.adoc
@@ -18,7 +18,7 @@ under the License.
 ////
 
 === Basic Querying
-GORM for MongoDB supports all of the https://docs.grails.org/latest/grails-data/hibernate5/manual/index.html#querying[regular methods] for executing GORM queries apart from HQL, which is a Hibernate specific query language more appropriate for SQL databases.
+GORM for MongoDB supports all of the https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#querying[regular methods] for executing GORM queries apart from HQL, which is a Hibernate specific query language more appropriate for SQL databases.
 
 If you wish to execute a native MongoDB query you can use the `find` method that takes a https://api.mongodb.com/java/current/org/bson/conversions/Bson.html[Bson] argument. For example:
 

--- a/grails-data-mongodb/grails-plugin/src/main/groovy/grails/plugins/mongodb/MongodbGrailsPlugin.groovy
+++ b/grails-data-mongodb/grails-plugin/src/main/groovy/grails/plugins/mongodb/MongodbGrailsPlugin.groovy
@@ -46,7 +46,7 @@ class MongodbGrailsPlugin extends Plugin {
     def loadAfter = ['domainClass', 'hibernate', 'hibernate5', 'hibernate6', 'services']
     def title = 'GORM MongoDB'
     def description = 'A plugin that integrates the MongoDB document datastore into the Grails framework, providing a GORM API onto it'
-    def documentation = 'https://docs.grails.org/latest/grails-data/mongodb/manual/'
+    def documentation = 'https://grails.apache.org/docs/latest/grails-data/mongodb/manual/'
 
     @Override
     @CompileStatic

--- a/grails-data-neo4j/README.md
+++ b/grails-data-neo4j/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 This project has not been updated for Grails 7 yet and is not included in the build.
 
-This project implements [GORM](https://docs.grails.org/latest/grails-data/) for the Neo4j 3.x Graph Database using the Bolt Java Driver.
+This project implements [GORM](https://grails.apache.org/docs/latest/grails-data/) for the Neo4j 3.x Graph Database using the Bolt Java Driver.
 
 For more information see the following links:
 

--- a/grails-data-neo4j/docs/src/docs/asciidoc/mapping/associations.adoc
+++ b/grails-data-neo4j/docs/src/docs/asciidoc/mapping/associations.adoc
@@ -59,4 +59,4 @@ class Owner {
 
 In this case a bidirectional relationship will be created  in the graph such as `(from)<-[r:PETZ]->(to)`.
 
-TIP: For more information on defining relationships with GORM, see the https://docs.grails.org/latest/guide/GORM.html#gormAssociation[corresponding guide in the GORM documentation].
+TIP: For more information on defining relationships with GORM, see the https://grails.apache.org/docs/latest/guide/GORM.html#gormAssociation[corresponding guide in the GORM documentation].

--- a/grails-data-neo4j/docs/src/docs/asciidoc/querying.adoc
+++ b/grails-data-neo4j/docs/src/docs/asciidoc/querying.adoc
@@ -19,9 +19,9 @@ under the License.
 
 GORM for Neo4j supports all the different querying methods provided by GORM including:
 
-* https://docs.grails.org/latest/guide/GORM.html#finders[Dynamic Finders]
-* https://docs.grails.org/latest/guide/GORM.html#whereQueries[Where Queries]
-* https://docs.grails.org/latest/guide/GORM.html#criteria[Criteria Queries]
+* https://grails.apache.org/docs/latest/guide/GORM.html#finders[Dynamic Finders]
+* https://grails.apache.org/docs/latest/guide/GORM.html#whereQueries[Where Queries]
+* https://grails.apache.org/docs/latest/guide/GORM.html#criteria[Criteria Queries]
 
 However, HQL queries are not supported, instead you can use Cypher directly if you so choose.
 

--- a/grails-datamapping-core/src/main/groovy/org/grails/compiler/gorm/GormEntityTransformation.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/compiler/gorm/GormEntityTransformation.groovy
@@ -287,7 +287,7 @@ class GormEntityTransformation extends AbstractASTTransformation implements Comp
         classNode.addMethod('$static_propertyMissing', Modifier.PUBLIC | Modifier.STATIC, AstUtils.OBJECT_CLASS_NODE, propertyMissingGetParameters, null, propertyMissingGetBody)
 
         // now process named query associations
-        // see https://docs.grails.org/latest/ref/Domain%20Classes/namedQueries.html
+        // see https://grails.apache.org/docs/latest/ref/Domain%20Classes/namedQueries.html
 
         // for each method call create a named query proxy lookup
         def thisClassNode = classNode

--- a/grails-doc/README.md
+++ b/grails-doc/README.md
@@ -17,6 +17,6 @@ limitations under the License.
 Grails User/Reference Guide
 ===========================
 
-This is the project for generating the [Grails user & reference guide](https://docs.grails.org/latest/) that explains how to build applications with the [Grails](https://grails.apache.org/) framework.
+This is the project for generating the [Grails user & reference guide](https://grails.apache.org/docs/latest/) that explains how to build applications with the [Grails](https://grails.apache.org/) framework.
 
 For contributing to grails docs look at the [Contribution Guide](../CONTRIBUTING.md) on GitHub.

--- a/grails-doc/src/en/guide/services/dependencyInjectionServices.adoc
+++ b/grails-doc/src/en/guide/services/dependencyInjectionServices.adoc
@@ -112,7 +112,7 @@ class Book {
 }
 ----
 
-WARNING: Since Grails 3.2.8 this is not enabled by default. If you want to enable it again, take a look at https://docs.grails.org/latest/ref/Domain%20Classes/Usage.html#_spring_autowiring_of_domain_instances[Spring Autowiring of Domain Instance]
+WARNING: Since Grails 3.2.8 this is not enabled by default. If you want to enable it again, take a look at https://grails.apache.org/docs/latest/ref/Domain%20Classes/Usage.html#_spring_autowiring_of_domain_instances[Spring Autowiring of Domain Instance]
 
 ==== Service Bean Names
 

--- a/grails-fields/README.md
+++ b/grails-fields/README.md
@@ -23,8 +23,8 @@ logic.
 
 ## Documentation
 
-* Latest Guide - https://docs.grails.org/latest/guide/theWebLayer.html#fields
-* Latest API - https://docs.grails.org/latest/api/grails/plugin/formfields/package-summary.html
+* Latest Guide - https://grails.apache.org/docs/latest/guide/theWebLayer.html#fields
+* Latest API - https://grails.apache.org/docs/latest/api/grails/plugin/formfields/package-summary.html
 
-* Snapshot Guide - https://docs.grails.org/snapshot/guide/theWebLayer.html#fields
-* Snapshot API - https://docs.grails.org/snapshot/api/grails/plugin/formfields/package-summary.html
+* Snapshot Guide - https://grails.apache.org/docs/snapshot/guide/theWebLayer.html#fields
+* Snapshot API - https://grails.apache.org/docs/snapshot/api/grails/plugin/formfields/package-summary.html

--- a/grails-forge/README.md
+++ b/grails-forge/README.md
@@ -22,7 +22,7 @@ Generates Grails applications.
 
 ## Installation
 
-The CLI application comes in various flavours from a universal Java applications to native applications for Windows, Linux and OS X. These are available for direct download on the [releases page](https://github.com/apache/grails-core/releases). For installation see the [Grails documentation](https://docs.grails.org/latest/guide/index.html#buildCLI).
+The CLI application comes in various flavours from a universal Java applications to native applications for Windows, Linux and OS X. These are available for direct download on the [releases page](https://github.com/apache/grails-core/releases). For installation see the [Grails documentation](https://grails.apache.org/docs/latest/guide/index.html#buildCLI).
 
 If you prefer not to install an application to create Grails applications you can do so with `curl` directly from the API:
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/cache/GrailsCache.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/cache/GrailsCache.java
@@ -70,7 +70,7 @@ public class GrailsCache implements Feature {
 
     @Override
     public String getDocumentation() {
-        return "https://docs.grails.org/" + VersionInfo.getDocumentationVersion() + "/guide/cache.html";
+        return "https://grails.apache.org/docs/" + VersionInfo.getDocumentationVersion() + "/guide/cache.html";
     }
 
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/MongoGorm.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/MongoGorm.java
@@ -82,6 +82,6 @@ public class MongoGorm extends GormOneOfFeature {
     @Nullable
     @Override
     public String getThirdPartyDocumentation() {
-        return "https://docs.grails.org/latest/grails-data/mongodb/manual/";
+        return "https://grails.apache.org/docs/latest/grails-data/mongodb/manual/";
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
@@ -51,7 +51,7 @@ public class DatabaseMigrationPlugin implements MigrationFeature {
 
     @Override
     public String getDocumentation() {
-        return "https://docs.grails.org/" + VersionInfo.getDocumentationVersion() + "/grails-data/hibernate5/manual/index.html#databaseMigration";
+        return "https://grails.apache.org/docs/" + VersionInfo.getDocumentationVersion() + "/grails-data/hibernate5/manual/index.html#databaseMigration";
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/other/template/maindocs.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/other/template/maindocs.rocker.raw
@@ -23,11 +23,11 @@ under the License.
 ## Grails @VersionInfo.getGrailsVersion() Documentation
 
 @if (VersionInfo.isGrailsSnapshot()) {
-- [User Guide](https://docs.grails.org/snapshot/guide/index.html)
-- [API Reference](https://docs.grails.org/snapshot/api/index.html)
+- [User Guide](https://grails.apache.org/docs/snapshot/guide/index.html)
+- [API Reference](https://grails.apache.org/docs/snapshot/api/index.html)
 } else {
-- [User Guide](https://docs.grails.org/@VersionInfo.getGrailsVersion()/guide/index.html)
-- [API Reference](https://docs.grails.org/@VersionInfo.getGrailsVersion()/api/index.html)
+- [User Guide](https://grails.apache.org/docs/@VersionInfo.getGrailsVersion()/guide/index.html)
+- [API Reference](https://grails.apache.org/docs/@VersionInfo.getGrailsVersion()/api/index.html)
 }
 - [Grails Guides](https://guides.grails.org/index.html)
 ---

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/test/template/spock.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/test/template/spock.rocker.raw
@@ -31,7 +31,7 @@ import grails.plugin.geb.ContainerGebSpec
 import grails.testing.mixin.integration.Integration
 
 /**
- * See https://docs.grails.org/latest/guide/testing.html#functionalTesting and https://groovy.apache.org/geb/manual/current/
+ * See https://grails.apache.org/docs/latest/guide/testing.html#functionalTesting and https://groovy.apache.org/geb/manual/current/
  * for more instructions on how to write functional tests with Grails and Geb.
  */
 @@Integration

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsViews.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsViews.java
@@ -50,7 +50,7 @@ public abstract class GrailsViews implements OneOfFeature {
 
     @Override
     public String getDocumentation() {
-        return "https://docs.grails.org/" + VersionInfo.getDocumentationVersion() + "/guide/theWebLayer.html";
+        return "https://grails.apache.org/docs/" + VersionInfo.getDocumentationVersion() + "/guide/theWebLayer.html";
     }
 
     public GrailsWeb getGrailsWeb() {

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/Scaffolding.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/Scaffolding.java
@@ -63,7 +63,7 @@ public class Scaffolding implements DefaultFeature {
 
     @Override
     public String getDocumentation() {
-        return "https://docs.grails.org/" + VersionInfo.getDocumentationVersion() + "/guide/scaffolding.html";
+        return "https://grails.apache.org/docs/" + VersionInfo.getDocumentationVersion() + "/guide/scaffolding.html";
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/resources/gsp/main.gsp
+++ b/grails-forge/grails-forge-core/src/main/resources/gsp/main.gsp
@@ -47,11 +47,11 @@
             <div class="card border-0 col-12 col-md">
                 <div class="card-body">
                     <h6 class="card-title">
-                        <a class="link-underline link-underline-opacity-0" href="https://docs.grails.org" target="_blank">
+                        <a class="link-underline link-underline-opacity-0" href="https://grails.apache.org/docs/" target="_blank">
                             <asset:image src="documentation.svg" alt="Grails Documentation" class="me-2" width="34" />Documentation
                         </a>
                     </h6>
-                    <p class="card-text">Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://docs.grails.org" target="_blank">User Guide</a>.</p>
+                    <p class="card-text">Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
                 </div>
             </div>
             <div class="card border-0 col-12 col-md">

--- a/grails-gradle/docs-core/src/main/groovy/grails/doc/DocPublisher.groovy
+++ b/grails-gradle/docs-core/src/main/groovy/grails/doc/DocPublisher.groovy
@@ -323,7 +323,7 @@ class DocPublisher {
             // pass attributes to asciidoc
             ((AsciiDocEngine) engine).attributes.putAll(
                     version: version,
-                    apiDocs: "https://docs.grails.org/${version}/api/",
+                    apiDocs: "https://grails.apache.org/docs/${version}/api/",
                     sourceRepo: sourceRepo
             )
             ((AsciiDocEngine) engine).attributes.putAll(

--- a/grails-gradle/docs-core/src/main/groovy/grails/doc/dropdown/CreateReleaseDropDownTask.groovy
+++ b/grails-gradle/docs-core/src/main/groovy/grails/doc/dropdown/CreateReleaseDropDownTask.groovy
@@ -101,7 +101,7 @@ abstract class CreateReleaseDropDownTask extends DefaultTask {
         modifiedPagesDirectory = objects.directoryProperty().convention(project.layout.buildDirectory.dir('modified-pages'))
         gitTags = objects.fileProperty().convention(project.layout.buildDirectory.file('git-tags.txt'))
         minimumVersion = objects.property(SoftwareVersion).convention(new SoftwareVersion(major: 5))
-        docBaseUrl = objects.property(String).convention('https://docs.grails.org')
+        docBaseUrl = objects.property(String).convention('https://grails.apache.org/docs')
         versionHtml = objects.property(String).convention(project.provider { '<p><strong>Version:</strong> ' + projectVersion.get() + '</p>' })
         additionalPath = objects.property(String).convention('')
     }

--- a/grails-gradle/docs-core/src/main/resources/grails/doc/doc.properties
+++ b/grails-gradle/docs-core/src/main/resources/grails/doc/doc.properties
@@ -15,8 +15,8 @@
 
 # javadoc alias used to link to external javadocs in the form [HttpServletRequest|api:javax.servlet.http.HttpServletRequest]
 api.org.hibernate=http://docs.jboss.org/hibernate/orm/4.3/javadocs/
-api.org.grails=https://docs.grails.org/lastest/api/
-api.org.codehaus.groovy.grails=https://docs.grails.org/lastest/api/
+api.org.grails=https://grails.apache.org/docs/lastest/api/
+api.org.codehaus.groovy.grails=https://grails.apache.org/docs/lastest/api/
 api.org.springframework=http://docs.spring.io/spring/docs/current/javadoc-api/
 api.javax.servlet=http://docs.oracle.com/javaee/6/api/
 api.java.=http://docs.oracle.com/javase/7/docs/api/

--- a/grails-gradle/plugins/README.md
+++ b/grails-gradle/plugins/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 Grails Gradle Plugins
 ========
 
-Latest API Docs: https://docs.grails.org/latest/api/
+Latest API Docs: https://grails.apache.org/docs/latest/api/
 
 Below are the plugins that are provided by the grails-gradle-plugin dependency.
 

--- a/grails-gsp/README.md
+++ b/grails-gsp/README.md
@@ -18,8 +18,8 @@ limitations under the License.
 
 This project contains the sources for GSP, the server-side view rendering technology used in the [Grails framework](https://grails.apache.org/).
 
-* Latest Guide - https://docs.grails.org/latest/guide/theWebLayer.html#gsp
-* Latest API - https://docs.grails.org/latest/api/grails/plugin/formfields/package-summary.html
+* Latest Guide - https://grails.apache.org/docs/latest/guide/theWebLayer.html#gsp
+* Latest API - https://grails.apache.org/docs/latest/api/grails/plugin/formfields/package-summary.html
 
-* Snapshot Guide - https://docs.grails.org/snapshot/guide/theWebLayer.html#gsp
-* Snapshot API - https://docs.grails.org/snapshot/api/grails/plugin/formfields/package-summary.html
+* Snapshot Guide - https://grails.apache.org/docs/snapshot/guide/theWebLayer.html#gsp
+* Snapshot API - https://grails.apache.org/docs/snapshot/api/grails/plugin/formfields/package-summary.html

--- a/grails-gsp/grails-sitemesh3/src/main/groovy/org/grails/plugins/sitemesh3/Sitemesh3GrailsPlugin.groovy
+++ b/grails-gsp/grails-sitemesh3/src/main/groovy/org/grails/plugins/sitemesh3/Sitemesh3GrailsPlugin.groovy
@@ -77,7 +77,7 @@ class Sitemesh3GrailsPlugin extends Plugin {
         { ->
             ConfigurableEnvironment configurableEnvironment = grailsApplication.mainContext.environment as ConfigurableEnvironment
             def propertySources = configurableEnvironment.getPropertySources()
-            // https://docs.grails.org/latest/guide/single.html#layouts
+            // https://grails.apache.org/docs/latest/guide/single.html#layouts
             // Default view should be application, but it is inefficient to add a rule for a page that may not exist.
             String defaultLayout = grailsApplication.getConfig().getProperty('grails.sitemesh.default.layout')
             propertySources.addFirst(getDefaultPropertySource(configurableEnvironment, defaultLayout))

--- a/grails-logging/README.md
+++ b/grails-logging/README.md
@@ -16,4 +16,4 @@ limitations under the License.
 
 ## grails-logging
 
-This subproject adds a log property to all artefacts. Refer to https://docs.grails.org/latest/ref/Plug-ins/logging.html
+This subproject adds a log property to all artefacts. Refer to https://grails.apache.org/docs/latest/ref/Plug-ins/logging.html

--- a/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
+++ b/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
@@ -47,11 +47,11 @@
             <div class="card border-0 col-12 col-md">
                 <div class="card-body">
                     <h6 class="card-title">
-                        <a class="link-underline link-underline-opacity-0" href="https://docs.grails.org" target="_blank">
+                        <a class="link-underline link-underline-opacity-0" href="https://grails.apache.org/docs/" target="_blank">
                             <asset:image src="documentation.svg" alt="Grails Documentation" class="me-2" width="34" />Documentation
                         </a>
                     </h6>
-                    <p class="card-text">Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://docs.grails.org" target="_blank">User Guide</a>.</p>
+                    <p class="card-text">Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
                 </div>
             </div>
             <div class="card border-0 col-12 col-md">

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingGrailsPlugin.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingGrailsPlugin.groovy
@@ -40,7 +40,7 @@ Plugin that generates scaffolded controllers and views for a Grails application.
 '''
 
     // URL to the plugin's documentation
-    def documentation = 'https://docs.grails.org/latest/guide/scaffolding.html'
+    def documentation = 'https://grails.apache.org/docs/latest/guide/scaffolding.html'
 
     // Extra (optional) plugin metadata
 

--- a/grails-test-examples/cache/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/cache/grails-app/views/layouts/main.gsp
@@ -60,11 +60,11 @@
 
     </div>
     <div class="col">
-        <a href="http://docs.grails.org" target="_blank">
+        <a href="https://grails.apache.org/docs/" target="_blank">
             <asset:image src="documentation.svg" alt="Grails Documentation" class="float-left"/>
         </a>
-        <strong class="centered"><a href="http://docs.grails.org" target="_blank">Documentation</a></strong>
-        <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="http://docs.grails.org" target="_blank">User Guide</a>.</p>
+        <strong class="centered"><a href="https://grails.apache.org/docs/" target="_blank">Documentation</a></strong>
+        <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
 
     </div>
 

--- a/grails-test-examples/geb-gebconfig/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/geb-gebconfig/grails-app/views/layouts/main.gsp
@@ -63,11 +63,11 @@
 
             </div>
             <div class="col">
-                <a href="https://docs.grails.org" target="_blank">
+                <a href="https://grails.apache.org/docs/" target="_blank">
                     <asset:image src="documentation.svg" alt="Grails Documentation" class="float-left"/>
                 </a>
-                <strong class="centered"><a href="https://docs.grails.org" target="_blank">Documentation</a></strong>
-                <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://docs.grails.org" target="_blank">User Guide</a>.</p>
+                <strong class="centered"><a href="https://grails.apache.org/docs/" target="_blank">Documentation</a></strong>
+                <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
 
             </div>
             <div class="col">

--- a/grails-test-examples/geb/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/geb/grails-app/views/layouts/main.gsp
@@ -63,11 +63,11 @@
 
             </div>
             <div class="col">
-                <a href="https://docs.grails.org" target="_blank">
+                <a href="https://grails.apache.org/docs/" target="_blank">
                     <asset:image src="documentation.svg" alt="Grails Documentation" class="float-left"/>
                 </a>
-                <strong class="centered"><a href="https://docs.grails.org" target="_blank">Documentation</a></strong>
-                <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://docs.grails.org" target="_blank">User Guide</a>.</p>
+                <strong class="centered"><a href="https://grails.apache.org/docs/" target="_blank">Documentation</a></strong>
+                <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
 
             </div>
             <div class="col">

--- a/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/RootPageSpec.groovy
+++ b/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/RootPageSpec.groovy
@@ -29,7 +29,7 @@ import grails.plugin.geb.ContainerGebSpec
 import grails.testing.mixin.integration.Integration
 
 /**
- * See https://docs.grails.org/latest/guide/testing.html#functionalTesting and https://groovy.apache.org/geb/manual/current/
+ * See https://grails.apache.org/docs/latest/guide/testing.html#functionalTesting and https://groovy.apache.org/geb/manual/current/
  * for more instructions on how to write functional tests with Grails and Geb.
  */
 @Integration

--- a/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/ServerNameControllerSpec.groovy
+++ b/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/ServerNameControllerSpec.groovy
@@ -26,7 +26,7 @@ import grails.plugin.geb.ContainerGebSpec
 import grails.testing.mixin.integration.Integration
 
 /**
- * See https://docs.grails.org/latest/guide/testing.html#functionalTesting and https://groovy.apache.org/geb/manual/current/
+ * See https://grails.apache.org/docs/latest/guide/testing.html#functionalTesting and https://groovy.apache.org/geb/manual/current/
  * for more instructions on how to write functional tests with Grails and Geb.
  */
 @Integration

--- a/grails-test-examples/gsp-layout/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/gsp-layout/grails-app/views/layouts/main.gsp
@@ -63,11 +63,11 @@
 
             </div>
             <div class="col">
-                <a href="https://docs.grails.org" target="_blank">
+                <a href="https://grails.apache.org/docs/" target="_blank">
                     <asset:image src="documentation.svg" alt="Grails Documentation" class="float-left"/>
                 </a>
-                <strong class="centered"><a href="https://docs.grails.org" target="_blank">Documentation</a></strong>
-                <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://docs.grails.org" target="_blank">User Guide</a>.</p>
+                <strong class="centered"><a href="https://grails.apache.org/docs/" target="_blank">Documentation</a></strong>
+                <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
 
             </div>
             <div class="col">

--- a/grails-test-examples/gsp-sitemesh3/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/gsp-sitemesh3/grails-app/views/layouts/main.gsp
@@ -63,11 +63,11 @@
 
             </div>
             <div class="col">
-                <a href="https://docs.grails.org" target="_blank">
+                <a href="https://grails.apache.org/docs/" target="_blank">
                     <asset:image src="documentation.svg" alt="Grails Documentation" class="float-left"/>
                 </a>
-                <strong class="centered"><a href="https://docs.grails.org" target="_blank">Documentation</a></strong>
-                <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://docs.grails.org" target="_blank">User Guide</a>.</p>
+                <strong class="centered"><a href="https://grails.apache.org/docs/" target="_blank">Documentation</a></strong>
+                <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
 
             </div>
             <div class="col">

--- a/grails-test-examples/hibernate5/issue450/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/hibernate5/issue450/grails-app/views/layouts/main.gsp
@@ -60,11 +60,11 @@
 
     </div>
     <div class="col">
-        <a href="http://docs.grails.org" target="_blank">
+        <a href="https://grails.apache.org/docs/" target="_blank">
             <asset:image src="documentation.svg" alt="Grails Documentation" class="float-left"/>
         </a>
-        <strong class="centered"><a href="http://docs.grails.org" target="_blank">Documentation</a></strong>
-        <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="http://docs.grails.org" target="_blank">User Guide</a>.</p>
+        <strong class="centered"><a href="https://grails.apache.org/docs/" target="_blank">Documentation</a></strong>
+        <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
 
     </div>
 

--- a/grails-test-examples/micronaut/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/micronaut/grails-app/views/layouts/main.gsp
@@ -60,11 +60,11 @@
 
     </div>
     <div class="col">
-        <a href="http://docs.grails.org" target="_blank">
+        <a href="https://grails.apache.org/docs/" target="_blank">
             <asset:image src="documentation.svg" alt="Grails Documentation" class="float-left"/>
         </a>
-        <strong class="centered"><a href="http://docs.grails.org" target="_blank">Documentation</a></strong>
-        <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="http://docs.grails.org" target="_blank">User Guide</a>.</p>
+        <strong class="centered"><a href="https://grails.apache.org/docs/" target="_blank">Documentation</a></strong>
+        <p>Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
 
     </div>
 

--- a/grails-test-examples/scaffolding/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/scaffolding/grails-app/views/layouts/main.gsp
@@ -65,11 +65,11 @@
             <div class="card border-0 col-12 col-md">
                 <div class="card-body">
                     <h6 class="card-title">
-                        <a class="link-underline link-underline-opacity-0" href="https://docs.grails.org" target="_blank">
+                        <a class="link-underline link-underline-opacity-0" href="https://grails.apache.org/docs/" target="_blank">
                             <asset:image src="documentation.svg" alt="Grails Documentation" class="me-2" width="34" />Documentation
                         </a>
                     </h6>
-                    <p class="card-text">Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://docs.grails.org" target="_blank">User Guide</a>.</p>
+                    <p class="card-text">Ready to dig in? You can find in-depth documentation for all the features of Grails in the <a href="https://grails.apache.org/docs/" target="_blank">User Guide</a>.</p>
                 </div>
             </div>
             <div class="card border-0 col-12 col-md">

--- a/grails-views-gson/src/main/groovy/grails/plugin/json/view/JsonViewGrailsPlugin.groovy
+++ b/grails-views-gson/src/main/groovy/grails/plugin/json/view/JsonViewGrailsPlugin.groovy
@@ -37,7 +37,7 @@ class JsonViewGrailsPlugin extends Plugin {
     def profiles = ['web']
 
     // URL to the plugin's documentation
-    def documentation = 'https://docs.grails.org/snapshot/guide/theWebLayer.html#gson'
+    def documentation = 'https://grails.apache.org/docs/snapshot/guide/theWebLayer.html#gson'
 
     // Extra (optional) plugin metadata
 

--- a/grails-views-markup/src/main/groovy/grails/plugin/markup/view/MarkupViewGrailsPlugin.groovy
+++ b/grails-views-markup/src/main/groovy/grails/plugin/markup/view/MarkupViewGrailsPlugin.groovy
@@ -42,7 +42,7 @@ class MarkupViewGrailsPlugin extends Plugin {
     def profiles = ['web']
 
     // URL to the plugin's documentation
-    def documentation = 'https://docs.grails.org/snapshot/guide/theWebLayer.html#markup'
+    def documentation = 'https://grails.apache.org/docs/snapshot/guide/theWebLayer.html#markup'
 
     // Extra (optional) plugin metadata
 


### PR DESCRIPTION
Replaced all references to docs.grails.org with grails.apache.org/docs across documentation, source code, and plugin metadata. This ensures consistency and points users to the correct and current documentation URLs.