### PR TITLE
Take snapshot prior to mongo update then mark any changes during beforeUpdate and update events as dirty.

### DIFF
--- a/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/engine/MongoCodecEntityPersister.groovy
+++ b/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/engine/MongoCodecEntityPersister.groovy
@@ -240,7 +240,26 @@ class MongoCodecEntityPersister extends ThirdPartyCacheEntityPersister<Object> {
                 mongoCodecSession.addPendingUpdate(new PendingUpdateAdapter(entity, id, obj, entityAccess) {
                     @Override
                     void run() {
+                        // Take snapshot of all property values BEFORE the PreUpdate event fires
+                        Map<String, Object> beforeUpdateSnapshot = [:]
+                        if (obj instanceof DirtyCheckable) {
+                            for (PersistentProperty prop : entity.persistentProperties) {
+                                beforeUpdateSnapshot[prop.name] = entityAccess.getProperty(prop.name)
+                            }
+                        }
                         if (!cancelUpdate(entity, entityAccess)) {
+                            // Compare with snapshot and mark modified properties dirty
+                            if (obj instanceof DirtyCheckable) {
+                                DirtyCheckable dirtyCheckable = (DirtyCheckable) obj
+                                for (PersistentProperty prop : entity.persistentProperties) {
+                                    Object oldValue = beforeUpdateSnapshot[prop.name]
+                                    Object newValue = entityAccess.getProperty(prop.name)
+                                    boolean valueChanged = oldValue != newValue && (oldValue == null || !oldValue.equals(newValue))
+                                    if (valueChanged) {
+                                        dirtyCheckable.markDirty(prop.name, newValue, oldValue)
+                                    }
+                                }
+                            }
                             updateCaches(entity, obj, id)
                             addCascadeOperation(new PendingOperationAdapter(entity, id, obj) {
                                 @Override

--- a/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/engine/codecs/PersistentEntityCodec.groovy
+++ b/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/engine/codecs/PersistentEntityCodec.groovy
@@ -64,7 +64,6 @@ import org.grails.datastore.mapping.engine.internal.MappingUtils
 import org.grails.datastore.mapping.model.EmbeddedPersistentEntity
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.datastore.mapping.model.PersistentProperty
-import org.grails.datastore.mapping.model.config.GormProperties
 import org.grails.datastore.mapping.model.types.Association
 import org.grails.datastore.mapping.model.types.Embedded
 import org.grails.datastore.mapping.model.types.EmbeddedCollection
@@ -248,12 +247,6 @@ class PersistentEntityCodec extends BsonPersistentEntityCodec {
                     EntityPersister.incrementEntityVersion(access)
                 }
 
-            }
-            else {
-                // schedule lastUpdated if necessary
-                if (entity.getPropertyByName(GormProperties.LAST_UPDATED) != null) {
-                    dirtyProperties.add(GormProperties.LAST_UPDATED)
-                }
             }
 
             for (propertyName in dirtyProperties) {

--- a/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/BeforeUpdatePropertyPersistenceSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/BeforeUpdatePropertyPersistenceSpec.groovy
@@ -34,7 +34,8 @@ class BeforeUpdatePropertyPersistenceSpec extends GrailsDataTckSpec<GrailsDataMo
     void setupSpec() {
         manager.domainClasses.addAll([UserWithBeforeUpdate, UserWithBeforeUpdateAndAutoTimestamp])
     }
-    
+
+    @Issue('GRAILS-15139')
     void "Test that properties set in beforeUpdate are persisted"() {
         given: "A user is created"
         def user = new UserWithBeforeUpdate(name: "Fred")
@@ -115,7 +116,7 @@ class BeforeUpdatePropertyPersistenceSpec extends GrailsDataTckSpec<GrailsDataMo
         user.random.length() == 5
     }
 
-    @Issue('GPMONGODB-XXX')
+    @Issue('GRAILS-15120')
     void "Test that properties set in beforeUpdate with AutoTimestamp are persisted"() {
         given: "A user with auto timestamp is created"
         def user = new UserWithBeforeUpdateAndAutoTimestamp(name: "Fred")

--- a/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/BeforeUpdatePropertyPersistenceSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/BeforeUpdatePropertyPersistenceSpec.groovy
@@ -36,8 +36,7 @@ class BeforeUpdatePropertyPersistenceSpec extends GrailsDataTckSpec<GrailsDataMo
     void setupSpec() {
         manager.domainClasses.addAll([UserWithBeforeUpdate, UserWithBeforeUpdateAndAutoTimestamp])
     }
-
-    @PendingFeature
+    
     void "Test that properties set in beforeUpdate are persisted"() {
         given: "A user is created"
         def user = new UserWithBeforeUpdate(name: "Fred")
@@ -92,7 +91,6 @@ class BeforeUpdatePropertyPersistenceSpec extends GrailsDataTckSpec<GrailsDataMo
         user.random.length() == 5
     }
 
-    @PendingFeature
     void "Test that multiple updates continue to trigger beforeUpdate"() {
         given: "A user is created"
         def user = new UserWithBeforeUpdate(name: "Fred")
@@ -119,7 +117,6 @@ class BeforeUpdatePropertyPersistenceSpec extends GrailsDataTckSpec<GrailsDataMo
         user.random.length() == 5
     }
 
-    @PendingFeature
     @Issue('GPMONGODB-XXX')
     void "Test that properties set in beforeUpdate with AutoTimestamp are persisted"() {
         given: "A user with auto timestamp is created"

--- a/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/BeforeUpdatePropertyPersistenceSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/BeforeUpdatePropertyPersistenceSpec.groovy
@@ -18,8 +18,6 @@
  */
 package org.grails.datastore.gorm.mongo
 
-import spock.lang.PendingFeature
-
 import grails.persistence.Entity
 import org.apache.grails.data.mongo.core.GrailsDataMongoTckManager
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec

--- a/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/BeforeUpdatePropertyPersistenceSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/BeforeUpdatePropertyPersistenceSpec.groovy
@@ -18,6 +18,7 @@
  */
 package org.grails.datastore.gorm.mongo
 
+import grails.gorm.annotation.AutoTimestamp
 import grails.persistence.Entity
 import org.apache.grails.data.mongo.core.GrailsDataMongoTckManager
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
@@ -132,11 +133,13 @@ class BeforeUpdatePropertyPersistenceSpec extends GrailsDataTckSpec<GrailsDataMo
         user.random == "Not Updated"
         user.dateCreated != null
         user.lastUpdated != null
+        user.modified != null
 
         when: "The user's name is updated"
         sleep 100 // ensure lastUpdated differs
         def previousRandom = user.random
         def previousLastUpdated = user.lastUpdated
+        def previousModified = user.modified
         user.name = "Bob"
         user.save(flush: true)
         manager.session.clear()
@@ -149,6 +152,7 @@ class BeforeUpdatePropertyPersistenceSpec extends GrailsDataTckSpec<GrailsDataMo
         user.random != "Not Updated"
         user.random.length() == 5
         user.lastUpdated > previousLastUpdated
+        user.modified > previousModified
     }
 }
 
@@ -180,9 +184,11 @@ class UserWithBeforeUpdateAndAutoTimestamp {
     String random
     Date dateCreated
     Date lastUpdated
+    @AutoTimestamp Date modified
 
     static constraints = {
         random nullable: true
+        modified nullable: true
     }
 
     def beforeInsert() {


### PR DESCRIPTION
 Hibernate overrides all dirty checking in the GormInstanceApi

https://github.com/apache/grails-core/blob/7.0.x/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/HibernateGormInstanceApi.groovy#L77-L80

which uses hibernate's api for comparing against an internal snapshot.

Currently mongodb does not persist any updates during Events and AutoTimestamp events because the changes are not marked dirty and must be manually marked dirty.

https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#eventsAutoTimestamping

This fix takes a snapshot before all events and then marks any changes as dirty props to persistence.