### PR TITLE
7.0.x Fix for Fields Rendering of java.time.*

### DIFF
--- a/grails-databinding/src/main/groovy/org/grails/databinding/converters/DefaultConvertersConfiguration.java
+++ b/grails-databinding/src/main/groovy/org/grails/databinding/converters/DefaultConvertersConfiguration.java
@@ -177,6 +177,11 @@ public class DefaultConvertersConfiguration {
         return jsr310ConvertersConfiguration.instantValueConverter();
     }
 
+    @Bean("instantStructuredBindingEditor")
+    TypedStructuredBindingEditor instantStructuredBindingEditor() {
+        return jsr310ConvertersConfiguration.instantStructuredBindingEditor();
+    }
+
     @Bean("defaultUUIDConverter")
     protected UUIDConverter defaultuuidConverter() {
         return new UUIDConverter();

--- a/grails-databinding/src/main/groovy/org/grails/databinding/converters/Jsr310ConvertersConfiguration.groovy
+++ b/grails-databinding/src/main/groovy/org/grails/databinding/converters/Jsr310ConvertersConfiguration.groovy
@@ -388,6 +388,21 @@ class Jsr310ConvertersConfiguration {
         }
     }
 
+    @Bean
+    TypedStructuredBindingEditor instantStructuredBindingEditor() {
+        new CustomDateBindingEditor<Instant>() {
+            @Override
+            Instant getDate(Calendar c) {
+                c.toInstant()
+            }
+
+            @Override
+            Class<?> getTargetType() {
+                Instant
+            }
+        }
+    }
+
     abstract class Jsr310DateValueConverter<T> implements ValueConverter {
 
         @Override

--- a/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -951,11 +951,11 @@ class FormFieldsTagLib {
                 g.formatBoolean(boolean: model.value)
                 break
             case LocalDate:
+            case java.sql.Date:
                 g.formatDate(date: model.value, format: 'yyyy-MM-dd')
                 break
             case Calendar:
             case Date:
-            case java.sql.Date:
             case java.sql.Time:
             case LocalDateTime:
             case Instant:

--- a/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -20,8 +20,11 @@ package grails.plugin.formfields
 
 import java.sql.Blob
 import java.text.NumberFormat
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -725,7 +728,7 @@ class FormFieldsTagLib {
         }
 
         // TODO: https://github.com/apache/grails-core/issues/14198
-        boolean datePicker = model.type in [Date, Calendar, java.sql.Date, java.sql.Time, LocalDate, LocalDateTime]
+        boolean datePicker = model.type in [Date, Calendar, java.sql.Date, java.sql.Time, LocalDate, LocalDateTime, Instant, ZonedDateTime, OffsetDateTime]
         if (!datePicker) {
             attrs.remove('selectDateClass')
         }
@@ -953,6 +956,9 @@ class FormFieldsTagLib {
             case java.sql.Time:
             case LocalDate:
             case LocalDateTime:
+            case Instant:
+            case ZonedDateTime:
+            case OffsetDateTime:
                 g.formatDate(date: model.value)
                 break
             default:

--- a/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -729,7 +729,7 @@ class FormFieldsTagLib {
         }
 
         // TODO: https://github.com/apache/grails-core/issues/14198
-        boolean datePicker = model.type in [Date, Calendar, java.sql.Date, java.sql.Time, LocalDate, LocalDateTime, Instant, ZonedDateTime, OffsetDateTime]
+        boolean datePicker = model.type in [Date, Calendar, java.sql.Date, java.sql.Time, java.sql.Timestamp, LocalDate, LocalDateTime, Instant, ZonedDateTime, OffsetDateTime]
         if (!datePicker) {
             attrs.remove('selectDateClass')
         }
@@ -962,6 +962,7 @@ class FormFieldsTagLib {
             case Calendar:
             case Date:
             case LocalDateTime:
+            case java.sql.Timestamp:
             case Instant:
             case ZonedDateTime:
             case OffsetDateTime:

--- a/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -950,11 +950,13 @@ class FormFieldsTagLib {
             case Boolean:
                 g.formatBoolean(boolean: model.value)
                 break
+            case LocalDate:
+                g.formatDate(date: model.value, format: 'yyyy-MM-dd')
+                break
             case Calendar:
             case Date:
             case java.sql.Date:
             case java.sql.Time:
-            case LocalDate:
             case LocalDateTime:
             case Instant:
             case ZonedDateTime:

--- a/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -23,6 +23,7 @@ import java.text.NumberFormat
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 
@@ -954,9 +955,12 @@ class FormFieldsTagLib {
             case java.sql.Date:
                 g.formatDate(date: model.value, format: 'yyyy-MM-dd')
                 break
+            case java.sql.Time:
+            case LocalTime:
+                g.formatDate(date: model.value, type: 'TIME')
+                break
             case Calendar:
             case Date:
-            case java.sql.Time:
             case LocalDateTime:
             case Instant:
             case ZonedDateTime:

--- a/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -953,7 +953,7 @@ class FormFieldsTagLib {
                 break
             case LocalDate:
             case java.sql.Date:
-                g.formatDate(date: model.value, format: 'yyyy-MM-dd')
+                g.formatDate(date: model.value, type: 'DATE')
                 break
             case java.sql.Time:
             case LocalTime:

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/DisplayWidgetSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/DisplayWidgetSpec.groovy
@@ -18,6 +18,7 @@
  */
 package grails.plugin.formfields
 
+import grails.plugin.formfields.mock.Cyborg
 import grails.plugin.formfields.mock.Person
 import grails.plugin.formfields.taglib.AbstractFormFieldsTagLibSpec
 import grails.testing.web.taglib.TagLibUnitTest
@@ -27,7 +28,7 @@ class DisplayWidgetSpec extends AbstractFormFieldsTagLibSpec implements TagLibUn
 	def mockFormFieldsTemplateService = Mock(FormFieldsTemplateService)
 
 	def setupSpec() {
-		mockDomain(Person)
+		mockDomains(Person, Cyborg)
 	}
 
 	def setup() {
@@ -38,6 +39,11 @@ class DisplayWidgetSpec extends AbstractFormFieldsTagLibSpec implements TagLibUn
 	void 'f:displayWidget without template and a date value renders the formatted date'() {
 		expect:
 		applyTemplate('<f:displayWidget bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) == applyTemplate('<g:formatDate date="${personInstance.dateOfBirth}"/>', [personInstance: personInstance])
+	}
+
+	void 'f:displayWidget without template and an instant value renders the formatted date'() {
+		expect:
+		applyTemplate('<f:displayWidget bean="cyborgInstance" property="timestamp"/>', [cyborgInstance: cyborgInstance]) == applyTemplate('<g:formatDate date="${cyborgInstance.timestamp}"/>', [cyborgInstance: cyborgInstance])
 	}
 
 	void 'f:displayWidget without template and a boolean value renders the formatted boolean'() {

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/DisplayWidgetSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/DisplayWidgetSpec.groovy
@@ -48,7 +48,7 @@ class DisplayWidgetSpec extends AbstractFormFieldsTagLibSpec implements TagLibUn
 
 	void 'f:displayWidget without template and a LocalDate value renders the formatted date'() {
 		expect:
-		applyTemplate('<f:displayWidget bean="cyborgInstance" property="birthDate"/>', [cyborgInstance: cyborgInstance]) == applyTemplate('<g:formatDate date="${cyborgInstance.birthDate}" format="yyyy-MM-dd"/>', [cyborgInstance: cyborgInstance])
+		applyTemplate('<f:displayWidget bean="cyborgInstance" property="birthDate"/>', [cyborgInstance: cyborgInstance]) == applyTemplate('<g:formatDate date="${cyborgInstance.birthDate}" type="DATE"/>', [cyborgInstance: cyborgInstance])
 	}
 
 	void 'f:displayWidget without template and a boolean value renders the formatted boolean'() {

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/DisplayWidgetSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/DisplayWidgetSpec.groovy
@@ -46,6 +46,11 @@ class DisplayWidgetSpec extends AbstractFormFieldsTagLibSpec implements TagLibUn
 		applyTemplate('<f:displayWidget bean="cyborgInstance" property="timestamp"/>', [cyborgInstance: cyborgInstance]) == applyTemplate('<g:formatDate date="${cyborgInstance.timestamp}"/>', [cyborgInstance: cyborgInstance])
 	}
 
+	void 'f:displayWidget without template and a LocalDate value renders the formatted date'() {
+		expect:
+		applyTemplate('<f:displayWidget bean="cyborgInstance" property="birthDate"/>', [cyborgInstance: cyborgInstance]) == applyTemplate('<g:formatDate date="${cyborgInstance.birthDate}" format="yyyy-MM-dd"/>', [cyborgInstance: cyborgInstance])
+	}
+
 	void 'f:displayWidget without template and a boolean value renders the formatted boolean'() {
 		expect:
 		applyTemplate('<f:displayWidget bean="personInstance" property="minor"/>', [personInstance: personInstance]) == applyTemplate('<g:formatBoolean boolean="${personInstance.minor}"/>', [personInstance: personInstance])

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/mock/Person.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/mock/Person.groovy
@@ -19,6 +19,7 @@
 package grails.plugin.formfields.mock
 
 import java.time.Instant
+import java.time.LocalDate
 
 import grails.gorm.annotation.AutoTimestamp
 import grails.persistence.Entity
@@ -28,6 +29,7 @@ class Cyborg extends Person {
 	@AutoTimestamp(AutoTimestamp.EventType.CREATED) Date created
 	@AutoTimestamp Date modified
 	Instant timestamp
+	LocalDate birthDate
 }
 
 @Entity

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/mock/Person.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/mock/Person.groovy
@@ -18,6 +18,8 @@
  */
 package grails.plugin.formfields.mock
 
+import java.time.Instant
+
 import grails.gorm.annotation.AutoTimestamp
 import grails.persistence.Entity
 
@@ -25,6 +27,7 @@ import grails.persistence.Entity
 class Cyborg extends Person {
 	@AutoTimestamp(AutoTimestamp.EventType.CREATED) Date created
 	@AutoTimestamp Date modified
+	Instant timestamp
 }
 
 @Entity

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/taglib/AbstractFormFieldsTagLibSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/taglib/AbstractFormFieldsTagLibSpec.groovy
@@ -19,6 +19,8 @@
 
 package grails.plugin.formfields.taglib
 
+import java.time.Instant
+
 import grails.core.support.proxy.DefaultProxyHandler
 import grails.plugin.formfields.BeanPropertyAccessorFactory
 import grails.plugin.formfields.FieldsGrailsPlugin
@@ -45,7 +47,7 @@ abstract class AbstractFormFieldsTagLibSpec extends Specification implements Gra
 		personInstance.address = new Address(street: "94 Evergreen Terrace", city: "Springfield", country: "USA")
 		personInstance.emails = [home: "bart@thesimpsons.net", school: "bart.simpson@springfieldelementary.edu"]
         productInstance = new Product(netPrice: 12.33, name: "<script>alert('XSS');</script>")
-		cyborgInstance = new Cyborg(name: "Hal", password: "monolith", gender: null)
+		cyborgInstance = new Cyborg(name: "Hal", password: "monolith", gender: null, timestamp: Instant.parse("2025-10-16T00:12:15.195Z"))
 	}
 
 	def cleanup() {

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/taglib/AbstractFormFieldsTagLibSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/taglib/AbstractFormFieldsTagLibSpec.groovy
@@ -20,6 +20,7 @@
 package grails.plugin.formfields.taglib
 
 import java.time.Instant
+import java.time.LocalDate
 
 import grails.core.support.proxy.DefaultProxyHandler
 import grails.plugin.formfields.BeanPropertyAccessorFactory
@@ -47,7 +48,7 @@ abstract class AbstractFormFieldsTagLibSpec extends Specification implements Gra
 		personInstance.address = new Address(street: "94 Evergreen Terrace", city: "Springfield", country: "USA")
 		personInstance.emails = [home: "bart@thesimpsons.net", school: "bart.simpson@springfieldelementary.edu"]
         productInstance = new Product(netPrice: 12.33, name: "<script>alert('XSS');</script>")
-		cyborgInstance = new Cyborg(name: "Hal", password: "monolith", gender: null, timestamp: Instant.parse("2025-10-16T00:12:15.195Z"))
+		cyborgInstance = new Cyborg(name: "Hal", password: "monolith", gender: null, timestamp: Instant.parse("2025-10-16T00:12:15.195Z"), birthDate: LocalDate.of(2025, 10, 15))
 	}
 
 	def cleanup() {

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/DefaultGrailsTagDateHelper.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/DefaultGrailsTagDateHelper.groovy
@@ -134,6 +134,8 @@ class DefaultGrailsTagDateHelper implements GrailsTagDateHelper {
                 zonedDateTime = ZonedDateTime.of(date, ZoneId.systemDefault())
             } else if (date instanceof LocalDate) {
                 zonedDateTime = ZonedDateTime.of(date, LocalTime.MIN, ZoneId.systemDefault())
+            } else if (date instanceof Instant) {
+                zonedDateTime = ZonedDateTime.ofInstant(date, ZoneId.systemDefault())
             } else if (date instanceof OffsetDateTime) {
                 zonedDateTime = ((OffsetDateTime) date).toZonedDateTime()
 

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/DefaultGrailsTagDateHelper.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/DefaultGrailsTagDateHelper.groovy
@@ -93,6 +93,8 @@ class DefaultGrailsTagDateHelper implements GrailsTagDateHelper {
         TemporalAccessor instant
         if (date instanceof java.sql.Date) {
             instant = date.toLocalDate()
+        } else if (date instanceof java.sql.Time) {
+            instant = date.toLocalTime()
         } else if (date instanceof Date) {
             instant = date.toInstant()
         } else if (date instanceof Calendar) {


### PR DESCRIPTION
# Show DateTime

## 7.0.0

| Field            | Value                                             |
|------------------|---------------------------------------------------|
| **Calendar**     | 2025-10-08 00:48:46 PDT                           |
| **Date**         | 2025-10-08 00:48:46 PDT                           |
| **sql.Date**         | Exception Thrown                       |
| **sql.Time**         | Exception Thrown                       |
| **sql.Timestamp**         | Exception Thrown                       |
| **LocalTime**         | Exception Thrown                       |
| **Instant**      | 2025-10-08T07:48:46.407254Z                       |
| **Local Date**   | Exception Thrown                                  |
| **Local DateTime** | 2025-10-08 00:48:46 PDT                         |
| **OffsetDateTime** | 2025-10-08T00:48:46.407254-07:00                |
| **ZonedDateTime**  | 2025-10-08T00:48:46.407254-07:00[America/Los_Angeles] |

## With This Fix
| Field              | Value                         |
|--------------------|-------------------------------|
| **Calendar**       | 2025-10-08 00:48:46 PDT       |
| **Date**           | 2025-10-08 00:48:46 PDT       |
| **sql.Date**           | 2025-10-08 00:48:46 PDT       |
| **sql.Date**         | 12:48 PM                |
| **sql.Time**         | 12:48 PM                       |
| **sql.Timestamp**         | 2025-10-08 00:48:46 PDT   |
| **Instant**        | 2025-10-08 00:48:46 PDT       |
| **Local Date**     | 2025-10-08                    |
| **Local DateTime** | 2025-10-08 00:48:46 PDT       |
| **OffsetDateTime** | 2025-10-08 00:48:46 PDT       |
| **ZonedDateTime**  | 2025-10-08 00:48:46 PDT       |


# Edit/Create DateTime

## 7.0.0

| Field            | Value                                             |
|------------------|---------------------------------------------------|
| **Calendar**     | Date Precision                          |
| **Date**         | Date Precision                           |
| **sql.Date**         | Date Precision                           |
| **sql.Time**         | Date Time Minute Precision     |       
| **sql.Timestamp**         | Broken    |                 
| **LocalTime**         | Broken     |                 
| **Instant**      | Broken                      |
| **Local Date**   | Broken                                 |
| **Local DateTime** | Date Time Minute Precision                         |
| **OffsetDateTime** | Broken             |
| **ZonedDateTime**  | Broken  |

## With This Fix


| Field            | Value                                             |
|------------------|---------------------------------------------------|
| **Calendar**     | Date Precision                          |
| **Date**         | Date Precision                           |
| **sql.Time**         |  Date Time Minute Precision  |          
| **sql.Timestamp**         | Broken    |                    
| **LocalTime**         |   Broken  |              
| **Instant**      |  Date Precision                          |
| **Local Date**   |  Date Precision                                     |
| **Local DateTime** | Date Time Minute Precision                         |
| **OffsetDateTime** |  Date Precision                 |
| **ZonedDateTime**  |  Date Precision      |

### Remaining JSON Issues:
Spring Boot
```json
"time":"00:48:46","localTime":"00:48:46.407254",
```
Grails 7
```json
"time":"2025-10-08T07:48:46.407Z","localTime":{"hour":0,"minute":48,"nano":407254000,"second":46}
```