### PR TITLE
7.0.0 BUG FIX  -  Application fails if there is an error during index creation

### DIFF
--- a/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/MongoDatastore.java
+++ b/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/MongoDatastore.java
@@ -31,6 +31,7 @@ import jakarta.annotation.PreDestroy;
 import jakarta.persistence.FlushModeType;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCommandException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.IndexOptions;
@@ -846,7 +847,11 @@ public class MongoDatastore extends AbstractDatastore implements MappingContext.
                 for (MongoCollection.Index index : indices) {
                     final Map<String, Object> options = index.getOptions();
                     final IndexOptions indexOptions = MongoConstants.mapToObject(IndexOptions.class, options);
-                    collection.createIndex(new Document(index.getDefinition()), indexOptions);
+                    try {
+                        collection.createIndex(new Document(index.getDefinition()), indexOptions);
+                    } catch (MongoCommandException e) {
+                        LOG.error("Failed to create index for entity [" + entity.getName() + "] with definition [" + index.getDefinition() + "]: " + e.getMessage(), e);
+                    }
                 }
 
                 for (Map compoundIndex : mappedForm.getCompoundIndices()) {
@@ -859,11 +864,15 @@ public class MongoDatastore extends AbstractDatastore implements MappingContext.
                         }
                     }
                     Document indexDef = new Document(compoundIndex);
-                    if (indexAttributes != null) {
-                        final IndexOptions indexOptions = MongoConstants.mapToObject(IndexOptions.class, indexAttributes);
-                        collection.createIndex(indexDef, indexOptions);
-                    } else {
-                        collection.createIndex(indexDef);
+                    try {
+                        if (indexAttributes != null) {
+                            final IndexOptions indexOptions = MongoConstants.mapToObject(IndexOptions.class, indexAttributes);
+                            collection.createIndex(indexDef, indexOptions);
+                        } else {
+                            collection.createIndex(indexDef);
+                        }
+                    } catch (MongoCommandException e) {
+                        LOG.error("Failed to create compound index for entity [" + entity.getName() + "] with definition [" + indexDef + "]: " + e.getMessage(), e);
                     }
                 }
             }
@@ -889,11 +898,15 @@ public class MongoDatastore extends AbstractDatastore implements MappingContext.
                     }
                 }
                 // continue using deprecated method to support older versions of MongoDB
-                if (options.isEmpty()) {
-                    collection.createIndex(dbObject);
-                } else {
-                    final IndexOptions indexOptions = MongoConstants.mapToObject(IndexOptions.class, options);
-                    collection.createIndex(dbObject, indexOptions);
+                try {
+                    if (options.isEmpty()) {
+                        collection.createIndex(dbObject);
+                    } else {
+                        final IndexOptions indexOptions = MongoConstants.mapToObject(IndexOptions.class, options);
+                        collection.createIndex(dbObject, indexOptions);
+                    }
+                } catch (MongoCommandException e) {
+                    LOG.error("Failed to create index for entity [" + entity.getName() + "] on property [" + property.getName() + "]: " + e.getMessage(), e);
                 }
             }
         }


### PR DESCRIPTION
Currently, if you have any index creation failure during start up, the application throws an error and fails start.

This is extremely problematic for a `too many indexes` situation because if you use your application to clean up the indexes, you can't start your app unless you comment out the indexes that are failing.

```
 Caused by: com.mongodb.MongoCommandException: Command failed with error 
67 (CannotCreateIndex): 'add index fails, too many indexes for db.image key:{  publishedDate: 1, rating: -1, _id: -1 }' on server localhost:27017. The full response is
 {"ok": 0.0, "errmsg": "add index fails, too many indexes for db.image key:{ publishedDate: 1, rating: -1, _id: -1 }", "code": 67, "codeName": "CannotCreateIndex", 
"$clusterTime": {"clusterTime": {"$timestamp": {"t": 1760665240, "i": 1}}, "signature": {"hash": {"$binary": {"base64": 
"00MCRkPJRxQ1cAr9pnTySkvtoEk=", "subType": "00"}}, "keyId": 7524267233502035970}}, "operationTime": {"$timestamp": {"t": 
1760665240, "i": 1}}}
    at com.mongodb.internal.connection.ProtocolHelper.getCommandFailureException(ProtocolHelper.java:210)
    at com.mongodb.internal.connection.InternalStreamConnection.receiveCommandMessageResponse(InternalStreamConnection.java:520)
    at com.mongodb.internal.connection.InternalStreamConnection.sendAndReceiveInternal(InternalStreamConnection.java:448)
    at com.mongodb.internal.connection.InternalStreamConnection.lambda$sendAndReceive$0(InternalStreamConnection.java:375)
    at com.mongodb.internal.connection.InternalStreamConnection.sendAndReceive(InternalStreamConnection.java:378)
    at com.mongodb.internal.connection.UsageTrackingInternalConnection.sendAndReceive(UsageTrackingInternalConnection.java:111)
    at com.mongodb.internal.connection.DefaultConnectionPool$PooledConnection.sendAndReceive(DefaultConnectionPool.java:747)
    at com.mongodb.internal.connection.CommandProtocolImpl.execute(CommandProtocolImpl.java:61)
    at com.mongodb.internal.connection.DefaultServer$DefaultServerProtocolExecutor.execute(DefaultServer.java:208)
    at com.mongodb.internal.connection.DefaultServerConnection.executeProtocol(DefaultServerConnection.java:112)
    at com.mongodb.internal.connection.DefaultServerConnection.command(DefaultServerConnection.java:82)
    at com.mongodb.internal.connection.DefaultServerConnection.command(DefaultServerConnection.java:74)
    at com.mongodb.internal.connection.DefaultServer$OperationCountTrackingConnection.command(DefaultServer.java:298)
    at com.mongodb.internal.operation.SyncOperationHelper.lambda$executeCommand$5(SyncOperationHelper.java:209)
    at com.mongodb.internal.operation.SyncOperationHelper.lambda$withSourceAndConnection$0(SyncOperationHelper.java:131)
    at com.mongodb.internal.operation.SyncOperationHelper.withSuppliedResource(SyncOperationHelper.java:156)
    at com.mongodb.internal.operation.SyncOperationHelper.lambda$withSourceAndConnection$1(SyncOperationHelper.java:130)
    at com.mongodb.internal.operation.SyncOperationHelper.withSuppliedResource(SyncOperationHelper.java:156)
    at com.mongodb.internal.operation.SyncOperationHelper.withSourceAndConnection(SyncOperationHelper.java:129)
    at com.mongodb.internal.operation.SyncOperationHelper.executeCommand(SyncOperationHelper.java:207)
    at com.mongodb.internal.operation.CreateIndexesOperation.execute(CreateIndexesOperation.java:105)
    at com.mongodb.internal.operation.CreateIndexesOperation.execute(CreateIndexesOperation.java:60)
    at com.mongodb.client.internal.MongoClusterImpl$OperationExecutorImpl.execute(MongoClusterImpl.java:446)
    at com.mongodb.client.internal.MongoCollectionImpl.executeCreateIndexes(MongoCollectionImpl.java:941)
    at com.mongodb.client.internal.MongoCollectionImpl.createIndexes(MongoCollectionImpl.java:923)
    at com.mongodb.client.internal.MongoCollectionImpl.createIndexes(MongoCollectionImpl.java:918)
    at com.mongodb.client.internal.MongoCollectionImpl.createIndex(MongoCollectionImpl.java:903)
    at com.mongodb.client.internal.MongoCollectionImpl.createIndex(MongoCollectionImpl.java:898)
    at org.grails.datastore.mapping.mongo.MongoDatastore.initializeIndices(MongoDatastore.java:866)
    at org.grails.datastore.mapping.mongo.MongoDatastore.buildIndex(MongoDatastore.java:540)
    at org.grails.datastore.mapping.mongo.MongoDatastore.initialize(MongoDatastore.java:764)
    at org.grails.datastore.mapping.mongo.MongoDatastore.<init>(MongoDatastore.java:236)
    at org.grails.datastore.mapping.mongo.MongoDatastore.<init>(MongoDatastore.java:273)
    at org.grails.datastore.mapping.mongo.MongoDatastore.<init>(MongoDatastore.java:382)
    at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
    at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
    at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:483)
    at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:210)
    ... 115 common frames omitted 
```


This fix allows application to continue starting up after a failed index creation event by simply logging the error and continuing the startup.