### PR TITLE
Ignore MavenRepositorySpec tests for SNAPSHOT Grails versions

### DIFF
--- a/grails-shell-cli/src/test/groovy/org/grails/cli/profile/repository/MavenRepositorySpec.groovy
+++ b/grails-shell-cli/src/test/groovy/org/grails/cli/profile/repository/MavenRepositorySpec.groovy
@@ -18,11 +18,17 @@
  */
 package org.grails.cli.profile.repository
 
+import grails.util.Environment
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 /**
  * @author graemerocher
  */
+
+// Note: These tests will fail on a new SNAPSHOT version until the corresponding
+// grails-bom has been published for the first time.
+@IgnoreIf({ Environment.grailsVersion?.endsWith('SNAPSHOT') })
 class MavenRepositorySpec extends Specification {
 
     void "Test resolve profile"() {


### PR DESCRIPTION
Added @IgnoreIf annotation to MavenRepositorySpec to skip tests when running against a SNAPSHOT Grails version, as the required grails-bom may not be published yet.