### PR TITLE
default fields dates to datetime precision

### DIFF
--- a/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -966,7 +966,7 @@ class FormFieldsTagLib {
             case Instant:
             case ZonedDateTime:
             case OffsetDateTime:
-                g.formatDate(date: model.value)
+                g.formatDate(date: model.value, type: 'DATETIME')
                 break
             default:
                 g.fieldValue(bean: model.bean, field: model.property)

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/DisplayWidgetSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/DisplayWidgetSpec.groovy
@@ -38,12 +38,12 @@ class DisplayWidgetSpec extends AbstractFormFieldsTagLibSpec implements TagLibUn
 
 	void 'f:displayWidget without template and a date value renders the formatted date'() {
 		expect:
-		applyTemplate('<f:displayWidget bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) == applyTemplate('<g:formatDate date="${personInstance.dateOfBirth}"/>', [personInstance: personInstance])
+		applyTemplate('<f:displayWidget bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) == applyTemplate('<g:formatDate date="${personInstance.dateOfBirth}" type="DATETIME"/>', [personInstance: personInstance])
 	}
 
 	void 'f:displayWidget without template and an instant value renders the formatted date'() {
 		expect:
-		applyTemplate('<f:displayWidget bean="cyborgInstance" property="timestamp"/>', [cyborgInstance: cyborgInstance]) == applyTemplate('<g:formatDate date="${cyborgInstance.timestamp}"/>', [cyborgInstance: cyborgInstance])
+		applyTemplate('<f:displayWidget bean="cyborgInstance" property="timestamp"/>', [cyborgInstance: cyborgInstance]) == applyTemplate('<g:formatDate date="${cyborgInstance.timestamp}" type="DATETIME"/>', [cyborgInstance: cyborgInstance])
 	}
 
 	void 'f:displayWidget without template and a LocalDate value renders the formatted date'() {

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/taglib/DisplayTagSpec.groovy
@@ -98,7 +98,7 @@ class DisplayTagSpec extends AbstractFormFieldsTagLibSpec implements TagLibUnitT
 
 	void 'renders date values using g:formatDate'() {
 		expect:
-		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) ==~ /1987-04-19 00:00:00 [A-Z]{3,4}/
+		applyTemplate('<f:display bean="personInstance" property="dateOfBirth"/>', [personInstance: personInstance]) == applyTemplate('<g:formatDate date="${personInstance.dateOfBirth}" type="DATETIME"/>', [personInstance: personInstance])
 	}
 
 	void 'displays using template if one is present'() {


### PR DESCRIPTION
Alternative solution for `<f:all` rendering of date objects with time precision.

### NOTE: This proposal puts rendering IN SYNC with create/edit input tag rendering.  Currently the fields plugin ONLY supports MINUTE precision for input rendering using the date picker.

The documentation for [datePicker](https://grails.apache.org/docs/snapshot/ref/Tags%20-%20GSP/datePicker.html) is incorrect.  "and second of the day."  Seconds have never been supported, but are set to be added in with https://github.com/apache/grails-core/pull/15118


### Show DateTime - Proposal (contingent on Locale)

| Type              | Value              |
|--------------------|--------------------|
| Calendar           | 10/8/25, 12:48 AM  |
| Instant            | 10/8/25, 12:48 AM  |
| Offset Date Time   | 10/8/25, 12:48 AM  |
| Zoned Date Time    | 10/8/25, 12:48 AM  |
| Date               | 10/8/25, 12:48 AM  |
| SQL Date           | 10/8/25            |
| Time               | 12:48 AM           |
| Local Time         | 12:48 AM           |
| Timestamp          | 10/8/25, 12:48 AM  |
| Local Date         | 10/8/25            |
| Local Date Time    | 10/8/25, 12:48 AM  |


### Show DateTime - Current Behavior

| Type              | Value                     |
|--------------------|---------------------------|
| Calendar           | 2025-10-08 00:48:46 PDT  |
| Instant            | 2025-10-08 00:48:46 PDT  |
| Offset Date Time   | 2025-10-08 00:48:46 PDT  |
| Zoned Date Time    | 2025-10-08 00:48:46 PDT  |
| Date               | 2025-10-08 00:48:46 PDT  |
| SQL Date           | 10/8/25                  |
| Time               | 12:48 AM                 |
| Local Time         | 12:48 AM                 |
| Timestamp          | 2025-10-08 00:48:46 PDT  |
| Local Date         | 10/8/25                  |
| Local Date Time    | 2025-10-08 00:48:46 PDT  |



