### PR TITLE
Update to Spring Boot 3.5.7 and Groovy 4.0.29

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,7 +38,7 @@ ext {
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
             'gradle-spock.version'          : '2.3-groovy-3.0',
-            'spring-boot.version'           : '3.5.6',
+            'spring-boot.version'           : '3.5.7',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly
@@ -73,7 +73,7 @@ ext {
             'bootstrap.version'           : '5.3.7',
             'commons-codec.version'       : '1.18.0',
             'geb-spock.version'           : '8.0.0',
-            'groovy.version'              : '4.0.28',
+            'groovy.version'              : '4.0.29',
             'h2.version'                  : '2.3.232',
             'jackson.version'             : '2.19.1',
             'jquery.version'              : '3.7.1',


### PR DESCRIPTION
Bumped 'spring-boot.version' from 3.5.6 to 3.5.7 and 'groovy.version' from 4.0.28 to 4.0.29 in dependencies.gradle to include latest bug fixes and improvements.