### PR TITLE
Update issue template replacing Stack Overflow link with Mailing list

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -14,12 +14,12 @@
 # limitations under the License.
 
 contact_links:
+  - name: Grails Mailing List
+    url: https://grails.apache.org/community.html
+    about: Ask questions on Mailing List
   - name: Grails Core Discussions
     url: https://github.com/apache/grails-core/discussions
     about: Ask questions about Grails® framework on Github
-  - name: Stack Overflow
-    url: https://stackoverflow.com/tags/grails
-    about: Ask questions on Stack Overflow
   - name: Grails Slack
     url: https://grails.slack.com/
     about: Chat with us on Grails Community Slack.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -19,7 +19,7 @@ contact_links:
     about: Ask questions on the Mailing Lists
   - name: Grails Core Discussions
     url: https://github.com/apache/grails-core/discussions
-    about: Ask questions about Grails® framework on Github
+    about: Discuss Grails® framework on GitHub
   - name: Grails Slack
     url: https://grails.slack.com/
     about: Chat with us on Grails Community Slack.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 contact_links:
-  - name: Grails Mailing List
+  - name: Grails Mailing Lists
     url: https://grails.apache.org/community.html
     about: Ask questions on the Mailing Lists
   - name: Grails Core Discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,7 +16,7 @@
 contact_links:
   - name: Grails Mailing List
     url: https://grails.apache.org/community.html
-    about: Ask questions on Mailing List
+    about: Ask questions on the Mailing Lists
   - name: Grails Core Discussions
     url: https://github.com/apache/grails-core/discussions
     about: Ask questions about Grails® framework on Github


### PR DESCRIPTION
Removed Stack Overflow contact link from issue template and replace with mailing list link.  Reorder.