### PR TITLE
Preserve BuildSettings property prefixes for BuildSettings properties in forked jvms

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -535,7 +535,11 @@ class GrailsGradlePlugin extends GroovyPlugin {
             for (key in map.keySet()) {
                 def value = map.get(key)
                 if (value) {
-                    def sysPropName = key.toString().substring(7)
+                    String keyStr = key.toString()
+                    // Preserve full "grails." prefix for BuildSettings properties that are looked up with the prefix
+                    // Strip prefix for other properties for backward compatibility
+                    boolean isBuildSettingsProperty = keyStr.startsWith('grails.project.') || keyStr == BuildSettings.APP_BASE_DIR
+                    String sysPropName = isBuildSettingsProperty ? keyStr : keyStr.substring(7)
                     task.systemProperty(sysPropName, value.toString())
                 }
             }


### PR DESCRIPTION
Build settings are being prefixed stripped in forked jvms, This prevents that from happening.

`grails.project.target.dir` is turning into `target.dir` in forked jvm which is not a desired outcome.

### This fix is preferred and supersedes 
https://github.com/apache/grails-core/pull/15174

Without this fix, forked jvms that set the gradle build directory will throw a 
```
java.io.FileNotFoundException: /datetime-demo/grails-demo/build/.grailspid (No such file or directory)
```

```
./gradlew bootRun --project-prop buildDir=build-7.0.1-SNAPSHOT -PgrailsVersion=7.0.1-SNAPSHOT
  --args="--server.port=8082"
```

### Properties preserved by this fix
  - grails.project.work.dir (PROJECT_WORK_DIR)
  - grails.project.resource.dir (PROJECT_RESOURCES_DIR)
  - grails.project.source.dir (PROJECT_SOURCE_DIR)
  - grails.project.class.dir (PROJECT_CLASSES_DIR)
  - grails.project.test.class.dir (PROJECT_TEST_CLASSES_DIR)
  - grails.project.test.reports.dir (PROJECT_TEST_REPORTS_DIR)
  - grails.project.docs.output.dir (PROJECT_DOCS_OUTPUT_DIR)
  - grails.project.test.source.dir (PROJECT_TEST_SOURCE_DIR)
  - grails.project.target.dir (PROJECT_TARGET_DIR) ← The one that was broken
  - grails.project.war.file (PROJECT_WAR_FILE)
  - grails.project.autodeploy.dir (PROJECT_AUTODEPLOY_DIR)

### Properties That WILL Still Be Stripped (Examples):

  - grails.env → becomes env
  - grails.work.dir → becomes work.dir
  - grails.offline.mode → becomes offline.mode
  - Any other grails.* property not matching the above patterns

  The pattern grails.project.* was chosen because these are all build-time directory/file configuration properties
  that BuildSettings needs to look up with their full names.

 This fixes a long outstanding bug that was accidentally stripping properties that were never meant to be stripped. 

The properties were:
  - Set in Gradle JVM with full prefix: grails.project.target.dir
  - Stripped when copied to forked JVM: project.target.dir
  - Looked up with full prefix: grails.project.target.dir

  Now they:
  - Set with full prefix: grails.project.target.dir
  - Preserved when copied: grails.project.target.dir 
  - Looked up with full prefix: grails.project.target.dir