### PR TITLE
pass build settings being prefixed stripped by configureForkSettings (Alternative fix)

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -699,6 +699,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
             project.tasks.withType(BootRun).configureEach { BootRun it ->
                 it.dependsOn(findMainClassTask)
                 it.mainClass.convention(GrailsGradlePlugin.getMainClassProvider(project))
+                // Pass BuildSettings properties to forked JVM with full "grails." prefix
+                // so they're not affected by the prefix-stripping in configureForkSettings
+                it.systemProperty(BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath)
+                it.systemProperty(BuildSettings.PROJECT_TARGET_DIR, project.layout.buildDirectory.get().asFile.name)
             }
 
             project.tasks.withType(ResolveMainClassName).configureEach {


### PR DESCRIPTION
This fix sets settings properties needed in forked jvm that are being prefix stripped. 

`grails.project.target.dir` is turning into `target.dir` in forked jvm. This adds it back.

Preferred approach is to fix is to just not strip these properties in the first place:

https://github.com/apache/grails-core/pull/15173

Without this fix, forked jvms that set the gradle build directory will throw a 
```
java.io.FileNotFoundException: /datetime-demo/grails-demo/build/.grailspid (No such file or directory)
```

```
./gradlew bootRun --project-prop buildDir=build-7.0.1-SNAPSHOT -PgrailsVersion=7.0.1-SNAPSHOT
  --args="--server.port=8082"
```