### PR TITLE
Issue-15170 Docs - source includes not found

### DIFF
--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -254,7 +254,7 @@ publishGuideTask.configure { PublishGuideTask publish ->
         [
                 'cacheExampleSourceDir': rootProject.layout.projectDirectory.dir('grails-test-examples/cache').asFile,
                 'sourcedir'            : rootProject.layout.projectDirectory.asFile,
-                'functionalSourceDir'  : rootProject.layout.projectDirectory.asFile
+                'functionalSourceDir'  : rootProject.layout.projectDirectory.dir('grails-test-examples').asFile
         ] as Map<String, String>
     }
 }

--- a/grails-doc/src/en/guide/async/events/asyncConsuming.adoc
+++ b/grails-doc/src/en/guide/async/events/asyncConsuming.adoc
@@ -26,7 +26,7 @@ For example:
 ----
 import grails.events.annotation.*
 ...
-include::{sourcedir}/grails-events/transform/src/test/groovy/grails/events/annotation/PubSubSpec.groovy[tags=subscriber]
+include::{sourcedir}/grails-events/transforms/src/test/groovy/grails/events/annotation/PubSubSpec.groovy[tags=subscriber]
 ----
 
 In this example, every time a `sum` event occurs the subscriber will be invoked.
@@ -46,7 +46,7 @@ If you wish to subscribe to events dynamically or need more flexibility, then an
 import grails.events.bus.EventBusAware
 import jakarta.annotation.PostConstruct
 ...
-include::{sourcedir}/grails-events/transform/src/test/groovy/grails/events/ManualPubSubSpec.groovy[tags=subscriber]
+include::{sourcedir}/grails-events/transforms/src/test/groovy/grails/events/ManualPubSubSpec.groovy[tags=subscriber]
 ----
 
 In this example the `TotalService` calls `subscribe` and passes a closure within a method called `init`. The `init` method is annotated with the annotation `@PostConstruct` so that is called after the `EventBus` has been injected by Spring, ensuring it is only called once and the events are correctly subscribed to.

--- a/grails-doc/src/en/guide/async/events/asyncNotifying.adoc
+++ b/grails-doc/src/en/guide/async/events/asyncNotifying.adoc
@@ -26,7 +26,7 @@ For example:
 ----
 import grails.events.annotation.*
 ...
-include::{sourcedir}/grails-events/transform/src/test/groovy/grails/events/annotation/PubSubSpec.groovy[tags=publisher]
+include::{sourcedir}/grails-events/transforms/src/test/groovy/grails/events/annotation/PubSubSpec.groovy[tags=publisher]
 ----
 
 What the above does is take the return value of the method and publish an event using an event `id` that is the same as the method name.
@@ -45,7 +45,7 @@ If you want more flexiblity then you could simulate the behaviour of annotation 
 ----
 import grails.events.*
 ...
-include::{sourcedir}/grails-events/transform/src/test/groovy/grails/events/ManualPubSubSpec.groovy[tags=publisher]
+include::{sourcedir}/grails-events/transforms/src/test/groovy/grails/events/ManualPubSubSpec.groovy[tags=publisher]
 ----
 
 Notice in the above example, the link:{api}grails/events/EventPublisher.html[EventPublisher] trait is explicitly implemented.

--- a/grails-doc/src/en/guide/testing/unitTesting/annotations.adoc
+++ b/grails-doc/src/en/guide/testing/unitTesting/annotations.adoc
@@ -27,7 +27,7 @@ applied in conjunction with a fixture annnotation like `@Before` as shown below.
 [source,groovy]
 .src/test/groovy/grails/testing/spock/RunOnceSpec.groovy
 ----
-include::{sourcedir}/grails-testing-support/src/test/groovy/grails/testing/spock/RunOnceSpec.groovy[indent=0]
+include::{sourcedir}/grails-testing-support-core/src/test/groovy/grails/testing/spock/RunOnceSpec.groovy[indent=0]
 ----
 
 Applying both the `@RunOnce` and `@Before` annotations to a method will yield
@@ -49,7 +49,7 @@ accomplishing the same behavior that would be accomplished by applying both the
 [source,groovy]
 .src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy
 ----
-include::{sourcedir}/grails-testing-support/src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy[indent=0]
+include::{sourcedir}/grails-testing-support-core/src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy[indent=0]
 ----
 
 This is useful in the context of an integration test which wants to reference


### PR DESCRIPTION
Fixes issue:
  https://github.com/apache/grails-core/issues/15170

- The Asciidoc variable `functionalSourceDir` was not set correct
- `grails-events/transform/` had been renamed to `grails-events/transforms/`
- `grails-testing-support/` had been renamed to `grails-testing-support-core/`