### PR TITLE
use stripped PROJECT_TARGET_DIR for setting TARGET_DIR

### DIFF
--- a/grails-gradle/model/src/main/groovy/grails/util/BuildSettings.groovy
+++ b/grails-gradle/model/src/main/groovy/grails/util/BuildSettings.groovy
@@ -253,7 +253,7 @@ class BuildSettings {
         }
         BASE_DIR = System.getProperty(APP_BASE_DIR) ? new File(System.getProperty(APP_BASE_DIR)) : (IOUtils.findApplicationDirectoryFile() ?: new File('.'))
         GRAILS_APP_DIR_PRESENT = new File(BASE_DIR, 'grails-app').exists() || new File(BASE_DIR, 'Application.groovy').exists()
-        TARGET_DIR = System.getProperty(PROJECT_TARGET_DIR) ? new File(BASE_DIR, System.getProperty(PROJECT_TARGET_DIR)) : new File(BASE_DIR, 'build')
+        TARGET_DIR = new File(BASE_DIR, System.getProperty(PROJECT_TARGET_DIR.substring(7)) ?: 'build')
         RESOURCES_DIR = !GRAILS_APP_DIR_PRESENT ? null : (System.getProperty(PROJECT_RESOURCES_DIR) ? new File(System.getProperty(PROJECT_RESOURCES_DIR)) : new File(TARGET_DIR, 'resources/main'))
     }
 }

--- a/grails-gradle/model/src/main/groovy/grails/util/BuildSettings.groovy
+++ b/grails-gradle/model/src/main/groovy/grails/util/BuildSettings.groovy
@@ -253,7 +253,7 @@ class BuildSettings {
         }
         BASE_DIR = System.getProperty(APP_BASE_DIR) ? new File(System.getProperty(APP_BASE_DIR)) : (IOUtils.findApplicationDirectoryFile() ?: new File('.'))
         GRAILS_APP_DIR_PRESENT = new File(BASE_DIR, 'grails-app').exists() || new File(BASE_DIR, 'Application.groovy').exists()
-        TARGET_DIR = new File(BASE_DIR, System.getProperty(PROJECT_TARGET_DIR.substring(7)) ?: 'build')
+        TARGET_DIR = new File(BASE_DIR, System.getProperty('project.target.dir') ?: 'build')
         RESOURCES_DIR = !GRAILS_APP_DIR_PRESENT ? null : (System.getProperty(PROJECT_RESOURCES_DIR) ? new File(System.getProperty(PROJECT_RESOURCES_DIR)) : new File(TARGET_DIR, 'resources/main'))
     }
 }


### PR DESCRIPTION
`grails.` is stripped out of all build settings when the jvm is forked.

This correctly sets the TARGET_DIR after it has been stripped by using `project.target.dir` 


### Difference from 7.0.0
```groovy
TARGET_DIR = new File(BASE_DIR, 'build')
```
to
```groovy
TARGET_DIR = new File(BASE_DIR, System.getProperty(PROJECT_TARGET_DIR.substring(7)) ?: 'build')
```