### PR TITLE
Update plugin logic and profile excludes for web plugin

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsGradlePlugin.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsGradlePlugin.java
@@ -71,10 +71,10 @@ class GrailsGradlePlugin implements DefaultFeature {
 
         if (applicationType == ApplicationType.PLUGIN || applicationType == ApplicationType.WEB_PLUGIN) {
             generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.apache.grails.gradle.grails-plugin").useApplyPlugin(true).build());
-        }
-        if (generatorContext.getFeature(GrailsWeb.class).isPresent()) {
+        } else if (generatorContext.getFeature(GrailsWeb.class).isPresent()) {
             generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.apache.grails.gradle.grails-web").useApplyPlugin(true).build());
         }
+
         if (generatorContext.getFeature(GrailsGsp.class).isPresent()) {
             generatorContext.addBuildPlugin(GradlePlugin.builder().id("org.apache.grails.gradle.grails-gsp").useApplyPlugin(true).build());
         }

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
@@ -111,7 +111,22 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         build.contains("implementation \"org.apache.grails:grails-gsp\"")
 
         where:
-        applicationType << [ApplicationType.WEB, ApplicationType.WEB_PLUGIN]
+        applicationType << [ApplicationType.WEB]
+    }
+
+    @Unroll
+    void "test grails-plugin gradle plugins and dependencies are present for #applicationType application"() {
+        when:
+        final def output = generate(applicationType, new Options(TestFramework.SPOCK))
+        final String build = output['build.gradle']
+
+        then:
+        build.contains('apply plugin: "org.apache.grails.gradle.grails-plugin"')
+        build.contains('apply plugin: "org.apache.grails.gradle.grails-gsp"')
+        build.contains("implementation \"org.apache.grails:grails-gsp\"")
+
+        where:
+        applicationType << [ApplicationType.WEB_PLUGIN]
     }
 
     @Unroll

--- a/grails-profiles/web-plugin/profile.yml
+++ b/grails-profiles/web-plugin/profile.yml
@@ -35,5 +35,6 @@ build:
         - plugin
     excludes:
         - war
+        - org.apache.grails.gradle.grails-web
 
 


### PR DESCRIPTION
Refactored GrailsGradlePlugin to use else-if for GrailsWeb feature plugin application, ensuring correct plugin selection. Updated web-plugin profile.yml to exclude 'org.apache.grails.gradle.grails-web' from build plugins.

The plugin profile did not have the same issue, since it does not inherit from the web profile.