### PR TITLE
Use `micronaut-http-client-jdk`

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/MicronautHttpClient.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/MicronautHttpClient.java
@@ -91,7 +91,7 @@ public class MicronautHttpClient implements Feature {
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("io.micronaut")
-                .artifactId("micronaut-http-client")
+                .artifactId("micronaut-http-client-jdk") // Use jdk version as Spring and Micronaut has different Netty versions https://github.com/apache/grails-core/issues/15149
                 .implementation());
 
         // micronaut-http-client no longer provides the jackson implementation


### PR DESCRIPTION
The jdk version it not based on Netty so it will not have problems with different versions of Netty used by Micronaut and Spring.

Closes #15149