### PR TITLE
fix - #15193 fix empty spring profile causing configuration to not load

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/grails/config/NavigableMap.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/config/NavigableMap.groovy
@@ -18,8 +18,6 @@
  */
 package org.grails.config
 
-import java.util.regex.Pattern
-
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
@@ -37,15 +35,6 @@ import org.slf4j.LoggerFactory
 class NavigableMap implements Map<String, Object>, Cloneable {
 
     private static final Logger LOG = LoggerFactory.getLogger(NavigableMap)
-
-    private static final Pattern SPLIT_PATTERN = ~/\./
-    private static final String SPRING_PROFILES = 'spring.profiles.active'
-    private static final String SPRING = 'spring'
-    private static final String CONFIG = 'config'
-    private static final String ACTIVATE = 'activate'
-    private static final String ON_PROFILE = 'on-profile'
-    private static final String PROFILES = 'profiles'
-    private static final String SUBSCRIPT_REGEX = /((.*)\[(\d+)\]).*/
 
     final NavigableMap rootConfig
     final List<String> path
@@ -159,7 +148,7 @@ class NavigableMap implements Map<String, Object>, Cloneable {
                            Map sourceMap,
                            boolean parseFlatKeys) {
 
-        if (springProfileExclude(sourceMap, path)) {
+        if (isSourceMapExcludedBySpringProfile(sourceMap, path)) {
             return
         }
 
@@ -184,51 +173,41 @@ class NavigableMap implements Map<String, Object>, Cloneable {
         }
     }
 
-    private static boolean springProfileExclude(Map sourceMap, String path) {
+    private static Object resolveConfigMapValue(Map map, Object... keys) {
+        keys.inject(map) { acc, key -> acc instanceof Map ? acc[key] : null }
+    }
 
-        // Is there an active Spring profile?
-        def activeSpringProfile = System.getProperty(SPRING_PROFILES) ?: null
+    private static boolean isSourceMapExcludedBySpringProfile(Map configSource, String path) {
 
-        // Is there a 'spring.config.activate.on-profile' property defined in the source map?
-        def sourceMapProfile1 = ((Map) ((Map)((Map)sourceMap?.get(SPRING))?.get(CONFIG))?.get(ACTIVATE))?.get(ON_PROFILE)
-        if (!sourceMapProfile1 && path == "$SPRING.$CONFIG.$ACTIVATE") {
-            sourceMapProfile1 = sourceMap?.get(ON_PROFILE)
-        }
-        if (!sourceMapProfile1) {
-            sourceMapProfile1 = sourceMap.get("$SPRING.$CONFIG.$ACTIVATE.$ON_PROFILE" as String)
-        }
-        if (sourceMapProfile1 && !activeSpringProfile) {
-            // There is a spring.config.activate.on-profile property defined in this sourceMap, but there is no active spring profile
-            return true
-        }
-        if (sourceMapProfile1 == activeSpringProfile) {
-            // The active spring profile matches the spring.config.activate.on-profile property in this sourceMap
-            return false
-        }
+        // get the active spring profile: treat empty string as null
+        def active = System.getProperty('spring.profiles.active')?.trim() ?: null
 
-        // Is there a 'spring.profiles' property defined in the source map? (Old way of Spring profiles activation)
-        def sourceMapProfile2 = ((Map) sourceMap?.get(SPRING))?.get(PROFILES)
-        if (!sourceMapProfile2 && path == SPRING) {
-            sourceMapProfile2 = sourceMap?.get(PROFILES)
-        }
-        if (!sourceMapProfile2) {
-            sourceMapProfile2 = sourceMap.get("$SPRING.$PROFILES" as String)
-        }
-        if (sourceMapProfile1 && !activeSpringProfile) {
-            // There is a spring.config.activate.on-profile property defined in this sourceMap, but there is no active spring profile
-            return true
-        }
-        if (sourceMapProfile2 == activeSpringProfile) {
-            // The active spring profile matches the spring.profiles property in this sourceMap
-            return false
-        }
+        // lookup 'spring.config.activate.on-profile' in this config source
+        def onProfile =
+                resolveConfigMapValue(configSource, 'spring', 'config', 'activate', 'on-profile') ?:
+                        (path == 'spring.config.activate' ? configSource['on-profile'] : null) ?:
+                                configSource['spring.config.activate.on-profile']
 
-        if (activeSpringProfile && !sourceMapProfile1 && !sourceMapProfile2) {
-            // There is no spring profile defined in this sourceMap, it should always be included
-            return false
-        }
+        // no active profile is set but 'spring.config.activate.on-profile' is set in this config source -> exclude it
+        if (!active && onProfile) return true
+        // active profile is set and matches 'spring.config.activate.on-profile' in this config source -> include it
+        if (active && onProfile == active) return false
 
-        // We can skip this sourceMap as it defines a spring profile that is not active
+        // lookup (legacy) 'spring.profiles' in this config source
+        def profiles =
+                resolveConfigMapValue(configSource, 'spring', 'profiles') ?:
+                        (path == 'spring' ? configSource['profiles'] : null) ?:
+                                configSource['spring.profiles']
+
+        // no active profile is set but 'spring.profiles' is set in this config source -> exclude it
+        if (!active && profiles) return true
+        // active profile is set and matches 'spring.profiles' in this config source -> include it
+        if (active && profiles == active) return false
+
+        // active profile is not required for this this source map -> include it
+        if (!onProfile && !profiles) return false
+
+        // a profile constraint exists but doesn't match the active profile -> exclude
         return true
     }
 

--- a/grails-bootstrap/src/main/groovy/org/grails/config/NavigableMap.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/config/NavigableMap.groovy
@@ -187,7 +187,7 @@ class NavigableMap implements Map<String, Object>, Cloneable {
     private static boolean springProfileExclude(Map sourceMap, String path) {
 
         // Is there an active Spring profile?
-        def activeSpringProfile = System.getProperty(SPRING_PROFILES)
+        def activeSpringProfile = System.getProperty(SPRING_PROFILES) ?: null
 
         // Is there a 'spring.config.activate.on-profile' property defined in the source map?
         def sourceMapProfile1 = ((Map) ((Map)((Map)sourceMap?.get(SPRING))?.get(CONFIG))?.get(ACTIVATE))?.get(ON_PROFILE)

--- a/grails-bootstrap/src/test/groovy/grails/config/SpringProfileExcludeSpec.groovy
+++ b/grails-bootstrap/src/test/groovy/grails/config/SpringProfileExcludeSpec.groovy
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package grails.config
 
 import spock.lang.Specification

--- a/grails-bootstrap/src/test/groovy/grails/config/SpringProfileExcludeSpec.groovy
+++ b/grails-bootstrap/src/test/groovy/grails/config/SpringProfileExcludeSpec.groovy
@@ -1,0 +1,155 @@
+package grails.config
+
+import spock.lang.Specification
+import spock.lang.Unroll
+import spock.util.environment.RestoreSystemProperties
+
+import org.grails.config.NavigableMap
+
+@RestoreSystemProperties
+class isExcludedBySpringProfileSpec extends Specification {
+
+    def 'on-profile present in config source but no active profile is set => exclude'() {
+        given:
+            def src = nestedOnProfile('dev')
+            def path = 'whatever'
+
+        expect:
+            NavigableMap.isSourceMapExcludedBySpringProfile(src, path)
+    }
+
+    def 'on-profile matches active profile => include'() {
+        given:
+            System.setProperty('spring.profiles.active', 'dev')
+
+        and:
+            def src = nestedOnProfile('dev')
+            def path = 'does.not.matter'
+
+        expect:
+            !NavigableMap.isSourceMapExcludedBySpringProfile(src, path)
+    }
+
+    def 'profiles matches active => include'() {
+        given:
+            System.setProperty('spring.profiles.active', 'prod')
+
+        and:
+            def src = nestedProfiles('prod')
+            def path = 'does.not.matter'
+
+        expect:
+            !NavigableMap.isSourceMapExcludedBySpringProfile(src, path)
+    }
+
+    def 'profiles present in config but no active profile set => exclude'() {
+        given:
+            def src = nestedProfiles('prod')
+            def path = 'does.not.matter'
+
+        expect:
+            NavigableMap.isSourceMapExcludedBySpringProfile(src, path)
+    }
+
+    def 'empty string active profile is treated as null'() {
+        given:
+            System.setProperty('spring.profiles.active', '') // should behave like no active profile
+
+        and:
+            def src = nestedOnProfile('dev')
+            def path = 'does.not.matter'
+
+        expect:
+            NavigableMap.isSourceMapExcludedBySpringProfile(src, path)
+    }
+
+    @Unroll
+    def 'on-profile lookup via #desc is honored (active=#active -> exclude=#excludeExpected)'() {
+        given:
+            if (active) System.setProperty('spring.profiles.active', active)
+            else System.clearProperty('spring.profiles.active')
+
+        and:
+            def src = srcBuilder('qa')
+
+        expect:
+            NavigableMap.isSourceMapExcludedBySpringProfile(src, path) == excludeExpected
+
+        where:
+            desc                       | srcBuilder              | path                     | active | excludeExpected
+            'nested map'               | this.&nestedOnProfile   | 'any'                    | null   | true   // on-profile present, no active => exclude
+            'nested map (match)'       | this.&nestedOnProfile   | 'any'                    | 'qa'   | false  // matches => include
+            'relative via path match'  | this.&relativeOnProfile | 'spring.config.activate' | 'qa'   | false
+            'relative via path no act' | this.&relativeOnProfile | 'spring.config.activate' | null   | true
+            'dotted key'               | this.&dottedOnProfile   | 'any'                    | 'qa'   | false
+            'dotted key no active'     | this.&dottedOnProfile   | 'any'                    | null   | true
+            'non-match'                | this.&nestedOnProfile   | 'any'                    | 'dev'  | true   // profile set but different from active => exclude
+    }
+
+    @Unroll
+    def 'legacy spring.profiles lookup via #desc is honored (active=#active -> exclude=#excludeExpected)'() {
+        given:
+            if (active) System.setProperty('spring.profiles.active', active)
+            else System.clearProperty('spring.profiles.active')
+
+        and:
+            def src = srcBuilder('prod')
+
+        expect:
+            NavigableMap.isSourceMapExcludedBySpringProfile(src, path) == excludeExpected
+
+        where:
+            desc                       | srcBuilder             | path     | active | excludeExpected
+            'nested map'               | this.&nestedProfiles   | 'any'    | 'prod' | false  // matches => include
+            'nested map no active'     | this.&nestedProfiles   | 'any'    | null   | true   // present but no active => exclude
+            'relative via path match'  | this.&relativeProfiles | 'spring' | 'prod' | false
+            'relative via path no act' | this.&relativeProfiles | 'spring' | null   | true
+            'dotted key (match)'       | this.&dottedProfiles   | 'any'    | 'prod' | false
+            'non-match'                | this.&nestedProfiles   | 'any'    | 'qa'   | true   // different => exclude
+    }
+
+    def 'active profile present but no profile keys in config => include'() {
+        given:
+            System.setProperty('spring.profiles.active', 'anything')
+
+        and:
+            def src = [:]
+            def path = 'any'
+
+        expect:
+            !NavigableMap.isSourceMapExcludedBySpringProfile(src, path)
+    }
+
+    def 'no active and no profile keys => include'() {
+        given:
+            def src = [:]
+            def path = 'any'
+
+        expect:
+            !NavigableMap.isSourceMapExcludedBySpringProfile(src, path)
+    }
+
+    private static Map nestedOnProfile(String value) {
+        ['spring': ['config': ['activate': ['on-profile': value]]]]
+    }
+
+    private static Map relativeOnProfile(String value) {
+        ['on-profile': value]
+    }
+
+    private static Map dottedOnProfile(String value) {
+        ['spring.config.activate.on-profile': value]
+    }
+
+    private static Map nestedProfiles(String value) {
+        ['spring': ['profiles': value]]
+    }
+
+    private static Map relativeProfiles(String value) {
+        ['profiles': value]
+    }
+
+    private static Map dottedProfiles(String value) {
+        ['spring.profiles': value]
+    }
+}


### PR DESCRIPTION
This bug is preventing my application from loading any configuration in development mode because `spring.profiles.active` is not defined.  I'm specifically failing on loading of an `application.groovy` file without an environment specific configuration.