### PR TITLE
7.0.x Bug - Don't call a resource constructor until GORM has been initialized by Spring

### DIFF
--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -860,3 +860,49 @@ The `+` marker is opt-in and fully backward compatible:
 - Existing URL mappings without the `+` marker continue to work as before (splitting at the first dot)
 - No changes are required to existing applications
 - The feature can be adopted incrementally on a per-mapping basis
+
+===== 12.28 GormService API Changes
+
+The `grails.plugin.scaffolding.GormService` class has been updated to fix a thread-safety issue and improve API clarity.
+
+====== Changes
+
+1. The `resource` field type changed from `GormAllOperations<T>` to `Class<T>`
+2. A new `gormStaticApi` field of type `GormAllOperations<T>` was added with thread-safe lazy initialization using `@Lazy`
+3. The constructor no longer instantiates the resource class - it now stores the Class reference directly
+
+====== Migration Impact
+
+If your code extends `GormService` or accesses its fields:
+
+**Accessing GORM operations**: Previously the `resource` field provided GORM operations. Now use the `gormStaticApi` field instead:
+
+[source,groovy]
+----
+// Before (7.1.x and earlier)
+class MyService extends GormService<MyDomain> {
+    void myMethod() {
+        def result = resource.list()  // resource was GormAllOperations<T>
+        // ...
+    }
+}
+
+// After (7.1.x with fix)
+class MyService extends GormService<MyDomain> {
+    void myMethod() {
+        def result = gormStaticApi.list()  // use gormStaticApi instead
+        // ...
+    }
+}
+----
+
+**Accessing the domain class**: If you need the Class reference, the `resource` field is now properly typed as `Class<T>`:
+
+[source,groovy]
+----
+// Before
+Class<MyDomain> clazz = resource.getClass()  // awkward, resource was an instance
+
+// After
+Class<MyDomain> clazz = resource  // resource is now the Class itself
+----

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/DomainServiceLocator.java
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/DomainServiceLocator.java
@@ -33,7 +33,7 @@ import org.grails.datastore.gorm.GormEntity;
 /**
  * Resolves the appropriate service bean for a given domain class by:
  *   - Scanning only beans of type GormService
- *   - Matching via: ((GormEntity<?>) service.getResource()).instanceOf(domainClass)
+ *   - Matching via: domainClass.isAssignableFrom(service.getResource())
  *
  * Keeps a single shared cache for the whole app.
  */
@@ -72,28 +72,25 @@ public final class DomainServiceLocator {
 
         for (String name : names) {
             GormService<?> gs = (GormService<?>) ctx.getBean(name);
-            Object resource = gs.getResource();
-            if (resource instanceof GormEntity) {
-                GormEntity<?> ge = (GormEntity<?>) resource;
-                if (ge.instanceOf(domainClass)) {
-                    matchingBeanNames.add(name);
-                    if (match != null) {
-                        throw new IllegalStateException(
-                            "Multiple GormService beans match domain " + domainClass.getName() +
-                            ": " + matchingBeanNames
-                        );
-                    }
-                    @SuppressWarnings("unchecked")
-                    GormService<T> svc = (GormService<T>) gs;
-                    match = svc;
+            Class<?> resourceClass = gs.getResource();
+            if (resourceClass != null && domainClass.isAssignableFrom(resourceClass)) {
+                matchingBeanNames.add(name);
+                if (match != null) {
+                    throw new IllegalStateException(
+                        "Multiple GormService beans match domain " + domainClass.getName() +
+                        ": " + matchingBeanNames
+                    );
                 }
+                @SuppressWarnings("unchecked")
+                GormService<T> svc = (GormService<T>) gs;
+                match = svc;
             }
         }
 
         if (match == null) {
             throw new IllegalStateException(
                 "No GormService bean found for domain " + domainClass.getName() +
-                " using resource.instanceOf(..). Scanned " + names.length + " GormService beans."
+                ". Scanned " + names.length + " GormService beans."
             );
         }
 

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -35,7 +35,7 @@ import org.grails.datastore.gorm.GormEntityApi
 @CompileStatic
 class GormService<T extends GormEntity<T>> {
 
-    private GormAllOperations<T> gormStaticApi
+    GormAllOperations<T> gormStaticApi
     Class<T> resource
     String resourceName
     String resourceClassName

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -35,7 +35,8 @@ import org.grails.datastore.gorm.GormEntityApi
 @CompileStatic
 class GormService<T extends GormEntity<T>> {
 
-    GormAllOperations<T> gormStaticApi
+    @Lazy
+    GormAllOperations<T> gormStaticApi = GormEnhancer.findStaticApi(resource) as GormAllOperations<T>
     Class<T> resource
     String resourceName
     String resourceClassName
@@ -48,24 +49,16 @@ class GormService<T extends GormEntity<T>> {
         resourceName = GrailsNameUtils.getPropertyName(resource)
     }
 
-    protected GormAllOperations<T> getGormStaticApi() {
-        if (gormStaticApi == null) {
-            // Lazy initialization - happens on first access when GORM is ready
-            gormStaticApi = GormEnhancer.findStaticApi(resource) as GormAllOperations<T>
-        }
-        return gormStaticApi
-    }
-
     T get(Serializable id) {
-        getGormStaticApi().get(id)
+        gormStaticApi.get(id)
     }
 
     List<T> list(Map args) {
-        getGormStaticApi().list(args)
+        gormStaticApi.list(args)
     }
 
     Long count(Map args) {
-        getGormStaticApi().count()
+        gormStaticApi.count()
     }
 
     @Transactional

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -35,37 +35,37 @@ import org.grails.datastore.gorm.GormEntityApi
 @CompileStatic
 class GormService<T extends GormEntity<T>> {
 
-    private GormAllOperations<T> resource
-    Class<T> resourceClass
+    private GormAllOperations<T> gormStaticApi
+    Class<T> resource
     String resourceName
     String resourceClassName
     boolean readOnly
 
     GormService(Class<T> resource, boolean readOnly) {
+        this.resource = resource
         this.readOnly = readOnly
-        resourceClass = resource
         resourceClassName = resource.simpleName
         resourceName = GrailsNameUtils.getPropertyName(resource)
     }
 
-    protected GormAllOperations<T> getResource() {
-        if (resource == null) {
+    protected GormAllOperations<T> getGormStaticApi() {
+        if (gormStaticApi == null) {
             // Lazy initialization - happens on first access when GORM is ready
-            resource = GormEnhancer.findStaticApi(resourceClass) as GormAllOperations<T>
+            gormStaticApi = GormEnhancer.findStaticApi(resource) as GormAllOperations<T>
         }
-        return resource
+        return gormStaticApi
     }
 
     T get(Serializable id) {
-        getResource().get(id)
+        getGormStaticApi().get(id)
     }
 
     List<T> list(Map args) {
-        getResource().list(args)
+        getGormStaticApi().list(args)
     }
 
     Long count(Map args) {
-        getResource().count()
+        getGormStaticApi().count()
     }
 
     @Transactional

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -26,6 +26,7 @@ import grails.gorm.api.GormAllOperations
 import grails.gorm.transactions.ReadOnly
 import grails.gorm.transactions.Transactional
 import grails.util.GrailsNameUtils
+import org.grails.datastore.gorm.GormEnhancer
 import org.grails.datastore.gorm.GormEntity
 import org.grails.datastore.gorm.GormEntityApi
 
@@ -34,28 +35,37 @@ import org.grails.datastore.gorm.GormEntityApi
 @CompileStatic
 class GormService<T extends GormEntity<T>> {
 
-    GormAllOperations<T> resource
+    private Class<T> resourceClass
+    private GormAllOperations<T> resource
     String resourceName
     String resourceClassName
     boolean readOnly
 
     GormService(Class<T> resource, boolean readOnly) {
-        this.resource = resource.getDeclaredConstructor().newInstance() as GormAllOperations<T>
+        this.resourceClass = resource
         this.readOnly = readOnly
         resourceClassName = resource.simpleName
         resourceName = GrailsNameUtils.getPropertyName(resource)
     }
 
+    protected GormAllOperations<T> getResource() {
+        if (resource == null) {
+            // Lazy initialization - happens on first access when GORM is ready
+            resource = GormEnhancer.findStaticApi(resourceClass) as GormAllOperations<T>
+        }
+        return resource
+    }
+
     T get(Serializable id) {
-        resource.get(id)
+        getResource().get(id)
     }
 
     List<T> list(Map args) {
-        resource.list(args)
+        getResource().list(args)
     }
 
     Long count(Map args) {
-        resource.count()
+        getResource().count()
     }
 
     @Transactional

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -35,15 +35,15 @@ import org.grails.datastore.gorm.GormEntityApi
 @CompileStatic
 class GormService<T extends GormEntity<T>> {
 
-    private Class<T> resourceClass
     private GormAllOperations<T> resource
+    Class<T> resourceClass
     String resourceName
     String resourceClassName
     boolean readOnly
 
     GormService(Class<T> resource, boolean readOnly) {
-        this.resourceClass = resource
         this.readOnly = readOnly
+        resourceClass = resource
         resourceClassName = resource.simpleName
         resourceName = GrailsNameUtils.getPropertyName(resource)
     }


### PR DESCRIPTION
# The Problem

```
Caused by: java.lang.IllegalStateException: org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@48300ca8 has not been refreshed yet
        at org.springframework.context.support.AbstractApplicationContext.assertBeanFactoryActive(AbstractApplicationContext.java:1262)
        at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1280)
        at org.grails.web.context.ServletEnvironmentGrailsApplicationDiscoveryStrategy.findGrailsApplication(ServletEnvironmentGrailsApplicationDiscoveryStrategy.groovy:54)
        at grails.util.Holders.findApplication(Holders.java:126)
        at org.grails.plugins.web.controllers.api.ControllersDomainBindingApi.autowire(ControllersDomainBindingApi.java:90)
        at org.grails.plugins.web.controllers.api.ControllersDomainBindingApi.initialize(ControllersDomainBindingApi.java:50)
        at com.pixoto.community.CategoryParticipant.<init>(CategoryParticipant.groovy)
        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
        ... 43 common frames omitted
```


This is only an issue during a Spring Dev Tools restart, but this fixes the issue.

``` groovy
  this.resource = resource.getDeclaredConstructor().newInstance() as GormAllOperations<T>
```
results in a domain object instantiation during the constructor, which:
  1. Triggers Grails GORM enhancements
  2. Calls ControllersDomainBindingApi.initialize()
  3. Tries to access Holders.findApplication()
  4. Fails during DevTools restart when ApplicationContext is being switched

# The Fix
Lazy initialize the resource 