### PR TITLE
fix: #15201 RenderTagLib should be accessible if the gsp plugin is applied

### DIFF
--- a/grails-testing-support-web/build.gradle
+++ b/grails-testing-support-web/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation platform(project(':grails-bom'))
 
     api project(':grails-gsp')
+    api project(':grails-web-gsp-taglib') // Makes RenderTagLib available for mocking in tests
     api project(':grails-rest-transforms')
     api project(':grails-interceptors')
     api 'jakarta.servlet:jakarta.servlet-api'


### PR DESCRIPTION
RenderTagLib should be just as accessible as ApplicationTagLib, etc.  Otherwise, users have to include internal grails packages (grails-web-gsp-taglib)