### PR TITLE
Allow greedy parameters (+) prior to a format paramter that consume everything but the last .

### DIFF
--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -754,3 +754,109 @@ grails:
 * **8.0**: `SimpleEnumMarshaller` will become the default
 
 The legacy `org.grails.web.converters.marshaller.json.EnumMarshaller` and `org.grails.web.converters.marshaller.xml.EnumMarshaller` classes are marked as `@Deprecated(forRemoval = true, since = "7.0.2")` and will be removed in Grails 8.0.
+
+===== 12.27 Greedy Extension Parameter Matching in URL Mappings
+
+Grails 7.1 introduces a new greedy extension parameter marker (`+`) for URL mappings that provides more intuitive handling of file extensions in URLs with multiple dots.
+
+====== The Problem with Default Behavior
+
+By default, Grails URL mappings with optional extensions split at the **first** dot in the path:
+
+[source,groovy]
+----
+"/$id(.$format)?"(controller: 'user', action: 'profile')
+----
+
+When matching the URL `/test.test.json`:
+- `id` = `test` (stops at first dot)
+- `format` = `test.json` (everything after first dot)
+
+This can be problematic when IDs legitimately contain dots, such as file names, qualified class names, or version numbers.
+
+====== New Greedy Matching Behavior
+
+The new `+` marker enables **greedy** matching, which splits at the **last** dot instead:
+
+[source,groovy]
+----
+"/$id+(.$format)?"(controller: 'user', action: 'profile')
+----
+
+Now the same URL `/test.test.json` matches as:
+- `id` = `test.test` (everything up to last dot)
+- `format` = `json` (extension after last dot)
+
+====== Syntax
+
+The `+` marker is added after the variable name and before the optional marker:
+
+**Required parameter with greedy extension:**
+[source,groovy]
+----
+"/$id+(.$format)?"(controller: 'file', action: 'download')
+----
+
+**Optional parameter with greedy extension:**
+[source,groovy]
+----
+"/$id+?(.$format)?"(controller: 'resource', action: 'show')
+----
+
+====== Use Cases
+
+Greedy extension matching is particularly useful for:
+
+1. **File downloads with complex names:**
++
+[source,groovy]
+----
+"/files/$filename+(.$format)?"(controller: 'file', action: 'download')
+----
++
+Matches `/files/document.final.v2.pdf` → `filename=document.final.v2`, `format=pdf`
+
+2. **Versioned resources:**
++
+[source,groovy]
+----
+"/api/$resource+(.$format)?"(controller: 'api', action: 'show')
+----
++
+Matches `/api/user.service.v1.json` → `resource=user.service.v1`, `format=json`
+
+3. **Qualified class names:**
++
+[source,groovy]
+----
+"/docs/$className+(.$format)?"(controller: 'documentation', action: 'show')
+----
++
+Matches `/docs/com.example.MyClass.html` → `className=com.example.MyClass`, `format=html`
+
+====== Behavior Details
+
+- **With dots:** The greedy marker splits at the **last** dot, treating everything before as the parameter value and everything after as the extension
+- **Without dots:** URLs without any dots match entirely as the parameter with no format
+- **Extension optional:** When the extension is marked optional `(.$format)?`, URLs work both with and without extensions
+
+**Examples:**
+
+[source,groovy]
+----
+"/$id+(.$format)?"(controller: 'resource', action: 'show')
+
+// URL Matches:
+/test.test.json    → id='test.test', format='json'
+/test.json         → id='test', format='json'
+/simpletest        → id='simpletest', format=null
+/foo.bar.baz.xml   → id='foo.bar.baz', format='xml'
+----
+
+====== Backward Compatibility
+
+The `+` marker is opt-in and fully backward compatible:
+
+- Existing URL mappings without the `+` marker continue to work as before (splitting at the first dot)
+- No changes are required to existing applications
+- The feature can be adopted incrementally on a per-mapping basis

--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/UrlMappingData.java
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/UrlMappingData.java
@@ -70,4 +70,9 @@ public interface UrlMappingData {
      * @return Whether the pattern has an optional extension
      */
     boolean hasOptionalExtension();
+
+    /**
+     * @return Whether the parameter before the optional extension should use greedy matching (last-dot split)
+     */
+    boolean hasGreedyExtensionParam();
 }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingData.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingData.java
@@ -46,6 +46,7 @@ public class DefaultUrlMappingData implements UrlMappingData {
 
     private List<Boolean> optionalTokens = new ArrayList<>();
     private boolean hasOptionalExtension;
+    private boolean hasGreedyExtensionParam;
 
     public DefaultUrlMappingData(String urlPattern) {
         Assert.hasLength(urlPattern, "Argument [urlPattern] cannot be null or blank");
@@ -63,6 +64,11 @@ public class DefaultUrlMappingData implements UrlMappingData {
     @Override
     public boolean hasOptionalExtension() {
         return hasOptionalExtension;
+    }
+
+    @Override
+    public boolean hasGreedyExtensionParam() {
+        return hasGreedyExtensionParam;
     }
 
     private String[] tokenizeUrlPattern(String urlPattern) {
@@ -93,7 +99,23 @@ public class DefaultUrlMappingData implements UrlMappingData {
             if (hasOptionalExtension) {
                 int i = lastToken.indexOf(optionalExtensionPattern);
                 optionalExtension = lastToken.substring(i, lastToken.length());
-                tokens[tokens.length - 1] = lastToken.substring(0, i);
+                String beforeExtension = lastToken.substring(0, i);
+
+                // Check if the parameter before the extension ends with + (greedy marker)
+                // Can be either (*)+ for required greedy or (*)+? for optional greedy
+                if (beforeExtension.endsWith("+") || beforeExtension.endsWith("+?")) {
+                    hasGreedyExtensionParam = true;
+                    // Remove the + (keep ? if it follows)
+                    if (beforeExtension.endsWith("+?")) {
+                        // (*)+? -> (*)?  (optional greedy)
+                        beforeExtension = beforeExtension.substring(0, beforeExtension.length() - 2) + "?";
+                    } else {
+                        // (*)+ -> (*)  (required greedy)
+                        beforeExtension = beforeExtension.substring(0, beforeExtension.length() - 1);
+                    }
+                }
+
+                tokens[tokens.length - 1] = beforeExtension;
             }
 
         }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -251,8 +251,8 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                 // For /(*)+(\.(*))?  we want regex: /(.+?)(?:\.([^/.]+))?  (required, greedy)
                 // For /(*)?+(\.(*))?  we want regex: /(.+?)?(?:\.([^/.]+))? (optional, greedy)
                 String processed = urlEnd
-                        .replace("/(*)?(\\.(*))?" , "/(.+?)?(?:\\.([^/.]+))?")   // Optional greedy: (*)?+
-                        .replace("/(*)(\\.(*))?" , "/(.+?)(?:\\.([^/.]+))?");     // Required greedy: (*)+
+                        .replace("/(*)?(\\.(*)))", "/(.+?)?(?:\\.([^/.]+))?")   // Optional greedy: (*)?+
+                        .replace("/(*)(\\.(*)))", "/(.+?)(?:\\.([^/.]+))?");     // Required greedy: (*)+
                 pattern += processed;
             } else {
                 pattern += urlEnd

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -245,6 +245,14 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                 // happen any time a URL mapping ends with a pattern like
                 // /$someVariable(.$someExtension)
                 pattern += "/([^/]+)\\.([^/.]+)?";
+            } else if (urlData.hasGreedyExtensionParam() && urlData.hasOptionalExtension()) {
+                // Handle greedy extension param (+ marker): match everything up to the last dot
+                // For /(*)+(\.(*))?  we want regex: /(.+)\.([^/.]+)?  (required, greedy)
+                // For /(*)?+(\.(*))?  we want regex: /(.+)?\.([^/.]+)? (optional, greedy)
+                String processed = urlEnd
+                        .replace("/(*)?(\\.(*))?" , "/(.+)?\\.([^/.]+)?")   // Optional greedy: (*)?+
+                        .replace("/(*)(\\.(*))?" , "/(.+)\\.([^/.]+)?");     // Required greedy: (*)+
+                pattern += processed;
             } else {
                 pattern += urlEnd
                         .replace("(\\.(*))", "(\\.[^/]+)?")

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -251,8 +251,8 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                 // For /(*)+(\.(*))?  we want regex: /(.+?)(?:\.([^/.]+))?  (required, greedy)
                 // For /(*)?+(\.(*))?  we want regex: /(.+?)?(?:\.([^/.]+))? (optional, greedy)
                 String processed = urlEnd
-                        .replace("/(*)?(\\.(*)))", "/(.+?)?(?:\\.([^/.]+))?")   // Optional greedy: (*)?+
-                        .replace("/(*)(\\.(*)))", "/(.+?)(?:\\.([^/.]+))?");     // Required greedy: (*)+
+                        .replace("/(*)?(\\.(*))?", "/(.+?)?(?:\\.([^/.]+))?")   // Optional greedy: (*)?+
+                        .replace("/(*)(\\.(*))?", "/(.+?)(?:\\.([^/.]+))?");    // Required greedy: (*)+
                 pattern += processed;
             } else {
                 pattern += urlEnd

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -247,11 +247,12 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                 pattern += "/([^/]+)\\.([^/.]+)?";
             } else if (urlData.hasGreedyExtensionParam() && urlData.hasOptionalExtension()) {
                 // Handle greedy extension param (+ marker): match everything up to the last dot
-                // For /(*)+(\.(*))?  we want regex: /(.+)\.([^/.]+)?  (required, greedy)
-                // For /(*)?+(\.(*))?  we want regex: /(.+)?\.([^/.]+)? (optional, greedy)
+                // The key is to make the entire dot+extension group optional using (?: )?
+                // For /(*)+(\.(*))?  we want regex: /(.+?)(?:\.([^/.]+))?  (required, greedy)
+                // For /(*)?+(\.(*))?  we want regex: /(.+?)?(?:\.([^/.]+))? (optional, greedy)
                 String processed = urlEnd
-                        .replace("/(*)?(\\.(*))?" , "/(.+)?\\.([^/.]+)?")   // Optional greedy: (*)?+
-                        .replace("/(*)(\\.(*))?" , "/(.+)\\.([^/.]+)?");     // Required greedy: (*)+
+                        .replace("/(*)?(\\.(*))?" , "/(.+?)?(?:\\.([^/.]+))?")   // Optional greedy: (*)?+
+                        .replace("/(*)(\\.(*))?" , "/(.+?)(?:\\.([^/.]+))?");     // Required greedy: (*)+
                 pattern += processed;
             } else {
                 pattern += urlEnd

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/ResponseCodeMappingData.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/ResponseCodeMappingData.java
@@ -61,6 +61,11 @@ public class ResponseCodeMappingData implements UrlMappingData {
         return false;
     }
 
+    @Override
+    public boolean hasGreedyExtensionParam() {
+        return false;
+    }
+
     public int getResponseCode() {
         return responseCode;
     }

--- a/grails-web-url-mappings/src/test/groovy/grails/web/mapping/UrlMappingsWithGreedyExtensionSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/grails/web/mapping/UrlMappingsWithGreedyExtensionSpec.groovy
@@ -1,0 +1,230 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.web.mapping
+
+/**
+ * Tests for greedy extension parameter matching using the + marker.
+ * The + marker causes the parameter before an optional extension to match greedily,
+ * splitting at the LAST dot instead of the first dot.
+ */
+class UrlMappingsWithGreedyExtensionSpec extends AbstractUrlMappingsSpec {
+
+    void "Test that required greedy parameter splits at last dot"() {
+        given: "A URL mapping with required greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching a URL with multiple dots"
+            def info = urlMappingsHolder.match('/test.test.json')
+
+        then: "The id captures everything up to the last dot"
+            info != null
+            info.parameters.id == 'test.test'
+            info.parameters.format == 'json'
+    }
+
+    void "Test that required greedy parameter works with single dot"() {
+        given: "A URL mapping with required greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching a URL with single dot"
+            def info = urlMappingsHolder.match('/test.json')
+
+        then: "The id captures up to the dot"
+            info != null
+            info.parameters.id == 'test'
+            info.parameters.format == 'json'
+    }
+
+    void "Test that required greedy parameter works without any dots"() {
+        given: "A URL mapping with required greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching a URL without any dots"
+            def info = urlMappingsHolder.match('/simpletest')
+
+        then: "The id captures the entire value with no format"
+            info != null
+            info.parameters.id == 'simpletest'
+            info.parameters.format == null
+    }
+
+    void "Test that required greedy parameter works without explicit extension marker"() {
+        given: "A URL mapping with required greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching a URL like /test.test (ambiguous - could be id with extension or id without)"
+            def info = urlMappingsHolder.match('/test.test')
+
+        then: "The greedy pattern treats last dot as extension separator"
+            info != null
+            info.parameters.id == 'test'
+            info.parameters.format == 'test'
+    }
+
+    void "Test that required greedy parameter works with many dots"() {
+        given: "A URL mapping with required greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching a URL with many dots"
+            def info = urlMappingsHolder.match('/foo.bar.baz.xml')
+
+        then: "The id captures everything up to the last dot"
+            info != null
+            info.parameters.id == 'foo.bar.baz'
+            info.parameters.format == 'xml'
+    }
+
+    void "Test that optional greedy parameter splits at last dot"() {
+        given: "A URL mapping with optional greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+?(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching a URL with multiple dots"
+            def info = urlMappingsHolder.match('/test.test.json')
+
+        then: "The id captures everything up to the last dot"
+            info != null
+            info.parameters.id == 'test.test'
+            info.parameters.format == 'json'
+    }
+
+    void "Test that optional greedy parameter allows missing id"() {
+        given: "A URL mapping with optional greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+?(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching a URL without id"
+            def info = urlMappingsHolder.match('/')
+
+        then: "The mapping matches with null id"
+            info != null
+            info.parameters.id == null
+            info.parameters.format == null
+    }
+
+    void "Test that greedy parameter differs from non-greedy behavior"() {
+        given: "Two URL mappings - greedy and non-greedy"
+            def greedyHolder = getUrlMappingsHolder {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+            def nonGreedyHolder = getUrlMappingsHolder {
+                "/$id(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching the same URL with both"
+            def greedyInfo = greedyHolder.match('/test.test.json')
+            def nonGreedyInfo = nonGreedyHolder.match('/test.test.json')
+
+        then: "Greedy splits at last dot, non-greedy at first dot"
+            greedyInfo.parameters.id == 'test.test'
+            greedyInfo.parameters.format == 'json'
+
+            nonGreedyInfo.parameters.id == 'test'
+            nonGreedyInfo.parameters.format == 'test.json'
+    }
+
+    void "Test that greedy parameter works in complex mappings"() {
+        given: "A URL mapping with controller, action, and greedy id"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$controller/$action/$id+(.$format)?"()
+            }
+
+        when: "Matching a complex URL"
+            def info = urlMappingsHolder.match('/user/show/test.test.json')
+
+        then: "All parameters are correctly extracted"
+            info != null
+            info.parameters.controller == 'user'
+            info.parameters.action == 'show'
+            info.parameters.id == 'test.test'
+            info.parameters.format == 'json'
+    }
+
+    void "Test that greedy links are generated correctly with format"() {
+        given: "A link generator with greedy parameter mapping"
+            def linkGenerator = getLinkGenerator {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Generating a link with id containing dots and format"
+            def link = linkGenerator.link(controller: "user", action: "profile",
+                                         id: "test.test", params: [format: 'json'])
+
+        then: "The link is correctly formatted"
+            link == "http://localhost/test.test.json"
+    }
+
+    void "Test that greedy links are generated correctly without format"() {
+        given: "A link generator with greedy parameter mapping"
+            def linkGenerator = getLinkGenerator {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Generating a link with id containing dots but no format"
+            def link = linkGenerator.link(controller: "user", action: "profile",
+                                         id: "test.test")
+
+        then: "The link is correctly formatted without extension"
+            link == "http://localhost/test.test"
+    }
+
+    void "Test that greedy parameter works with different file extensions"() {
+        given: "A URL mapping with required greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        expect: "Various file extensions are correctly parsed"
+            urlMappingsHolder.match('/file.name.pdf').parameters.id == 'file.name'
+            urlMappingsHolder.match('/file.name.pdf').parameters.format == 'pdf'
+
+            urlMappingsHolder.match('/file.name.html').parameters.id == 'file.name'
+            urlMappingsHolder.match('/file.name.html').parameters.format == 'html'
+
+            urlMappingsHolder.match('/file.name.csv').parameters.id == 'file.name'
+            urlMappingsHolder.match('/file.name.csv').parameters.format == 'csv'
+    }
+
+    void "Test that UrlMappingData reports greedy extension correctly"() {
+        given: "A URL mapping with greedy parameter"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$id+(.$format)?"(controller: "user", action: "profile")
+            }
+
+        when: "Matching a URL"
+            def info = urlMappingsHolder.match('/test.test.json')
+
+        then: "The UrlMappingData indicates greedy extension parameter"
+            info != null
+            info.urlData.hasGreedyExtensionParam()
+            info.urlData.hasOptionalExtension()
+    }
+}


### PR DESCRIPTION
# Why?
Grails by default doesn't use mime types to render json.  It encourages using $format.  If you want to handle multiple mime types with the same controller while supporting ids with decimals, this becomes impossible due to how regular expression url mappings are handled in Grails.   This PR offers the capability of restricting format to not include periods by specifying the $id attribute to be greedy with the + symbol. 

# Problem
Currently when a url parameter is specified prior prior to a $format parameter, the parameter only consumes everything up until the first dot.   This results in undesired behavior on sites that's use parameters for usernames that include 1 or more periods. 

For instance

"/$controller/$action?/$id?(.$format)?" 
/user/show/bob.smith.json  results in controller = 'UserController' id = 'bob'. format = 'smith.json'

# The solution

Introduce the + symbol after a url parameter to make it greedy.

Syntax:

  - "/$id+(.$format)?" - Required id, greedy (splits at last dot)
  - "/$id+?(.$format)?" - Optional id, greedy (splits at last dot)

Examples with this Fix

"/$controller/$action?/$id+?(.$format)?" 

  /user/show/est.test.json  → id=test.test, format=json
  /user/show/test.json       → id=test, format=json
  /user/show/foo.bar.baz.xml → id=foo.bar.baz, format=xml



