### PR TITLE
Do not mark AST transformation methods as generated

### DIFF
--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/transform/AbstractMethodDecoratingTransformation.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/transform/AbstractMethodDecoratingTransformation.groovy
@@ -47,7 +47,6 @@ import jakarta.annotation.PreDestroy
 
 import org.grails.datastore.mapping.reflect.NameUtils
 
-import static org.apache.groovy.ast.tools.AnnotatedNodeUtils.markAsGenerated
 import static org.codehaus.groovy.ast.ClassHelper.VOID_TYPE
 import static org.codehaus.groovy.ast.tools.GeneralUtils.args
 import static org.codehaus.groovy.ast.tools.GeneralUtils.block
@@ -352,7 +351,6 @@ abstract class AbstractMethodDecoratingTransformation extends AbstractGormASTTra
         renamedMethodNode.addAnnotations(methodNode.getAnnotations(TYPE_CHECKED_TYPE))
 
         methodNode.setCode(null)
-        markAsGenerated(classNode, renamedMethodNode)
         classNode.addMethod(renamedMethodNode)
 
         // Use a dummy source unit to process the variable scopes to avoid the issue where this is run twice producing an error


### PR DESCRIPTION
Follow up #15150

Jacoco isn't displaying coverage lines on methods annotated with Transactional (or other annotation that apply AST transformation).

I think that has been applied to display a more clean list of methods in the tree, but I guess the coverage lines is more important than that.

I did some tests and below you can see the results.

### Current

No coverage lines are displayed.

```groovy
markAsGenerated(classNode, renamedMethodNode)
```

<img width="450" alt="image" src="https://github.com/user-attachments/assets/be779612-05d7-444c-ada3-a9bde1f5dcd0" />

### Marking the original method as generated

I don't think this is the best way, it feels counterintuitive to me.

```groovy
markAsGenerated(classNode, methodNode)
```

<img width="450" alt="image" src="https://github.com/user-attachments/assets/5d2796e7-26be-4582-8c74-cb84c79abe91" />

### Not marking methods as generated

It has a larger methods list than other ways.

<img width="450" alt="image" src="https://github.com/user-attachments/assets/6a65c113-2753-4d89-aeaa-7e76df68dbe6" />

---

I chose not to mark the methods as generated, let me know what you think.
