### PR TITLE
Issue 15205 Docs - Source contains license header

### DIFF
--- a/grails-doc/src/en/guide/cache/cacheUsage/cacheConfiguration.adoc
+++ b/grails-doc/src/en/guide/cache/cacheUsage/cacheConfiguration.adoc
@@ -40,7 +40,7 @@ supported options in the cache configuration.
 WARNING: Since there is no way to configure "time to live" with this plugin, all
 cached items have no timeout and remain cached until either the JVM restarts
 (since the backing store is in-memory) or the cache is partially or fully
-cleared (by calling a method or action annotated with \@CacheEvict or
+cleared (by calling a method or action annotated with @CacheEvict or
 programmatically).
 
 If you don't need to supply any configuration to your cache, simply don't include it in the configuration.

--- a/grails-doc/src/en/guide/cache/cacheUsage/cacheUnitTests.adoc
+++ b/grails-doc/src/en/guide/cache/cacheUsage/cacheUnitTests.adoc
@@ -29,7 +29,7 @@ include::{cacheExampleSourceDir}/grails-app/services/com/demo/BasicCachingServic
 
 [source,groovy]
 ----
-include::{cacheExampleSourceDir}/src/test/groovy/com/demo/BasicCachingServiceNoCacheManagerSpec.groovy[]
+include::{cacheExampleSourceDir}/src/test/groovy/com/demo/BasicCachingServiceNoCacheManagerSpec.groovy[tags=basic_declaration]
 ----
 
 In order for caching to be active when the unit test is running, cache manager
@@ -38,5 +38,5 @@ test.
 
 [source,groovy]
 ----
-include::{cacheExampleSourceDir}/src/test/groovy/com/demo/BasicCachingServiceSpec.groovy[]
+include::{cacheExampleSourceDir}/src/test/groovy/com/demo/BasicCachingServiceSpec.groovy[tags=basic_declaration]
 ----

--- a/grails-doc/src/en/guide/testing/unitTesting/annotations.adoc
+++ b/grails-doc/src/en/guide/testing/unitTesting/annotations.adoc
@@ -27,7 +27,7 @@ applied in conjunction with a fixture annnotation like `@Before` as shown below.
 [source,groovy]
 .src/test/groovy/grails/testing/spock/RunOnceSpec.groovy
 ----
-include::{sourcedir}/grails-testing-support-core/src/test/groovy/grails/testing/spock/RunOnceSpec.groovy[indent=0]
+include::{sourcedir}/grails-testing-support-core/src/test/groovy/grails/testing/spock/RunOnceSpec.groovy[tags=basic_declaration,indent=0]
 ----
 
 Applying both the `@RunOnce` and `@Before` annotations to a method will yield
@@ -49,7 +49,7 @@ accomplishing the same behavior that would be accomplished by applying both the
 [source,groovy]
 .src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy
 ----
-include::{sourcedir}/grails-testing-support-core/src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy[indent=0]
+include::{sourcedir}/grails-testing-support-core/src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy[tags=basic_declaration,indent=0]
 ----
 
 This is useful in the context of an integration test which wants to reference
@@ -58,5 +58,5 @@ dependency injected values during setup as shown below.
 [source,groovy]
 .src/integration-test/groovy/demo/DependencyInjectionSpec.groovy
 ----
-include::{functionalSourceDir}/demo33/src/integration-test/groovy/demo/DependencyInjectionSpec.groovy[indent=0]
+include::{functionalSourceDir}/demo33/src/integration-test/groovy/demo/DependencyInjectionSpec.groovy[tags=basic_declaration,indent=0]
 ----

--- a/grails-doc/src/en/guide/testing/unitTesting/unitTestingDomainClasses.adoc
+++ b/grails-doc/src/en/guide/testing/unitTesting/unitTestingDomainClasses.adoc
@@ -23,13 +23,13 @@ trait to unit test single domain class.
 [source,groovy]
 .grails-app/domain/demo/Person.groovy
 ----
-include::{functionalSourceDir}/demo33/grails-app/domain/demo/Person.groovy[indent=0]
+include::{functionalSourceDir}/demo33/grails-app/domain/demo/Person.groovy[tags=basic_declaration,indent=0]
 ----
 
 [source,groovy]
 .src/test/groovy/demo/PersonSpec.groovy
 ----
-include::{functionalSourceDir}/demo33/src/test/groovy/demo/PersonSpec.groovy[indent=0]
+include::{functionalSourceDir}/demo33/src/test/groovy/demo/PersonSpec.groovy[tags=basic_declaration,indent=0]
 ----
 
 Alternatively, the link:{api}grails/testing/gorm/DataTest.html[`grails.testing.gorm.DataTest`]
@@ -42,7 +42,7 @@ test. This is useful when mocking more than one Domain class at a time to test p
 [source,groovy]
 .src/test/groovy/demo/DataTestTraitSpec.groovy
 ----
-include::{functionalSourceDir}/demo33/src/test/groovy/demo/DataTestTraitSpec.groovy[indent=0]
+include::{functionalSourceDir}/demo33/src/test/groovy/demo/DataTestTraitSpec.groovy[tags=basic_declaration,indent=0]
 ----
 
 Another way to express which domain classes should be mocked for this test is
@@ -51,7 +51,7 @@ to provide a `Class[] getDomainClassesToMock()` method in the test.
 [source,groovy]
 .src/test/groovy/demo/GetDomainClassesToMockMethodSpec.groovy
 ----
-include::{functionalSourceDir}/demo33/src/test/groovy/demo/GetDomainClassesToMockMethodSpec.groovy[indent=0]
+include::{functionalSourceDir}/demo33/src/test/groovy/demo/GetDomainClassesToMockMethodSpec.groovy[tags=basic_declaration,indent=0]
 ----
 
 When mocking domain classes in a test for another artifact type (like a
@@ -61,5 +61,5 @@ trait in order to mock the related domain classes.
 [source,groovy]
 .src/test/groovy/demo/PersonControllerSpec.groovy
 ----
-include::{functionalSourceDir}/demo33/src/test/groovy/demo/PersonControllerSpec.groovy[indent=0]
+include::{functionalSourceDir}/demo33/src/test/groovy/demo/PersonControllerSpec.groovy[tags=basic_declaration,indent=0]
 ----

--- a/grails-doc/src/en/guide/testing/unitTesting/unitTestingUrlMappings.adoc
+++ b/grails-doc/src/en/guide/testing/unitTesting/unitTestingUrlMappings.adoc
@@ -27,7 +27,7 @@ The examples assume the following mappings are being used.
 
 [source,groovy]
 ----
-include::{functionalSourceDir}/demo33/grails-app/controllers/demo/UrlMappings.groovy[indent=0]
+include::{functionalSourceDir}/demo33/grails-app/controllers/demo/UrlMappings.groovy[tags=basic_declaration,indent=0]
 ----
 
 === Getting Started

--- a/grails-test-examples/cache/src/test/groovy/com/demo/BasicCachingServiceNoCacheManagerSpec.groovy
+++ b/grails-test-examples/cache/src/test/groovy/com/demo/BasicCachingServiceNoCacheManagerSpec.groovy
@@ -17,6 +17,7 @@
  *  under the License.
  */
 
+// tag::basic_declaration[]
 package com.demo
 
 import grails.testing.services.ServiceUnitTest
@@ -40,3 +41,4 @@ class BasicCachingServiceNoCacheManagerSpec extends Specification implements Ser
         service.invocationCounter == 2
     }
 }
+// end::basic_declaration[]

--- a/grails-test-examples/cache/src/test/groovy/com/demo/BasicCachingServiceSpec.groovy
+++ b/grails-test-examples/cache/src/test/groovy/com/demo/BasicCachingServiceSpec.groovy
@@ -17,6 +17,7 @@
  *  under the License.
  */
 
+// tag::basic_declaration[]
 package com.demo
 
 import grails.plugin.cache.CustomCacheKeyGenerator
@@ -78,3 +79,4 @@ class BasicCachingServiceSpec extends Specification implements ServiceUnitTest<B
         service.conditionalInvocationCounter == 3
     }
 }
+// end::basic_declaration[]

--- a/grails-test-examples/demo33/grails-app/controllers/demo/UrlMappings.groovy
+++ b/grails-test-examples/demo33/grails-app/controllers/demo/UrlMappings.groovy
@@ -17,6 +17,7 @@
  *  under the License.
  */
 
+// tag::basic_declaration[]
 package demo
 
 class UrlMappings {
@@ -37,3 +38,4 @@ class UrlMappings {
         "404"(view:'/notFound')
     }
 }
+// end::basic_declaration[]

--- a/grails-test-examples/demo33/grails-app/domain/demo/Person.groovy
+++ b/grails-test-examples/demo33/grails-app/domain/demo/Person.groovy
@@ -16,10 +16,11 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
+// tag::basic_declaration[]
 package demo
 
 class Person {
     String firstName
     String lastName
 }
+// end::basic_declaration[]

--- a/grails-test-examples/demo33/src/integration-test/groovy/demo/DependencyInjectionSpec.groovy
+++ b/grails-test-examples/demo33/src/integration-test/groovy/demo/DependencyInjectionSpec.groovy
@@ -17,6 +17,7 @@
  *  under the License.
  */
 
+// tag::basic_declaration[]
 package demo
 
 import grails.testing.mixin.integration.Integration
@@ -36,3 +37,4 @@ class DependencyInjectionSpec extends Specification {
         helperService != null
     }
 }
+// end::basic_declaration[]

--- a/grails-test-examples/demo33/src/test/groovy/demo/DataTestTraitSpec.groovy
+++ b/grails-test-examples/demo33/src/test/groovy/demo/DataTestTraitSpec.groovy
@@ -16,6 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+// tag::basic_declaration[]
 package demo
 
 import grails.testing.gorm.DataTest
@@ -39,3 +40,4 @@ class DataTestTraitSpec extends Specification implements DataTest {
         Person.count() == 2
     }
 }
+// end::basic_declaration[]

--- a/grails-test-examples/demo33/src/test/groovy/demo/GetDomainClassesToMockMethodSpec.groovy
+++ b/grails-test-examples/demo33/src/test/groovy/demo/GetDomainClassesToMockMethodSpec.groovy
@@ -16,6 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+// tag::basic_declaration[]
 package demo
 
 import grails.testing.gorm.DataTest
@@ -36,3 +37,4 @@ class GetDomainClassesToMockMethodSpec extends Specification implements DataTest
         Person.count() == 2
     }
 }
+// end::basic_declaration[]

--- a/grails-test-examples/demo33/src/test/groovy/demo/PersonControllerSpec.groovy
+++ b/grails-test-examples/demo33/src/test/groovy/demo/PersonControllerSpec.groovy
@@ -16,6 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+// tag::basic_declaration[]
 package demo
 
 import grails.testing.gorm.DataTest
@@ -41,3 +42,4 @@ class PersonControllerSpec extends Specification implements ControllerUnitTest<P
         model.keySet().contains('people')
     }
 }
+// end::basic_declaration[]

--- a/grails-test-examples/demo33/src/test/groovy/demo/PersonSpec.groovy
+++ b/grails-test-examples/demo33/src/test/groovy/demo/PersonSpec.groovy
@@ -16,6 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+// tag::basic_declaration[]
 package demo
 
 import grails.testing.gorm.DomainUnitTest
@@ -59,3 +60,4 @@ class PersonSpec extends Specification implements DomainUnitTest<Person> {
         System.identityHashCode(domain) != id
     }
 }
+// end::basic_declaration[]

--- a/grails-testing-support-core/src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy
+++ b/grails-testing-support-core/src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy
@@ -16,6 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+// tag::basic_declaration[]
 package grails.testing.spock
 
 import spock.lang.Shared
@@ -79,3 +80,4 @@ class OnceBeforeSpec extends Specification {
         anotherOnceBeforeCounter == 1
     }
 }
+// end::basic_declaration[]

--- a/grails-testing-support-core/src/test/groovy/grails/testing/spock/RunOnceSpec.groovy
+++ b/grails-testing-support-core/src/test/groovy/grails/testing/spock/RunOnceSpec.groovy
@@ -16,6 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+// tag::basic_declaration[]
 package grails.testing.spock
 
 import org.junit.jupiter.api.BeforeEach
@@ -82,3 +83,4 @@ class RunOnceSpec extends Specification {
         anotherOnceBeforeCounter == 1
     }
 }
+// end::basic_declaration[]


### PR DESCRIPTION
Fixes issue #15205

Adds missing Asciidoctor tags needed to include sourcecode without license headers.

https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/