### PR TITLE
Gradle Plugin Fix - remove calls to setSystemProperty() and set on individual tasks instead

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -133,8 +133,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
         registerFindMainClassTask(project)
 
-        configureGrailsBuildSettings(project)
-
         String grailsVersion = resolveGrailsVersion(project)
 
         enableNative2Ascii(project, grailsVersion)
@@ -424,12 +422,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
         }
     }
 
-    @CompileStatic
-    protected String configureGrailsBuildSettings(Project project) {
-        System.setProperty(BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath)
-        System.setProperty(BuildSettings.PROJECT_TARGET_DIR, project.layout.buildDirectory.get().asFile.name)
-    }
-
     @CompileDynamic
     protected void configureApplicationCommands(Project project) {
         def applicationContextCommands = FactoriesLoaderSupport.loadFactoryNames(APPLICATION_CONTEXT_COMMAND_CLASS)
@@ -543,6 +535,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
             task.systemProperty(Metadata.APPLICATION_NAME, project.name)
             task.systemProperty(Metadata.APPLICATION_VERSION, (project.version instanceof Serializable ? project.version : project.version.toString()))
             task.systemProperty(Metadata.APPLICATION_GRAILS_VERSION, grailsVersion)
+            task.systemProperty(BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath)
+            task.systemProperty(BuildSettings.PROJECT_TARGET_DIR, project.layout.buildDirectory.get().asFile.name)
             task.systemProperty(Environment.KEY, defaultGrailsEnv)
             task.systemProperty(Environment.FULL_STACKTRACE, System.getProperty(Environment.FULL_STACKTRACE) ?: '')
             if (task.minHeapSize == null) {


### PR DESCRIPTION
This was an extremely frustrating bug for multiproject builds.  The gradle plugins were calling System.setProperty() as part of any grails gradle plugin setup - which means the set Property is for the life of that jvm instance.  Since gradle is threaded, with multiproject builds, it resulted in a race condition / random setting of this field.  This meant that the basedir was incorrectly set for bootRun, etc.  It was even complicated more in that if it was set for that daemon process, it would remain set.  

We already set other properties as part of task execution, so this PR takes the same approach.  This does mean that the properties are no longer set for gradle code, but after testing, I think this is ok.  