### PR TITLE
Apply `java-library` Gradle Plugin to Grails Plugin projects

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -63,15 +63,10 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         project.pluginManager.apply('java-library')
 
         checkForConfigurationClash(project)
-
         configureAstSources(project)
-
         configureAssembleTask(project)
-
         configurePluginResources(project)
-
         configureJarTask(project)
-
         configureSourcesJarTask(project)
     }
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -60,6 +60,8 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
     void apply(Project project) {
         super.apply(project)
 
+        project.pluginManager.apply('java-library')
+
         checkForConfigurationClash(project)
 
         configureAstSources(project)


### PR DESCRIPTION
Grails plugins are Java libraries and should have access to the `api` dependency configuration by default.