### PR TITLE
fix: Re-implemented ContainerRenderer on AbstractJsonViewContainerRenderer

### DIFF
--- a/grails-rest-transforms/src/main/groovy/grails/rest/render/ContainerRenderer.groovy
+++ b/grails-rest-transforms/src/main/groovy/grails/rest/render/ContainerRenderer.groovy
@@ -24,7 +24,7 @@ package grails.rest.render
  * @author Graeme Rocher
  * @since 2.3
  */
-interface ContainerRenderer<C, T> extends Renderer<C> {
+interface ContainerRenderer<C, T> extends Renderer<T> {
 
     /**
      * @return The underlying type wrapped by the container. For example with List<Book>, this method would return Book

--- a/grails-rest-transforms/src/main/groovy/grails/rest/render/errors/VndErrorJsonRenderer.groovy
+++ b/grails-rest-transforms/src/main/groovy/grails/rest/render/errors/VndErrorJsonRenderer.groovy
@@ -25,7 +25,6 @@ import groovy.transform.CompileStatic
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.validation.BeanPropertyBindingResult
-import org.springframework.validation.Errors
 import org.springframework.validation.ObjectError
 
 import grails.rest.render.RenderContext
@@ -48,7 +47,7 @@ class VndErrorJsonRenderer extends AbstractVndErrorRenderer {
     MimeType[] mimeTypes = [MIME_TYPE, MimeType.HAL_JSON, MimeType.JSON, MimeType.TEXT_JSON] as MimeType[]
 
     @Override
-    void render(Errors object, RenderContext context) {
+    void render(Object object, RenderContext context) {
         if (messageSource == null) throw new IllegalStateException('messageSource property null')
         if (object instanceof BeanPropertyBindingResult) {
 

--- a/grails-rest-transforms/src/main/groovy/grails/rest/render/errors/VndErrorXmlRenderer.groovy
+++ b/grails-rest-transforms/src/main/groovy/grails/rest/render/errors/VndErrorXmlRenderer.groovy
@@ -22,7 +22,6 @@ import groovy.transform.CompileStatic
 
 import org.springframework.http.HttpStatus
 import org.springframework.validation.BeanPropertyBindingResult
-import org.springframework.validation.Errors
 import org.springframework.validation.ObjectError
 
 import grails.rest.render.RenderContext
@@ -50,7 +49,7 @@ class VndErrorXmlRenderer extends AbstractVndErrorRenderer {
     MimeType[] mimeTypes = [MIME_TYPE, MimeType.HAL_XML, MimeType.XML, MimeType.TEXT_XML] as MimeType[]
 
     @Override
-    void render(Errors object, RenderContext context) {
+    void render(Object object, RenderContext context) {
         if (object instanceof BeanPropertyBindingResult) {
             def errors = object as BeanPropertyBindingResult
             context.setContentType(GrailsWebUtil.getContentType(MIME_TYPE.name, encoding))

--- a/grails-rest-transforms/src/main/groovy/grails/rest/render/hal/HalJsonRenderer.groovy
+++ b/grails-rest-transforms/src/main/groovy/grails/rest/render/hal/HalJsonRenderer.groovy
@@ -108,7 +108,7 @@ class HalJsonRenderer<T> extends AbstractLinkingRenderer<T> {
     }
 
     @Override
-    void renderInternal(T object, RenderContext context) {
+    void renderInternal(Object object, RenderContext context) {
         final mimeType = context.acceptMimeType ?: mimeTypes[0]
         final responseWriter = context.writer
         Writer targetWriter = prettyPrint ? new StringWriter() : responseWriter

--- a/grails-rest-transforms/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
+++ b/grails-rest-transforms/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
@@ -107,7 +107,7 @@ abstract class AbstractLinkingRenderer<T> extends AbstractIncludeExcludeRenderer
     }
 
     @Override
-    void render(T object, RenderContext renderContext) {
+    void render(Object object, RenderContext renderContext) {
         def mimeType = renderContext.acceptMimeType ?: getMimeTypes()[0]
         def contentType = GrailsWebUtil.getContentType(mimeType.name, encoding)
         renderContext.setContentType(contentType)
@@ -123,7 +123,7 @@ abstract class AbstractLinkingRenderer<T> extends AbstractIncludeExcludeRenderer
         }
     }
 
-    abstract void renderInternal(T object, RenderContext context)
+    abstract void renderInternal(Object object, RenderContext context)
 
     protected boolean isDomainResource(Class clazz) {
         if (mappingContext != null) {

--- a/grails-rest-transforms/src/main/groovy/org/grails/plugins/web/rest/render/json/DefaultJsonRenderer.groovy
+++ b/grails-rest-transforms/src/main/groovy/org/grails/plugins/web/rest/render/json/DefaultJsonRenderer.groovy
@@ -76,7 +76,7 @@ class DefaultJsonRenderer<T> implements Renderer<T> {
     }
 
     @Override
-    void render(T object, RenderContext context) {
+    void render(Object object, RenderContext context) {
         final mimeType = context.acceptMimeType ?: MimeType.JSON
         context.setContentType(GrailsWebUtil.getContentType(mimeType.name, encoding))
         def viewName = context.viewName ?: context.actionName

--- a/grails-test-examples/issue-15228/build.gradle
+++ b/grails-test-examples/issue-15228/build.gradle
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+version = '0.1'
+group = 'issue11767.app'
+
+apply plugin: 'org.apache.grails.gradle.grails-web'
+
+dependencies {
+    implementation platform(project(':grails-bom'))
+
+    implementation 'org.springframework.boot:spring-boot-starter-logging'
+    implementation 'org.apache.grails:grails-dependencies-starter-web'
+
+    implementation 'org.apache.grails:grails-views-gson'
+    implementation 'org.apache.grails:grails-rest-transforms'
+
+    testAndDevelopmentOnly platform(project(':grails-bom'))
+
+    testImplementation 'org.apache.grails:grails-testing-support-views-gson'
+    testImplementation 'org.apache.grails.testing:grails-testing-support-core'
+
+    integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
+    integrationTestImplementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
+    integrationTestImplementation "io.micronaut:micronaut-jackson-databind:$micronautHttpClientVersion"
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
+}

--- a/grails-test-examples/issue-15228/grails-app/conf/application.yml
+++ b/grails-test-examples/issue-15228/grails-app/conf/application.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info:
+  app:
+    name: '@info.app.name@'
+    version: '@info.app.version@'
+    grailsVersion: '@info.app.grailsVersion@'
+grails:
+  mime:
+    disable:
+      accept:
+        header:
+          userAgents:
+          - Gecko
+          - WebKit
+          - Presto
+          - Trident
+    types:
+      all: '*/*'
+      atom: application/atom+xml
+      css: text/css
+      csv: text/csv
+      form: application/x-www-form-urlencoded
+      html:
+      - text/html
+      - application/xhtml+xml
+      js: text/javascript
+      json:
+      - application/json
+      - text/json
+      multipartForm: multipart/form-data
+      pdf: application/pdf
+      rss: application/rss+xml
+      text: text/plain
+      hal:
+      - application/hal+json
+      - application/hal+xml
+      xml:
+      - text/xml
+      - application/xml
+micronaut:
+  http:
+    client:
+      readTimeout: PT10M
+      

--- a/grails-test-examples/issue-15228/grails-app/conf/logback.xml
+++ b/grails-test-examples/issue-15228/grails-app/conf/logback.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+
+-->
+<configuration>
+
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/grails-test-examples/issue-15228/grails-app/controllers/issue15228/app/AppController.groovy
+++ b/grails-test-examples/issue-15228/grails-app/controllers/issue15228/app/AppController.groovy
@@ -16,28 +16,27 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.rest.render
 
-import grails.web.mime.MimeTypeProvider
+package issue15228.app
 
-/**
- * Interface for class that render RESTful responses to implement
- *
- * @author Graeme Rocher
- * @since 2.3
- */
-interface Renderer<T> extends MimeTypeProvider {
+import org.springframework.http.HttpStatus
 
-    /**
-     * @return The target type
-     */
-    Class<T> getTargetType()
+import grails.artefact.Controller
+import grails.artefact.controller.RestResponder
 
-    /**
-     * Renders the object
-     *
-     * @param object The object to render
-     * @param context The {@link RenderContext}
-     */
-    void render(Object object, RenderContext context)
+class AppController implements Controller, RestResponder {
+
+    def normalView(ValidateableObject obj) {
+        respond(obj)
+    }
+
+    def typeView(OtherValidateableObject obj) {
+        respond(obj)
+    }
+
+    def errorView(ValidateableObject obj) {
+        respond(obj.errors, status: HttpStatus.UNPROCESSABLE_ENTITY)
+    }
+    
 }
+

--- a/grails-test-examples/issue-15228/grails-app/controllers/issue15228/app/UrlMappings.groovy
+++ b/grails-test-examples/issue-15228/grails-app/controllers/issue15228/app/UrlMappings.groovy
@@ -16,28 +16,15 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.rest.render
 
-import grails.web.mime.MimeTypeProvider
+package issue15228.app
 
-/**
- * Interface for class that render RESTful responses to implement
- *
- * @author Graeme Rocher
- * @since 2.3
- */
-interface Renderer<T> extends MimeTypeProvider {
-
-    /**
-     * @return The target type
-     */
-    Class<T> getTargetType()
-
-    /**
-     * Renders the object
-     *
-     * @param object The object to render
-     * @param context The {@link RenderContext}
-     */
-    void render(Object object, RenderContext context)
+class UrlMappings {
+    static mappings = {
+        "/$controller/$action?/$id?(.$format)?"{
+            constraints {
+                // apply constraints here
+            }
+        }
+    }
 }

--- a/grails-test-examples/issue-15228/grails-app/init/issue15228/app/Application.groovy
+++ b/grails-test-examples/issue-15228/grails-app/init/issue15228/app/Application.groovy
@@ -16,28 +16,16 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.rest.render
 
-import grails.web.mime.MimeTypeProvider
+package issue15228.app
 
-/**
- * Interface for class that render RESTful responses to implement
- *
- * @author Graeme Rocher
- * @since 2.3
- */
-interface Renderer<T> extends MimeTypeProvider {
+import grails.boot.GrailsApp
+import grails.boot.config.GrailsAutoConfiguration
+import groovy.transform.CompileStatic
 
-    /**
-     * @return The target type
-     */
-    Class<T> getTargetType()
-
-    /**
-     * Renders the object
-     *
-     * @param object The object to render
-     * @param context The {@link RenderContext}
-     */
-    void render(Object object, RenderContext context)
+@CompileStatic
+class Application extends GrailsAutoConfiguration {
+    static void main(String[] args) {
+        GrailsApp.run(Application, args)
+    }
 }

--- a/grails-test-examples/issue-15228/grails-app/views/app/normalView.gson
+++ b/grails-test-examples/issue-15228/grails-app/views/app/normalView.gson
@@ -16,28 +16,14 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.rest.render
+import issue15228.app.ValidateableObject
 
-import grails.web.mime.MimeTypeProvider
+model {
+    ValidateableObject validateableObject
+}
 
-/**
- * Interface for class that render RESTful responses to implement
- *
- * @author Graeme Rocher
- * @since 2.3
- */
-interface Renderer<T> extends MimeTypeProvider {
-
-    /**
-     * @return The target type
-     */
-    Class<T> getTargetType()
-
-    /**
-     * Renders the object
-     *
-     * @param object The object to render
-     * @param context The {@link RenderContext}
-     */
-    void render(Object object, RenderContext context)
+json {
+    normal {
+        foo validateableObject.foo
+    }
 }

--- a/grails-test-examples/issue-15228/grails-app/views/errors/_errors.gson
+++ b/grails-test-examples/issue-15228/grails-app/views/errors/_errors.gson
@@ -16,28 +16,24 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.rest.render
+import org.springframework.validation.*
 
-import grails.web.mime.MimeTypeProvider
+model {
+    Errors errors
+}
 
-/**
- * Interface for class that render RESTful responses to implement
- *
- * @author Graeme Rocher
- * @since 2.3
- */
-interface Renderer<T> extends MimeTypeProvider {
-
-    /**
-     * @return The target type
-     */
-    Class<T> getTargetType()
-
-    /**
-     * Renders the object
-     *
-     * @param object The object to render
-     * @param context The {@link RenderContext}
-     */
-    void render(Object object, RenderContext context)
+json {
+    error {
+        if(errors.globalErrorCount == 1 && errors.fieldErrorCount == 0) {
+            message messageSource.getMessage(errors.globalError, locale)
+        } else {
+            errors(errors.allErrors) { ObjectError error ->
+                if(error instanceof FieldError) {
+                    field error.field
+                    rejectedValue error.rejectedValue
+                }
+                message messageSource.getMessage(error, locale)
+            }
+        }
+    }
 }

--- a/grails-test-examples/issue-15228/grails-app/views/otherValidateableObject/_otherValidateableObject.gson
+++ b/grails-test-examples/issue-15228/grails-app/views/otherValidateableObject/_otherValidateableObject.gson
@@ -16,28 +16,14 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.rest.render
+import issue15228.app.OtherValidateableObject
 
-import grails.web.mime.MimeTypeProvider
+model {
+    OtherValidateableObject otherValidateableObject
+}
 
-/**
- * Interface for class that render RESTful responses to implement
- *
- * @author Graeme Rocher
- * @since 2.3
- */
-interface Renderer<T> extends MimeTypeProvider {
-
-    /**
-     * @return The target type
-     */
-    Class<T> getTargetType()
-
-    /**
-     * Renders the object
-     *
-     * @param object The object to render
-     * @param context The {@link RenderContext}
-     */
-    void render(Object object, RenderContext context)
+json {
+    type {
+        foo otherValidateableObject.foo
+    }
 }

--- a/grails-test-examples/issue-15228/src/integration-test/groovy/issue11767/app/GsonViewRespondSpec.groovy
+++ b/grails-test-examples/issue-15228/src/integration-test/groovy/issue11767/app/GsonViewRespondSpec.groovy
@@ -1,0 +1,104 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package issue11767.app
+
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class GsonViewRespondSpec extends Specification {
+
+    @Shared
+    ObjectMapper objectMapper
+
+    def setupSpec() {
+        objectMapper = new ObjectMapper()
+    }
+
+    @Shared
+    @AutoCleanup
+    HttpClient httpClient
+
+    void setup() {
+        def baseUrl = "http://localhost:$serverPort"
+        httpClient = HttpClient.create(baseUrl.toURL())
+    }
+
+    void 'respond with Error gson view'() {
+        when: 'The app controller is visited on errorView'
+        def request = HttpRequest.GET('/app/errorView?foo=Too+Short').accept(MediaType.APPLICATION_JSON)
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.UNPROCESSABLE_ENTITY
+
+        and:
+        objectMapper.readTree(ex.response.body() as String) == objectMapper.readTree('''
+            {
+              "error": {
+                "errors": [
+                  {
+                    "field": "foo",
+                    "rejectedValue": "Too Short",
+                    "message": "Property [foo] of class [class issue15228.app.ValidateableObject] with value [Too Short] is less than the minimum size of [10]"
+                  }
+                ]
+              }
+            }''')
+    }
+
+    void 'respond with gson view from action name'() {
+        when: 'The app controller is visited on normalView'
+        def request = HttpRequest.GET('/app/normalView?foo=Testing+normal+view').accept(MediaType.APPLICATION_JSON)
+        def response = httpClient.toBlocking().exchange(request, String)
+
+        then:
+        objectMapper.readTree(response.body() as String) == objectMapper.readTree('''{
+              "normal": {
+                "foo": "Testing normal view"
+              } 
+           }''')
+    }
+
+    void 'respond with gson view from type'() {
+        when: 'The app controller is visited on typeView'
+        def request = HttpRequest.GET('/app/typeView?foo=Testing+type+view').accept(MediaType.APPLICATION_JSON)
+        def response = httpClient.toBlocking().exchange(request, String)
+
+        then:
+        objectMapper.readTree(response.body() as String) == objectMapper.readTree('''{
+              "type": {
+                "foo": "Testing type view"
+              } 
+           }''')
+    }
+
+}

--- a/grails-test-examples/issue-15228/src/main/groovy/issue15228/app/OtherValidateableObject.groovy
+++ b/grails-test-examples/issue-15228/src/main/groovy/issue15228/app/OtherValidateableObject.groovy
@@ -16,28 +16,14 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.rest.render
+package issue15228.app
 
-import grails.web.mime.MimeTypeProvider
+import grails.validation.Validateable
 
-/**
- * Interface for class that render RESTful responses to implement
- *
- * @author Graeme Rocher
- * @since 2.3
- */
-interface Renderer<T> extends MimeTypeProvider {
-
-    /**
-     * @return The target type
-     */
-    Class<T> getTargetType()
-
-    /**
-     * Renders the object
-     *
-     * @param object The object to render
-     * @param context The {@link RenderContext}
-     */
-    void render(Object object, RenderContext context)
+class OtherValidateableObject implements Validateable {
+    String foo
+    
+    static constraints = {
+        foo minSize: 10
+    }
 }

--- a/grails-test-examples/issue-15228/src/main/groovy/issue15228/app/ValidateableObject.groovy
+++ b/grails-test-examples/issue-15228/src/main/groovy/issue15228/app/ValidateableObject.groovy
@@ -16,28 +16,14 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.rest.render
+package issue15228.app
 
-import grails.web.mime.MimeTypeProvider
+import grails.validation.Validateable
 
-/**
- * Interface for class that render RESTful responses to implement
- *
- * @author Graeme Rocher
- * @since 2.3
- */
-interface Renderer<T> extends MimeTypeProvider {
+class ValidateableObject implements Validateable {
+    String foo
 
-    /**
-     * @return The target type
-     */
-    Class<T> getTargetType()
-
-    /**
-     * Renders the object
-     *
-     * @param object The object to render
-     * @param context The {@link RenderContext}
-     */
-    void render(Object object, RenderContext context)
+    static constraints = {
+        foo minSize: 10
+    }
 }

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/BookSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/BookSpec.groovy
@@ -40,7 +40,7 @@ class BookSpec extends HttpClientSpec {
     def setupSpec() {
         objectMapper = new ObjectMapper()
     }
-
+    
     @RunOnce
     @BeforeEach
     void init() {
@@ -56,22 +56,17 @@ class BookSpec extends HttpClientSpec {
         HttpClientResponseException e = thrown()
         e.response.status == HttpStatus.UNPROCESSABLE_ENTITY
         e.response.headers.getFirst(HttpHeaders.CONTENT_TYPE).isPresent()
-        // This has changed somewhere along the way
-        // e.response.headers.getFirst(HttpHeaders.CONTENT_TYPE).get() == 'application/vnd.error;charset=UTF-8'
-        // to ->
-        e.response.headers.getFirst(HttpHeaders.CONTENT_TYPE).get() == 'application/json;charset=UTF-8'
-        objectMapper.readTree(e.response.body().toString()) == objectMapper.readTree('''
+        e.response.headers.getFirst(HttpHeaders.CONTENT_TYPE).get() == 'application/vnd.error;charset=UTF-8'
+        objectMapper.readTree(e.response.body().toString()) == objectMapper.readTree("""
             {
-                "errors": [
-                    {
-                        "object": "functional.tests.Book",
-                        "field": "title",
-                        "rejected-value": null,
-                        "message": "Property [title] of class [class functional.tests.Book] cannot be null"
-                    }
-                ]
-            }
-        ''')
+              "message": "Property [title] of class [class functional.tests.Book] cannot be null",
+              "path": "/book/index",
+              "_links": {
+                "self": {
+                  "href": "$baseUrl/book/index"
+                }
+              }
+            }""")
     }
 
     void 'Test REST view rendering'() {

--- a/grails-views-core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
+++ b/grails-views-core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
@@ -64,7 +64,7 @@ abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
     }
 
     @Override
-    void render(T object, RenderContext context) {
+    void render(Object object, RenderContext context) {
         def arguments = context.arguments
         def ct = arguments?.contentType
 

--- a/grails-views-gson/src/main/groovy/grails/plugin/json/renderer/AbstractJsonViewContainerRenderer.groovy
+++ b/grails-views-gson/src/main/groovy/grails/plugin/json/renderer/AbstractJsonViewContainerRenderer.groovy
@@ -25,6 +25,7 @@ import groovy.transform.InheritConstructors
 import org.springframework.beans.factory.annotation.Autowired
 
 import grails.plugin.json.view.mvc.JsonViewResolver
+import grails.rest.render.ContainerRenderer
 import grails.rest.render.RenderContext
 import grails.util.GrailsNameUtils
 import grails.views.Views
@@ -39,13 +40,13 @@ import org.grails.plugins.web.rest.render.json.DefaultJsonRenderer
  */
 @CompileStatic
 @InheritConstructors
-abstract class AbstractJsonViewContainerRenderer<C,T> extends DefaultJsonRenderer<T> {
+abstract class AbstractJsonViewContainerRenderer<C,T> extends DefaultJsonRenderer<T> implements ContainerRenderer<C,T> {
 
     @Autowired
     JsonViewResolver jsonViewResolver
 
     @Override
-    void render(T object, RenderContext context) {
+    void render(Object object, RenderContext context) {
         if (jsonViewResolver != null) {
             String viewUri = "/${context.controllerName}/_${GrailsNameUtils.getPropertyName(targetType)}"
             def webRequest = ((ServletRenderContext) context).getWebRequest()
@@ -68,12 +69,10 @@ abstract class AbstractJsonViewContainerRenderer<C,T> extends DefaultJsonRendere
                 def request = webRequest.currentRequest
                 def response = webRequest.currentResponse
                 view.render(model, request, response)
-            }
-            else {
+            } else {
                 super.render(object, context)
             }
-        }
-        else {
+        } else {
             super.render(object, context)
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -406,6 +406,7 @@ include(
         'grails-test-examples-plugins-loadafter',
         'grails-test-examples-plugins-issue11005',
         'grails-test-examples-issue-11767',
+        'grails-test-examples-issue-15228',
         'grails-test-examples-plugins-exploded',
         'grails-test-examples-plugins-issue-11767',
         'grails-test-examples-cache',
@@ -438,6 +439,7 @@ project(':grails-test-examples-plugins-loadsecond').projectDir = file('grails-te
 project(':grails-test-examples-plugins-loadafter').projectDir = file('grails-test-examples/plugins/loadafter')
 project(':grails-test-examples-plugins-issue11005').projectDir = file('grails-test-examples/plugins/issue11005')
 project(':grails-test-examples-issue-11767').projectDir = file('grails-test-examples/issue-11767')
+project(':grails-test-examples-issue-15228').projectDir = file('grails-test-examples/issue-15228')
 project(':grails-test-examples-plugins-exploded').projectDir = file('grails-test-examples/plugins/exploded')
 project(':grails-test-examples-plugins-issue-11767').projectDir = file('grails-test-examples/plugins/issue-11767')
 project(':grails-test-examples-cache').projectDir = file('grails-test-examples/cache')


### PR DESCRIPTION
* Re-enabled gson view resolver
* `ContainerRenderer` extends `Renderer` fix to generics parameter
  * consequence fix, that `Renderer` calls `render(T render, ...` changed to `render(Object render, ...` and thus contract changed back to pre Grails 7.0.x
* New test project to verify outcome.
Fixes #14199 
Fixes #15228 