### PR TITLE
fix #15237 - do not marshall static properties

### DIFF
--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GenericJavaBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GenericJavaBeanMarshaller.java
@@ -61,6 +61,7 @@ public class GenericJavaBeanMarshaller extends IncludeExcludePropertyMarshaller<
                 if (!shouldInclude(includeExcludeSupport, includes, excludes, o, name)) continue;
 
                 if (readMethod != null && !(name.equals("metaClass")) && !(name.equals("class"))) {
+                    if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
                     Object value = readMethod.invoke(o, (Object[]) null);

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GroovyBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GroovyBeanMarshaller.java
@@ -63,6 +63,7 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<JSON>
                 if (!shouldInclude(includeExcludeSupport, includes, excludes, o, name)) continue;
 
                 if (readMethod != null && !(name.equals("metaClass")) && !(name.equals("class"))) {
+                    if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
                     Object value = readMethod.invoke(o, (Object[]) null);

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GenericJavaBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GenericJavaBeanMarshaller.java
@@ -45,6 +45,7 @@ public class GenericJavaBeanMarshaller implements ObjectMarshaller<XML> {
                 String name = property.getName();
                 Method readMethod = property.getReadMethod();
                 if (readMethod != null) {
+                    if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     Object value = readMethod.invoke(o, (Object[]) null);
                     xml.startNode(name);
                     xml.convertAnother(value);

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GroovyBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GroovyBeanMarshaller.java
@@ -63,6 +63,7 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<XML> 
                 if (isEntity && (name.equals(GormProperties.ATTACHED) || name.equals(GormProperties.ERRORS))) continue;
                 Method readMethod = property.getReadMethod();
                 if (readMethod != null && !(name.equals("metaClass")) && !(name.equals("class"))) {
+                    if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
                     Object value = readMethod.invoke(o, (Object[]) null);

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/StaticPropertySpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/StaticPropertySpec.groovy
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.grails.web.converters.marshaller.json
 
 import spock.lang.Specification

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/StaticPropertySpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/StaticPropertySpec.groovy
@@ -1,0 +1,50 @@
+package org.grails.web.converters.marshaller.json
+
+import spock.lang.Specification
+
+import org.springframework.context.ApplicationContext
+
+import grails.converters.JSON
+import grails.core.DefaultGrailsApplication
+import grails.validation.Constrained
+import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
+
+class StaticPropertySpec extends Specification {
+    void initJson() {
+        final initializer = new ConvertersConfigurationInitializer()
+        def grailsApplication = new DefaultGrailsApplication(MyGroovyBean)
+        grailsApplication.initialise()
+        def mappingContext = new KeyValueMappingContext("json")
+        grailsApplication.setApplicationContext(Stub(ApplicationContext) {
+            getBean('grailsDomainClassMappingContext', MappingContext) >> {
+                mappingContext
+            }
+        })
+        grailsApplication.setMappingContext(mappingContext)
+        initializer.grailsApplication = grailsApplication
+        initializer.initialize()
+
+    }
+
+    void "static property should be excluded"() {
+        given:
+        initJson()
+
+        when:
+        MyGroovyBean bean = new MyGroovyBean(aProperty: 'testing')
+
+        then:
+        def jsonString = new JSON(bean).toString()
+        jsonString == '{"aProperty":"testing"}'
+    }
+}
+
+class MyGroovyBean {
+    static Map<String, Constrained> getConstraintsMap() {
+        [:]
+    }
+
+    String aProperty
+}

--- a/grails-test-suite-web/src/test/groovy/org/grails/plugins/web/rest/render/xml/DefaultXmlRendererSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/plugins/web/rest/render/xml/DefaultXmlRendererSpec.groovy
@@ -18,7 +18,6 @@
  */
 package org.grails.plugins.web.rest.render.xml
 
-import groovy.transform.CompileStatic
 import groovy.xml.XmlSlurper
 import grails.converters.XML
 import grails.core.DefaultGrailsApplication
@@ -36,7 +35,6 @@ import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockServletContext
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 /**
@@ -56,7 +54,6 @@ class DefaultXmlRendererSpec extends Specification implements DomainUnitTest<Xml
         ConvertersConfigurationHolder.clear()
     }
 
-    @PendingFeature(reason = 'java.lang.IllegalAccessException: class org.grails.web.converters.marshaller.xml.GenericJavaBeanMarshaller cannot access a member of class org.grails.datastore.mapping.model.MappingFactory$1 with modifiers "public"')
     void 'Test that XML renderer writes XML to the response for a domain instance'() {
         when: 'A domain instance is rendered'
             def renderer = new DefaultXmlRenderer(XmlBook)


### PR DESCRIPTION
In my application, we have a spot where we do `myCommandObject as JSON` and it wasn't marshaling.  Comparing to 6.x behavior, the static properties are now being returned by spring's helper utilities and need to be filtered.

Fixes https://github.com/apache/grails-core/issues/15237