### PR TITLE
Compatibility with Docker 29

### DIFF
--- a/grails-geb/src/testFixtures/resources/docker-java.properties
+++ b/grails-geb/src/testFixtures/resources/docker-java.properties
@@ -1,0 +1,2 @@
+# Workaround for running Testcontainers 1.x with Docker 29.0.0+
+api.version=1.44


### PR DESCRIPTION
Testcontainers 1.x is not by default compatible with Docker 29.0.0+ API.