### PR TITLE
Fix links to controllers with namespaces in create-app index.gsp

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/grails/templates/urlMappings.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/grails/templates/urlMappings.rocker.raw
@@ -27,6 +27,7 @@ package @project.getPackageName()
 class UrlMappings {
     static mappings = {
 @if(applicationType == ApplicationType.WEB || applicationType == ApplicationType.WEB_PLUGIN) {
+        "/$namespace/$controller/$action?/$id?(.$format)?" {}
         "/$controller/$action?/$id?(.$format)?"{
             constraints {
                 // apply constraints here

--- a/grails-forge/grails-forge-core/src/main/resources/gsp/index.gsp
+++ b/grails-forge/grails-forge-core/src/main/resources/gsp/index.gsp
@@ -71,7 +71,7 @@
                 <ul>
                     <g:each var="c" in="${grailsApplication.controllerClasses.sort { it.fullName } }">
                         <li class="controller">
-                            <g:link controller="${c.logicalPropertyName}">${c.fullName}</g:link>
+                            <g:link namespace="${c.namespace}" controller="${c.logicalPropertyName}">${c.fullName}</g:link>
                         </li>
                     </g:each>
                 </ul>

--- a/grails-profiles/web/skeleton/grails-app/controllers/@grails.codegen.defaultPackage.path@/UrlMappings.groovy
+++ b/grails-profiles/web/skeleton/grails-app/controllers/@grails.codegen.defaultPackage.path@/UrlMappings.groovy
@@ -3,6 +3,7 @@ package @grails.codegen.defaultPackage@
 class UrlMappings {
 
     static mappings = {
+        "/$namespace/$controller/$action?/$id?(.$format)?" {}
         "/$controller/$action?/$id?(.$format)?"{
             constraints {
                 // apply constraints here

--- a/grails-profiles/web/skeleton/grails-app/views/index.gsp
+++ b/grails-profiles/web/skeleton/grails-app/views/index.gsp
@@ -71,7 +71,7 @@
                 <ul>
                     <g:each var="c" in="${grailsApplication.controllerClasses.sort { it.fullName } }">
                         <li class="controller">
-                            <g:link controller="${c.logicalPropertyName}">${c.fullName}</g:link>
+                            <g:link namespace="${c.namespace}" controller="${c.logicalPropertyName}">${c.fullName}</g:link>
                         </li>
                     </g:each>
                 </ul>


### PR DESCRIPTION
Currently the default index.gsp is displaying the wrong links with controllers with namespaces. This fixes it so that the namespace is included in the url.