### PR TITLE
Solve BOM existential crisis - Fixes #15258

### DIFF
--- a/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/PropertyNameCalculator.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/PropertyNameCalculator.groovy
@@ -28,6 +28,8 @@ import org.gradle.api.plugins.JavaPlatformPlugin
  */
 class PropertyNameCalculator {
 
+    static final String GRAILS_VERSION_PROPERTY = 'grails.version'
+
     final Map<String, String> keysToPlatformCoordinates = [:]
     final Map<String, ExtractedDependencyConstraint> platformDefinitions = [:]
 
@@ -41,22 +43,21 @@ class PropertyNameCalculator {
         this.versions.putAll(definitionVersions)
     }
 
-    void addProjects(Collection<Project> projects) {
+    void addProjects(Collection<Project> projects, String grailsVersion) {
+        versions.put(GRAILS_VERSION_PROPERTY, grailsVersion)
+
         for (Project project : projects) {
             if (project.plugins.hasPlugin(JavaPlatformPlugin) || !project.extensions.findByName('grailsPublish')) {
                 continue
             }
 
             String artifactId = (project.findProperty('pomArtifactId') ?: project.name)
-            String baseVersionName = artifactId.replaceAll('-', '.')
-            String versionName = "${baseVersionName}.version" as String
             String coordinates = "${project.group}:${artifactId}:${project.version}" as String
             ExtractedDependencyConstraint constraint = new ExtractedDependencyConstraint(coordinates as String)
-            constraint.versionPropertyReference = "\${${versionName}}" as String
+            constraint.versionPropertyReference = "\${${GRAILS_VERSION_PROPERTY}}" as String
 
             definitions.put(coordinates, constraint)
-            keysToCoordinates.put(coordinates, baseVersionName)
-            versions.put(versionName, project.version as String)
+            keysToCoordinates.put(coordinates, 'grails')
         }
     }
 

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/PublishPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/PublishPlugin.groovy
@@ -183,16 +183,11 @@ class PublishPlugin implements Plugin<Project> {
                 it.url.set('https://apache.org/')
             }
             it.developers.set(project.provider { lookupProperty(project, 'pomDevelopers', determineDevelopers(project))})
+            it.pomCustomization = lookupProperty(project, 'pomCustomization') as Closure
             it.publishTestSources.set(project.provider { lookupProperty(project, 'pomPublishTestSources', false)})
             it.testRepositoryPath.set(project.provider { shouldSkipJavaComponent(project) ? null : findRootGrailsCoreDir(project).dir('build/local-maven')})
             it.publicationName.set(project.provider { lookupProperty(project, 'pomMavenPublicationName', 'maven')})
             it.addComponents.set(project.provider { !shouldSkipJavaComponent(project) && !project.pluginManager.hasPlugin('java-gradle-plugin')})
-        }
-
-        project.afterEvaluate {
-            project.extensions.configure(GrailsPublishExtension) {
-                it.pomCustomization = lookupProperty(project, 'pomCustomization') as Closure
-            }
         }
     }
 

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/PublishPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/PublishPlugin.groovy
@@ -183,11 +183,16 @@ class PublishPlugin implements Plugin<Project> {
                 it.url.set('https://apache.org/')
             }
             it.developers.set(project.provider { lookupProperty(project, 'pomDevelopers', determineDevelopers(project))})
-            it.pomCustomization = lookupProperty(project, 'pomCustomization') as Closure
             it.publishTestSources.set(project.provider { lookupProperty(project, 'pomPublishTestSources', false)})
             it.testRepositoryPath.set(project.provider { shouldSkipJavaComponent(project) ? null : findRootGrailsCoreDir(project).dir('build/local-maven')})
             it.publicationName.set(project.provider { lookupProperty(project, 'pomMavenPublicationName', 'maven')})
             it.addComponents.set(project.provider { !shouldSkipJavaComponent(project) && !project.pluginManager.hasPlugin('java-gradle-plugin')})
+        }
+
+        project.afterEvaluate {
+            project.extensions.configure(GrailsPublishExtension) {
+                it.pomCustomization = lookupProperty(project, 'pomCustomization') as Closure
+            }
         }
     }
 

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -39,15 +39,6 @@ javaPlatform {
     allowDependencies()
 }
 
-// Disable gradle (.module file) for the BOM only
-// This allows properties to be overridden with the Spring dependency management plugin
-// Also fixes older versions being resolved on transitive dependencies with updated parents
-afterEvaluate {
-    tasks.named('generateMetadataFileForMavenPublication').configure {
-        enabled = false
-    }
-}
-
 ext {
     isReleaseBuild = System.getenv('GRAILS_PUBLISH_RELEASE') == 'true'
     isPublishedExternal = System.getenv().containsKey('NEXUS_PUBLISH_STAGING_PROFILE_ID')

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -20,6 +20,7 @@
 import org.apache.grails.gradle.tasks.bom.ExtractDependenciesTask
 import org.apache.grails.gradle.tasks.bom.ExtractedDependencyConstraint
 import org.apache.grails.gradle.tasks.bom.PropertyNameCalculator
+import org.gradle.api.publish.tasks.GenerateModuleMetadata
 
 buildscript {
     apply from: rootProject.layout.projectDirectory.file('dependencies.gradle')
@@ -37,6 +38,12 @@ group = 'org.apache.grails'
 
 javaPlatform {
     allowDependencies()
+}
+
+// Disable Gradle Module Metadata (.module files) for the BOM
+// This allows properties to be overridden with the Spring dependency management plugin
+tasks.withType(GenerateModuleMetadata).configureEach {
+    enabled = false
 }
 
 ext {

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -167,6 +167,9 @@ ext {
         def deps = depMgmt?.dependencies?.getAt(0)
         if (deps) {
             Map<String, String> pomProperties = [:]
+            PropertyNameCalculator propertyNameCalculator = new PropertyNameCalculator(combinedPlatforms, combinedDependencies, combinedVersions)
+            propertyNameCalculator.addProjects(rootProject.subprojects, projectVersion)
+
             deps.dependency.each { dep ->
                 String groupId = dep.groupId.text().trim()
                 String artifactId = dep.artifactId.text().trim()
@@ -178,8 +181,6 @@ ext {
                 }
 
                 if (inlineVersion) {
-                    PropertyNameCalculator propertyNameCalculator = new PropertyNameCalculator(combinedPlatforms, combinedDependencies, combinedVersions)
-                    propertyNameCalculator.addProjects(rootProject.subprojects)
                     ExtractedDependencyConstraint extractedConstraint = propertyNameCalculator.calculate(groupId, artifactId, inlineVersion, isBom)
                     if (extractedConstraint?.versionPropertyReference) {
                         // use the property reference instead of the hard coded version so that it can be
@@ -190,18 +191,17 @@ ext {
                         pomProperties.put(extractedConstraint.versionPropertyName, inlineVersion)
                     }
 
-                    if (gradle.includedBuilds*.any { it.name == artifactId && groupId.startsWith('org.apache.grails') }) {
-                        String baseVersionName = artifactId.replaceAll('-', '.')
-                        String versionName = "${baseVersionName}.version" as String
-                        dep.version[0].value = "\${${versionName}}" as String
-                        pomProperties.put(versionName, inlineVersion)
+                    // For included builds (grails-gradle), also use grails.version
+                    if (gradle.includedBuilds.any { it.name == artifactId && groupId.startsWith('org.apache.grails') }) {
+                        dep.version[0].value = "\${${PropertyNameCalculator.GRAILS_VERSION_PROPERTY}}" as String
+                        pomProperties.put(PropertyNameCalculator.GRAILS_VERSION_PROPERTY, inlineVersion)
                     }
                 } else if (!inlineVersion) {
                     throw new GradleException("Dependency $groupId:$artifactId does not have a version.")
                 }
             }
 
-            for (Map.Entry<String, String> property : pomProperties.entrySet()) {
+            for (Map.Entry<String, String> property : pomProperties.sort().entrySet()) {
                 propertiesNode.appendNode(property.key, property.value)
             }
         }

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -20,7 +20,6 @@
 import org.apache.grails.gradle.tasks.bom.ExtractDependenciesTask
 import org.apache.grails.gradle.tasks.bom.ExtractedDependencyConstraint
 import org.apache.grails.gradle.tasks.bom.PropertyNameCalculator
-import org.gradle.api.publish.tasks.GenerateModuleMetadata
 
 buildscript {
     apply from: rootProject.layout.projectDirectory.file('dependencies.gradle')
@@ -40,10 +39,13 @@ javaPlatform {
     allowDependencies()
 }
 
-// Disable Gradle Module Metadata (.module files) for the BOM
+// Disable gradle (.module file) for the BOM only
 // This allows properties to be overridden with the Spring dependency management plugin
-tasks.withType(GenerateModuleMetadata).configureEach {
-    enabled = false
+// Also fixes older versions being resolved on transitive dependencies with updated parents
+afterEvaluate {
+    tasks.named('generateMetadataFileForMavenPublication').configure {
+        enabled = false
+    }
 }
 
 ext {


### PR DESCRIPTION
# Version naming should be Consistent and Properly Grouped and Should Match Spring Boot

When this PR was created, bom versioning didn't even work. Now with [7.04](https://repo1.maven.org/maven2/org/apache/grails/grails-bom/7.0.4/grails-bom-7.0.4.pom), we have things like
```xml
<spring-boot.version>3.5.8</spring-boot.version>
<spring.boot.cli.version>3.5.8</spring.boot.cli.version>
<spring.boot.gradle.plugin.version>3.5.8</spring.boot.gradle.plugin.version>
<spring.boot.dependencies.version>3.5.8</spring.boot.dependencies.version>
```
when the version should just be `spring-boot.version`

This fix allows me to go to sleep tonight...

1. Fixes version resolution
2. Sorts versions
3. Disables bom module file that breaks dependency management and actually forces wrong versions on transitive dependencies 
4. Removes 131 redundant versions

https://github.com/apache/grails-core/issues/15258

Gradle modules are not needed for the bom and prohibit the dependency management plugin

[Working M3 Bom Artifacts](https://repo1.maven.org/maven2/org/grails/grails-bom/7.0.0-M3/) 
[Broken M4 Bom Artifacts](https://repo1.maven.org/maven2/org/apache/grails/grails-bom/7.0.0-M4/) 

```
grails-bom-7.0.0-M3.pom       27207 <- everything working, no module file
grails-bom-7.0.0-M4.pom       28845 
grails-bom-7.0.0-M4.module    52007 <- forces versions on everything, version overrides broken
grails-bom-7.0.0-RC2.pom      41614 <- adds 131 versions 
grails-bom-7.0.0-RC2.module   54584
grails-bom-7.0.3.pom          26621 <- removes all versions from everything
grails-bom-7.0.3.module       52007
grails-bom-7.1.0-SNAPSHOT.pom 29781 <- no module, allows version overrides
```

# After this fix you can override any version just by modifying `gradle.properties`
This was not possible in 7.0.0-M4 -> 7.0.3
```properties
spring-boot.version=3.5.8
groovy.version=4.0.29
```


Spring Boot **_Does Not Use_** a `.module` file with their bom:
[3.5.8](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/3.5.8/)
[4.0.0](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/4.0.0/)
