### PR TITLE
#15258 - fix - restore bom properties

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/PublishPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/PublishPlugin.groovy
@@ -183,7 +183,7 @@ class PublishPlugin implements Plugin<Project> {
                 it.url.set('https://apache.org/')
             }
             it.developers.set(project.provider { lookupProperty(project, 'pomDevelopers', determineDevelopers(project))})
-            it.pomCustomization = lookupProperty(project, 'pomCustomization') as Closure
+            it.pomCustomization.set(project.provider { lookupProperty(project, 'pomCustomization') as Closure })
             it.publishTestSources.set(project.provider { lookupProperty(project, 'pomPublishTestSources', false)})
             it.testRepositoryPath.set(project.provider { shouldSkipJavaComponent(project) ? null : findRootGrailsCoreDir(project).dir('build/local-maven')})
             it.publicationName.set(project.provider { lookupProperty(project, 'pomMavenPublicationName', 'maven')})

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
             'commons-text.version'          : '1.13.1',
             'directory-watcher.version'     : '0.19.1',
             'gradle-spock.version'          : '2.3-groovy-3.0',
-            'grails-publish-plugin.version' : '0.0.2',
+            'grails-publish-plugin.version' : '0.0.3-SNAPSHOT',
             'jansi.version'                 : '1.18',
             'javaparser-core.version'       : '3.27.0',
             'jline.version'                 : '2.14.6',


### PR DESCRIPTION
This PR will fail until https://github.com/apache/grails-gradle-publish/pull/16 is merged.  Properties in the bom were broken because of not doing a deferred lookup of the pomCustomization closure.  This change adopts the provider syntax for pomCustomization so that the property isn't looked up until execution