### PR TITLE
webjars-locator-core dependency is now provided implicitly by asset-pipeline

### DIFF
--- a/grails-data-neo4j/examples/grails3-neo4j-hibernate/build.gradle
+++ b/grails-data-neo4j/examples/grails3-neo4j-hibernate/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     implementation "org.apache.grails:grails-data-hibernate5:$hibernateDatastoreVersion"
     implementation "org.hibernate:hibernate-ehcache:$hibernateEhcacheVersion"
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-data-neo4j/examples/grails3-neo4j/build.gradle
+++ b/grails-data-neo4j/examples/grails3-neo4j/build.gradle
@@ -30,7 +30,6 @@ dependencies {
 
     implementation project(":grails-plugin")
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-dependencies/assets/build.gradle
+++ b/grails-dependencies/assets/build.gradle
@@ -36,7 +36,6 @@ def configurations = [
                 'org.webjars.npm:bootstrap',
                 'org.webjars.npm:bootstrap-icons',
                 'org.webjars.npm:jquery',
-                'org.webjars:webjars-locator-core',
         ]
 ]
 

--- a/grails-doc/src/en/guide/commandLine/gradleBuild/gradleDependencies.adoc
+++ b/grails-doc/src/en/guide/commandLine/gradleBuild/gradleDependencies.adoc
@@ -28,7 +28,6 @@ dependencies {
     testAndDevelopmentOnly "org.webjars.npm:bootstrap"
     testAndDevelopmentOnly "org.webjars.npm:bootstrap-icons"
     testAndDevelopmentOnly "org.webjars.npm:jquery"
-    implementation 'org.webjars:webjars-locator-core'
     implementation platform("org.apache.grails:grails-bom:$grailsVersion")
     implementation "org.apache.grails:grails-core"
     implementation "org.apache.grails:grails-logging"

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/assetPipeline/AssetPipeline.java
@@ -77,11 +77,6 @@ public class AssetPipeline implements DefaultFeature {
                 .runtimeOnly());
 
         generatorContext.addDependency(Dependency.builder()
-                .groupId("org.webjars")
-                .artifactId("webjars-locator-core")
-                .implementation());
-
-        generatorContext.addDependency(Dependency.builder()
                 .groupId("org.webjars.npm")
                 .artifactId("bootstrap")
                 .testAndDevelopmentOnly());

--- a/grails-profiles/web/profile.yml
+++ b/grails-profiles/web/profile.yml
@@ -51,8 +51,6 @@ dependencies:
       coords: "org.apache.grails:grails-scaffolding"
     - scope: testImplementation
       coords: "org.apache.grails:grails-testing-support-web"
-    - scope: implementation
-      coords: "org.webjars:webjars-locator-core"
     - scope: testAndDevelopmentOnly
       coords: "org.webjars.npm:bootstrap"
     - scope: testAndDevelopmentOnly

--- a/grails-test-examples/app1/build.gradle
+++ b/grails-test-examples/app1/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'org.apache.grails:grails-cache'
     implementation 'org.apache.grails:grails-scaffolding'
 
-    implementation 'org.webjars:webjars-locator-core'
+
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/app2/build.gradle
+++ b/grails-test-examples/app2/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate5'
     implementation 'org.apache.grails:grails-cache'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/demo33/build.gradle
+++ b/grails-test-examples/demo33/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate5'
     implementation 'org.apache.grails:grails-views-gson'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'

--- a/grails-test-examples/geb-gebconfig/build.gradle
+++ b/grails-test-examples/geb-gebconfig/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-tomcat'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'

--- a/grails-test-examples/geb/build.gradle
+++ b/grails-test-examples/geb/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-tomcat'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'

--- a/grails-test-examples/gsp-layout/build.gradle
+++ b/grails-test-examples/gsp-layout/build.gradle
@@ -36,7 +36,6 @@ dependencies {
     implementation 'org.apache.grails:grails-controllers'
     implementation 'org.apache.grails:grails-rest-transforms'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'

--- a/grails-test-examples/gsp-sitemesh3/build.gradle
+++ b/grails-test-examples/gsp-sitemesh3/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     implementation 'org.apache.grails:grails-rest-transforms'
     implementation 'org.apache.grails:grails-sitemesh3'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'

--- a/grails-test-examples/hibernate5/grails-database-per-tenant/build.gradle
+++ b/grails-test-examples/hibernate5/grails-database-per-tenant/build.gradle
@@ -40,7 +40,6 @@ dependencies {
         implementation 'org.apache.grails:grails-layout'
     }
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/hibernate5/grails-hibernate/build.gradle
+++ b/grails-test-examples/hibernate5/grails-hibernate/build.gradle
@@ -42,7 +42,6 @@ dependencies {
         implementation 'org.apache.grails:grails-layout'
     }
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/build.gradle
+++ b/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/build.gradle
@@ -40,7 +40,6 @@ dependencies {
         implementation 'org.apache.grails:grails-layout'
     }
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/hibernate5/grails-schema-per-tenant/build.gradle
+++ b/grails-test-examples/hibernate5/grails-schema-per-tenant/build.gradle
@@ -40,7 +40,6 @@ dependencies {
         implementation 'org.apache.grails:grails-layout'
     }
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/hibernate5/issue450/build.gradle
+++ b/grails-test-examples/hibernate5/issue450/build.gradle
@@ -40,7 +40,6 @@ dependencies {
         implementation 'org.apache.grails:grails-layout'
     }
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'

--- a/grails-test-examples/hyphenated/build.gradle
+++ b/grails-test-examples/hyphenated/build.gradle
@@ -42,7 +42,6 @@ dependencies {
 
     implementation 'org.apache.grails:grails-data-hibernate5'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/issue-11102/build.gradle
+++ b/grails-test-examples/issue-11102/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     implementation 'org.apache.grails:grails-events'
     implementation 'org.apache.grails:grails-gsp'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'

--- a/grails-test-examples/mongodb/base/build.gradle
+++ b/grails-test-examples/mongodb/base/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     }
     implementation 'org.apache.grails:grails-gsp'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/mongodb/database-per-tenant/build.gradle
+++ b/grails-test-examples/mongodb/database-per-tenant/build.gradle
@@ -40,7 +40,6 @@ dependencies {
         implementation 'org.apache.grails:grails-layout'
     }
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/mongodb/gson-templates/build.gradle
+++ b/grails-test-examples/mongodb/gson-templates/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation 'org.apache.grails:grails-url-mappings'
     implementation 'org.apache.grails.data:grails-data-mongodb-core'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/mongodb/hibernate5/build.gradle
+++ b/grails-test-examples/mongodb/hibernate5/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     }
     implementation 'org.apache.grails:grails-data-hibernate5'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/namespaces/build.gradle
+++ b/grails-test-examples/namespaces/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate5'
     implementation 'org.apache.grails:grails-cache'
 
-    implementation 'org.webjars:webjars-locator-core'
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 

--- a/grails-test-examples/scaffolding/build.gradle
+++ b/grails-test-examples/scaffolding/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation "org.apache.grails:grails-scaffolding"
     implementation "org.apache.grails:grails-data-hibernate5"
     implementation "org.apache.grails:grails-gsp"
-    implementation 'org.webjars:webjars-locator-core'
     integrationTestImplementation testFixtures("org.apache.grails:grails-geb")
     profile "org.apache.grails.profiles:web"
     runtimeOnly "org.fusesource.jansi:jansi"

--- a/grails-test-examples/views-functional-tests/build.gradle
+++ b/grails-test-examples/views-functional-tests/build.gradle
@@ -58,8 +58,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-autoconfigure'
     implementation 'org.springframework.boot:spring-boot-starter-logging'
     implementation 'org.springframework.boot:spring-boot-starter-tomcat'
-
-    implementation 'org.webjars:webjars-locator-core'
+    
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 


### PR DESCRIPTION
Removes the explicit 'org.webjars:webjars-locator-core' dependency from multiple build.gradle files, documentation, profile configuration, and asset pipeline feature.