### PR TITLE
Issue 14379 remove dependency to tomcat embed logging log4j

### DIFF
--- a/grails-data-graphql/core/build.gradle
+++ b/grails-data-graphql/core/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     testImplementation 'com.github.fakemongo:fongo:2.1.1'
     testImplementation 'com.h2database:h2:2.2.224'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:8.5.97'
-    testImplementation "org.apache.tomcat.embed:tomcat-embed-logging-log4j:8.5.2"
     testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 }
 

--- a/grails-data-graphql/examples/spring-boot-app/build.gradle
+++ b/grails-data-graphql/examples/spring-boot-app/build.gradle
@@ -52,7 +52,6 @@ dependencies {
 	implementation 'junit:junit'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.apache.tomcat:tomcat-jdbc'
-	runtimeOnly "org.apache.tomcat.embed:tomcat-embed-logging-log4j"
 	implementation 'jakarta.persistence:jakarta.persistence-api'
 
 	runtimeOnly "javax.el:javax.el-api"

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/gettingStarted/outsideGrails.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/gettingStarted/outsideGrails.adoc
@@ -17,21 +17,21 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-If you wish to use GORM for Hibernate outside of a Grails application you should declare the necessary dependencies for GORM and the database you are using, for example in Gradle:
+If you wish to use GORM for Hibernate outside a Grails application you should declare the necessary dependencies for GORM and the database you are using, for example in Gradle:
 
 [source,groovy,subs="attributes"]
 ----
-compile "org.apache.grails.data:grails-data-hibernate5-core:{version}"
-runtime "com.h2database:h2:1.4.192"
-runtime "org.apache.tomcat:tomcat-jdbc:8.5.0"
-runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:8.5.0"
-runtime "org.slf4j:slf4j-api:1.7.10"
+implementation platform("org.apache.grails:{version}")
+implementation "org.apache.grails.data:grails-data-hibernate5-core"
+runtimeOnly "com.h2database"
+runtimeOnly "org.apache.tomcat:tomcat-jdbc"
+runtimeOnly "org.slf4j:slf4j-nop"
 ----
 
 NOTE: The above example also uses the https://www.h2database.com[H2 Database] and Tomcat connection pool.
-However other pool implementations are supported including `commons-dbcp`, `tomcat pool` or `hikari`.
+However, other pool implementations are supported including `commons-dbcp`, `tomcat pool` or `hikari`.
 If a connection pool is not specified `org.springframework.jdbc.datasource.DriverManagerDataSource` is used,
-which creates a new connection to the database each time you request a connect.
+which creates a new connection to the database each time you request a connection.
 The latter will probably cause issues with an H2 in-memory database in that it will create a new in-memory
 database each time a connection is requested, losing previously created tables.
 Normal databases (`MySql`, `Postgres` or even file-based `H2`) are not affected.
@@ -40,6 +40,9 @@ Then create your entities in the `src/main/groovy` directory and annotate them w
 
 [source,groovy]
 ----
+import grails.gorm.annotation.Entity
+import org.grails.datastore.gorm.GormEntity
+
 @Entity
 class Person implements GormEntity<Person> { // <1>
     String firstName

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/gettingStarted/outsideGrails.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/gettingStarted/outsideGrails.adoc
@@ -21,7 +21,7 @@ If you wish to use GORM for Hibernate outside a Grails application you should de
 
 [source,groovy,subs="attributes"]
 ----
-implementation platform("org.apache.grails:{version}")
+implementation platform("org.apache.grails:grails-bom:{version}")
 implementation "org.apache.grails.data:grails-data-hibernate5-core"
 runtimeOnly "com.h2database"
 runtimeOnly "org.apache.tomcat:tomcat-jdbc"


### PR DESCRIPTION
Issue 14379 Remove dependency to tomcat-embed-logging-log4j

Fixes https://github.com/apache/grails-core/issues/14379

The dependency `tomcat-embed-logging-log4j` is old, unmaintained and
should not be used.

Updated Hibernate documentation and related example.

Removed `tomcat-embed-logging-log4j` dependency from GraphQL
The GraphQL code is not active in the grails-core project but I removed
the dependency anyway - it should not be there if we reintroduce the
code again.
