### PR TITLE
Remove explicit `groovy` and `java-library` from `grails-layout`

### DIFF
--- a/grails-gsp/grails-layout/build.gradle
+++ b/grails-gsp/grails-layout/build.gradle
@@ -17,8 +17,6 @@
  *  under the License.
  */
 plugins {
-    id 'groovy'
-    id 'java-library'
     id 'project-report'
     id 'org.apache.grails.gradle.grails-plugin'
     id 'org.apache.grails.buildsrc.publish'


### PR DESCRIPTION
They get applied by `grails-plugin`.