### PR TITLE
Fix: Preserve deterministic Map ordering in UrlMappingsInfoHandlerAdapter

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/UrlMappingsInfoHandlerAdapter.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/UrlMappingsInfoHandlerAdapter.groovy
@@ -121,7 +121,7 @@ class UrlMappingsInfoHandlerAdapter implements HandlerAdapter, ApplicationContex
                 }
                 else if (result instanceof Map) {
                     String viewName = controllerClass.actionUriToViewName(action)
-                    def finalModel = new HashMap<String, Object>()
+                    def finalModel = new LinkedHashMap<String, Object>()
                     def flashScope = webRequest.getFlashScope()
                     if (!flashScope.isEmpty()) {
                         def chainModel = flashScope.get(FlashScope.CHAIN_MODEL)


### PR DESCRIPTION
This PR addresses the issue reported in  [#15281](https://github.com/apache/grails-core/issues/15281).

Starting from **Grails 3.x**, the framework switched to using `HashMap` when assembling the controller result model.  
Because `HashMap` does not guarantee insertion order, Maps returned by controllers may reach interceptors and filters with their fields in a different order than the one originally defined.  
This behavior has continued unchanged up to the current releases.

This PR updates the implementation of `UrlMappingsInfoHandlerAdapter` to use `LinkedHashMap`, restoring deterministic ordering consistent with Grails 2.

Only the relevant code path was modified, and no additional behavior was affected.
