### PR TITLE
Add IntelliJ IDEA Enhanced HotSwap to reloading guide

### DIFF
--- a/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
+++ b/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-Spring Boot Developer Tools, JRebel, and Hotswap Agent are tools designed to improve developer productivity by enabling application reloading during development, reducing the need for full application restarts. Since Grails is built on Spring Boot, all three tools are compatible, but they differ in mechanisms, features, and trade-offs. Spring Boot Developer Tools is the default in Grails, replacing older agents like Spring Loaded (no longer maintained and lacking support for Java 17+). Hotswap Agent and JRebel offer more advanced "true" hot swapping capabilities.
+Spring Boot Developer Tools, JRebel, IntelliJ IDEA Enhanced HotSwap in Debug Mode and Hotswap Agent are tools designed to improve developer productivity by enabling application reloading during development, reducing the need for full application restarts. Since Grails is built on Spring Boot, all three tools are compatible, but they differ in mechanisms, features, and trade-offs. Spring Boot Developer Tools is the default in Grails, replacing older agents like Spring Loaded (no longer maintained and lacking support for Java 17+). Hotswap Agent and JRebel offer more advanced "true" hot swapping capabilities.
 
 === Spring Boot Developer Tools
 
@@ -38,7 +38,18 @@ JRebel is a commercial tool that provides advanced hot swapping capabilities, al
 
 Please see the JRebel documentation for more details: https://manuals.jrebel.com/jrebel/standalone/springboot.html[JRebel].
 
+JRebel plugin for IntelliJ IDEA: https://plugins.jetbrains.com/plugin/4441-jrebel-and-xrebel[JRebel IntelliJ Plugin].
+
 *Reloading Mechanism:* True hot swapping via bytecode instrumentation; reloads classes, configurations, and resources without restarting the JVM, preserving application state.
+
+=== IntelliJ IDEA Enhanced HotSwap in Debug Mode
+IntelliJ IDEA Enhanced HotSwap is a feature available in the IntelliJ IDEA IDE that allows developers to reload code changes while debugging their applications. When running a Grails application in debug mode, IntelliJ IDEA can reload modified classes without requiring a full application restart. This feature is particularly useful for making quick changes and testing them during a debugging session.
+
+*Reloading Mechanism:* Enhanced hot swapping using IntelliJ's debugging capabilities; reloads modified classes during a debug session, with limitations on structural changes.
+
+Please see the IntelliJ IDEA documentation for more details: https://www.jetbrains.com/help/idea/altering-the-program-s-execution-flow.html#reload_classes[IntelliJ IDEA Enhanced HotSwap].
+
+Using https://github.com/JetBrains/JetBrainsRuntime[Jetbrains' Runtime] and jvmArgs `-XX:+AllowEnhancedClassRedefinition` on the `bootRun` task overcomes some of these limitations.
 
 === Hotswap Agent
 

--- a/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
+++ b/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-Spring Boot Developer Tools, JRebel, IntelliJ IDEA Enhanced HotSwap in Debug Mode and Hotswap Agent are tools designed to improve developer productivity by enabling application reloading during development, reducing the need for full application restarts. Since Grails is built on Spring Boot, all four tools are compatible, but they differ in mechanisms, features, and trade-offs. Spring Boot Developer Tools is the default in Grails, replacing older agents like Spring Loaded (no longer maintained and lacking support for Java 17+). Hotswap Agent and JRebel offer more advanced "true" hot swapping capabilities.
+Spring Boot Developer Tools, JRebel, IntelliJ IDEA Enhanced HotSwap in Debug Mode, and Hotswap Agent are tools designed to improve developer productivity by enabling application reloading during development, reducing the need for full application restarts. Since Grails is built on Spring Boot, all four tools are compatible, but they differ in mechanisms, features, and trade-offs. Spring Boot Developer Tools is the default in Grails, replacing older agents like Spring Loaded (no longer maintained and lacking support for Java 17+). Hotswap Agent and JRebel offer more advanced "true" hot swapping capabilities.
 
 === Spring Boot Developer Tools
 

--- a/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
+++ b/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
@@ -49,7 +49,7 @@ IntelliJ IDEA Enhanced HotSwap is a feature available in the IntelliJ IDEA IDE t
 
 Please see the IntelliJ IDEA documentation for more details: https://www.jetbrains.com/help/idea/altering-the-program-s-execution-flow.html#reload_classes[IntelliJ IDEA Enhanced HotSwap].
 
-Using https://github.com/JetBrains/JetBrainsRuntime[Jetbrains' Runtime] and jvmArgs `-XX:+AllowEnhancedClassRedefinition` on the `bootRun` task overcomes some of these limitations.
+Using https://github.com/JetBrains/JetBrainsRuntime[JetBrains' Runtime] and jvmArgs `-XX:+AllowEnhancedClassRedefinition` on the `bootRun` task overcomes some of these limitations.
 
 === Hotswap Agent
 

--- a/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
+++ b/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
@@ -38,7 +38,7 @@ JRebel is a commercial tool that provides advanced hot swapping capabilities, al
 
 Please see the JRebel documentation for more details: https://manuals.jrebel.com/jrebel/standalone/springboot.html[JRebel].
 
-JRebel plugin for IntelliJ IDEA: https://plugins.jetbrains.com/plugin/4441-jrebel-and-xrebel[JRebel IntelliJ Plugin].
+Alternatively, use the JRebel plugin for IntelliJ IDEA: https://plugins.jetbrains.com/plugin/4441-jrebel-and-xrebel[JRebel IntelliJ Plugin].
 
 *Reloading Mechanism:* True hot swapping via bytecode instrumentation; reloads classes, configurations, and resources without restarting the JVM, preserving application state.
 

--- a/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
+++ b/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-Spring Boot Developer Tools, JRebel, IntelliJ IDEA Enhanced HotSwap in Debug Mode and Hotswap Agent are tools designed to improve developer productivity by enabling application reloading during development, reducing the need for full application restarts. Since Grails is built on Spring Boot, all three tools are compatible, but they differ in mechanisms, features, and trade-offs. Spring Boot Developer Tools is the default in Grails, replacing older agents like Spring Loaded (no longer maintained and lacking support for Java 17+). Hotswap Agent and JRebel offer more advanced "true" hot swapping capabilities.
+Spring Boot Developer Tools, JRebel, IntelliJ IDEA Enhanced HotSwap in Debug Mode and Hotswap Agent are tools designed to improve developer productivity by enabling application reloading during development, reducing the need for full application restarts. Since Grails is built on Spring Boot, all four tools are compatible, but they differ in mechanisms, features, and trade-offs. Spring Boot Developer Tools is the default in Grails, replacing older agents like Spring Loaded (no longer maintained and lacking support for Java 17+). Hotswap Agent and JRebel offer more advanced "true" hot swapping capabilities.
 
 === Spring Boot Developer Tools
 


### PR DESCRIPTION
Updated the development reloading documentation to include IntelliJ IDEA Enhanced HotSwap in Debug Mode as a supported tool for hot code reloading in Grails. Added details about its mechanism, usage, and relevant documentation links, as well as a note on overcoming limitations with JetBrains Runtime.

Added link to JRebel IntelliJ Plugin.