### PR TITLE
documentation - removing old coordinates, assume the bom is applied, and add rxjava3 references

### DIFF
--- a/grails-doc/src/en/guide/async/asyncGorm.adoc
+++ b/grails-doc/src/en/guide/async/asyncGorm.adoc
@@ -28,7 +28,7 @@ Since Grails 3.3, the asynchronous part of GORM is optional. To enable it you fi
 [source,groovy]
 .build.gradle
 ----
-implementation "org.grails:grails-datastore-gorm-async"
+implementation "org.apache.grails:grails-datamapping-async"
 ----
 
 Then in your domain classes you wish to allow asynchronous processing you should use the `AsyncEntity` trait:

--- a/grails-doc/src/en/guide/async/asyncPromises.adoc
+++ b/grails-doc/src/en/guide/async/asyncPromises.adoc
@@ -24,7 +24,7 @@ To use the Grails Promise abstraction you should add a dependency on the `async`
 [source,groovy,subs="attributes"]
 .build.gradle
 ----
-implementation "org.apache.grails:grails-async:{version}"
+implementation "org.apache.grails:grails-async"
 ----
 
 === Promise Basics
@@ -98,7 +98,7 @@ However, the design of the Grails promises framework is such that you can swap o
 [source,groovy,subs="attributes"]
 .build.gradle
 ----
-runtimeOnly "org.grails:grails-async-rxjava:{GrailsVersion}"
+runtimeOnly 'org.apache.grails.async:grails-async-rxjava3'
 ----
 
 With the above in place RxJava 1.x will be used to create `Promise` instances.
@@ -120,6 +120,10 @@ The following table summarizes the available implementation and the dependency t
 |RxJava 2.x
 |`grails-async-rxjava2`
 |`org.grails.async.factory.rxjava2.RxPromiseFactory`
+
+|RxJava 3.x
+|`grails-async-rxjava3`
+|`org.grails.async.factory.rxjava3.RxPromiseFactory`
 
 |===
 

--- a/grails-doc/src/en/guide/async/events.adoc
+++ b/grails-doc/src/en/guide/async/events.adoc
@@ -26,7 +26,7 @@ To use the Grails Events abstraction you should add a dependency on the `events`
 [source,groovy,subs="attributes"]
 .build.gradle
 ----
-implementation "org.apache.grails:grails-events:{version}"
+implementation 'org.apache.grails:grails-events'
 ----
 
 If no asynchronous framework is present on the classpath then by default Grails creates an EventBus based off of the currently active `PromiseFactory`. The default implementation is link:{api}org/grails/async/factory/future/CachedThreadPoolPromiseFactory.html[CachedThreadPoolPromiseFactory] which uses a thread pool that will create threads as needed (the same as `java.util.concurrent.Executors.newCachedThreadPool()`).
@@ -36,7 +36,7 @@ If you wish to use a popular async framework such as RxJava as the `EventBus` im
 [source,groovy,subs="attributes"]
 .build.gradle
 ----
-runtimeOnly "org.grails:grails-events-rxjava:{GrailsVersion}"
+runtimeOnly 'org.apache.grails.events:grails-events-rxjava3'
 ----
 
 The following table summarizes async framework support and the necessary dependency:

--- a/grails-doc/src/en/guide/async/rxjava.adoc
+++ b/grails-doc/src/en/guide/async/rxjava.adoc
@@ -26,7 +26,7 @@ To get started simply declare a dependency on the plugin in `build.gradle`:
 ----
 dependencies {
     //...
-    implementation 'org.apache.grails:grails-rxjava:{version}'
+    implementation 'org.apache.grails:grails-rxjava3'
 }
 ----
 

--- a/grails-doc/src/en/guide/commandLine.adoc
+++ b/grails-doc/src/en/guide/commandLine.adoc
@@ -222,7 +222,7 @@ Grails now utilizes the Gradle Build System for project management. The project'
 [source, groovy]
 ----
 plugins {
-    id 'org.apache.grails.gradle.grails-web' version 'x.y.z' // Grails plugin
+    id 'org.apache.grails.gradle.grails-web' version "{version}" // Grails Application Gradle Plugin
 }
 
 repositories {
@@ -230,8 +230,9 @@ repositories {
 }
 
 dependencies {
+    implementation platform("org.apache.grails:grails-bom:{version}")
     implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.grails:grails-core'
+    implementation 'org.apache.grails:grails-core'
     // Add more dependencies as needed...
 }
 ----

--- a/grails-doc/src/en/guide/commandLine/gradleBuild/gradleDependencies.adoc
+++ b/grails-doc/src/en/guide/commandLine/gradleBuild/gradleDependencies.adoc
@@ -62,16 +62,16 @@ Note that version numbers are not present in the majority of the dependencies.
 
 This is thanks to the Spring dependency management plugin which automatically configures `grails-bom` as a Maven BOM via the Grails Gradle Plugin.  This defines the default dependency versions for most commonly used dependencies and plugins.
 
-For a Grails App, applying `org.grails:grails-gradle-plugin` will automatically configure the `grails-bom`.  No other steps required.
+For a Grails App, applying `org.apache.grails.gradle.grails-web` will automatically configure the `grails-bom`.  No other steps required.
 
-For Plugins and Projects which do not use `org.grails:grails-gradle-plugin`, you can apply the `grails-bom` in one of the following two ways.
+For Plugins and Projects which do not use `org.apache.grails.gradle.grails-web`, you can apply the `grails-bom` in one of the following two ways.
 
 build.gradle, using Gradle Platforms:
 [source,groovy]
 ----
 dependencies {
     implementation platform("org.apache.grails:grails-bom:{GrailsVersion}")
-    // all other dependencies
+    //...
 }
 ----
 

--- a/grails-doc/src/en/guide/profiles/profileStructure.adoc
+++ b/grails-doc/src/en/guide/profiles/profileStructure.adoc
@@ -112,9 +112,9 @@ A map of scopes and dependencies to configure. The `excludes` scope can be used 
 ----
 dependencies:
     - scope: excludes
-      coords: "org.grails:hibernate:*"
+      coords: "org.apache.grails:grails-data-hibernate5:*"
     - scope: build
-      coords: "org.grails:grails-gradle-plugin:$grailsVersion"
+      coords: "org.apache.grails:grails-gradle-plugins:{GrailsVersion}"
     - scope: compile
       coords: "org.springframework.boot:spring-boot-starter-logging"
     - scope: compile

--- a/grails-doc/src/en/guide/scaffolding.adoc
+++ b/grails-doc/src/en/guide/scaffolding.adoc
@@ -28,7 +28,7 @@ The way for an application to express a dependency on the scaffolding plugin is 
 ----
 dependencies {
         // ...
-        implementation "org.apache.grails:grails-scaffolding:{version}"
+        implementation "org.apache.grails:grails-scaffolding"
         // ...
     }
 ----

--- a/grails-doc/src/en/guide/testing/unitTesting/installation.adoc
+++ b/grails-doc/src/en/guide/testing/unitTesting/installation.adoc
@@ -21,7 +21,7 @@ To install the unit testing support library add the following dependency to the
 `dependencies` block of your `build.gradle` in a Grails application or plugin:
 
 [source,groovy,subs="attributes"]
-testCompile "org.grails:grails-gorm-testing-support:{version}"
-testCompile "org.grails:grails-web-testing-support:{version}"
+testCompile "org.apache.grails:grails-testing-support-datamapping"
+testCompile "org.apache.grails:grails-testing-support-web"
 
 NOTE: The dependencies are only required to implement unit tests for Grails Artifacts. Also, if you are not unit testing domain activity, you may not need the GORM testing support library.

--- a/grails-doc/src/en/guide/theWebLayer/fields/fieldsInstallation.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/fields/fieldsInstallation.adoc
@@ -22,6 +22,6 @@ The plugin is available on Maven Central and should be a dependency like this:
 [source,groovy,subs="attributes"]
 ---- 
 dependencies {
-    implementation 'org.apache.grails:grails-fields:{version}'
+    implementation 'org.apache.grails:grails-fields'
 }
 ----

--- a/grails-doc/src/en/guide/theWebLayer/fields/scaffolding/installation/index.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/fields/scaffolding/installation/index.adoc
@@ -23,7 +23,7 @@ To start using this library, there are only a couple simple steps:
 
 . Import the library in your `build.gradle`
 [source,groovy,subs="attributes",indent=1]
-compile "org.grails:scaffolding-core:{version}"
+compile "org.apache.grails:grails-scaffolding"
 . Register the scaffolding core bean configuration link:{api}org/grails/scaffolding/ScaffoldingBeanConfiguration.html[ScaffoldingBeanConfiguration]
 [source,groovy,indent=1]
 scaffoldingBeanConfiguration(ScaffoldingBeanConfiguration)

--- a/grails-doc/src/en/guide/theWebLayer/gson/gsonTesting.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gson/gsonTesting.adoc
@@ -84,6 +84,6 @@ Since the release of json views, a new testing framework was released for Grails
 
 The new trait works exactly the same way as the old one, however since the new trait is designed to work with the new framework, there are several benefits you can take advantage of. The first is configuration. In the old trait the application configuration was not included in the template engine, which had the potential to produce incorrect results. Other benefits include extensibility and features like `@OnceBefore`.
 
-To get started, add the `org.grails:views-json-testing-support:{version}` dependency to your project and implement the link:{api}grails/views/json/test/JsonViewUnitTest.html[JsonViewUnitTest] trait in your test instead of `JsonViewTest`.
+To get started, add the `org.apache.grails:grails-testing-support-views-gson` dependency to your project and implement the link:{api}grails/views/json/test/JsonViewUnitTest.html[JsonViewUnitTest] trait in your test instead of `JsonViewTest`.
 
 NOTE: The new testing trait, like the testing framework, requires Spock.

--- a/grails-doc/src/en/guide/theWebLayer/gson/jsonInstallation.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gson/jsonInstallation.adoc
@@ -27,15 +27,15 @@ implementation "org.apache.grails:grails-views-gson"
 otherwise, add the version explicitly:
 
 [source,groovy,subs="attributes"]
-implementation "org.apache.grails:grails-views-gson:{version}"
+implementation "org.apache.grails:grails-views-gson"
 
 To enable Gradle compilation of JSON views for production environment add the following to the `buildscript` `dependencies` block:
 
 [source,groovy,subs="attributes"]
 buildscript {
-    ...
+    //...
     dependencies {
-        ...
+        //...
         classpath platform("org.apache.grails:grails-gradle-bom:{version}")
         classpath "org.apache.grails:grails-gradle-plugins"
     }

--- a/grails-doc/src/en/guide/theWebLayer/gson/pluginSupport.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gson/pluginSupport.adoc
@@ -38,7 +38,8 @@ buildscript {
         maven { url "https://repo.grails.org/grails/restricted" }
     }
     dependencies {
-        classpath "org.grails.plugins:views-gradle:{version}"
+        classpath platform('org.apache.grails:grails-bom:{version}')
+        classpath "org.apache.grails:grails-gradle-plugins"
     }
 }
 
@@ -51,9 +52,8 @@ repositories {
 }
 
 dependencies {
-    compile "org.grails.plugins:views-json:{version}"
-    compileOnly "org.grails:grails-plugin-rest:3.1.7"
-    compileOnly "jakarta.servlet:jakarta.servlet-api:6.0.0"
+    implementation "org.apache.grails:grails-views-gson"
+    implementation "org.apache.grails:grails-rest-transforms"
 }
 
 task( compileViews, type:JsonViewCompilerTask ) {

--- a/grails-doc/src/en/guide/theWebLayer/gsp.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp.adoc
@@ -28,7 +28,7 @@ GSP was previously part of Grails core, but since version 3.3 it is an independe
 ----
 dependencies {
     //...
-    implementation "org.apache.grails:grails-gsp:{version}"
+    implementation "org.apache.grails:grails-gsp"
 }
 ----
 

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/usingJSPTagLibraries.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/usingJSPTagLibraries.adoc
@@ -26,7 +26,7 @@ In order to use JSP support you must ensure you have the `grails-web-jsp` depend
 ----
 dependencies {
     //...
-    runtimeOnly "org.grails:grails-web-jsp:{version}"
+    runtimeOnly "org.apache.grails.views:grails-web-jsp"
 }
 ----
 

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -85,7 +85,7 @@ Grails 7 introduces a BOM that includes all the dependencies required for a Grai
 .build.gradle
 ----
 dependencies {
-    implementation platform("org.apache.grails:grails-bom:${grailsVersion}")
+    implementation platform("org.apache.grails:grails-bom:{GrailsVersion}")
 }
 ----
 


### PR DESCRIPTION
Should address https://github.com/apache/grails-core/issues/15285

* I'm removing a hard coded GrailsVersion (except on the bom) since we can assume either the dependency management plugin or the gradle bom has been applied.  
* adjusting old coordinates to the newer coordinates
* consistent `// ...` to indicate that other Grails dependencies can be included
* prefer rxjava3 over rxjava1 since rxjava1 is the original version
* add rxjava3 to the events documentation