### PR TITLE
Compatibility with Docker 29

### DIFF
--- a/grails-data-mongodb/boot-plugin/src/test/resources/docker-java.properties
+++ b/grails-data-mongodb/boot-plugin/src/test/resources/docker-java.properties
@@ -1,0 +1,2 @@
+# Workaround for running Testcontainers 1.x with Docker 29.0.0+
+api.version=1.44


### PR DESCRIPTION
Testcontainers 1.x is not by default compatible with Docker 29.0.0+ API.