### PR TITLE
Issue 15254 docs issues tag library documentation

### DIFF
--- a/grails-doc/src/en/ref/Servlet API/servletContext.adoc
+++ b/grails-doc/src/en/ref/Servlet API/servletContext.adoc
@@ -25,7 +25,7 @@ under the License.
 === Purpose
 
 
-The servletContext object is an instance of the Servlet API's {jakartaee}jakarta/servlet/ServletContext.html[ServletContext] class.
+The `servletContext` object is an instance of the Servlet API's {jakartaee}jakarta/servlet/ServletContext.html[ServletContext] class.
 
 
 === Examples

--- a/grails-doc/src/en/ref/Tag Libraries/actionName.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/actionName.adoc
@@ -33,13 +33,18 @@ Returns the name of the currently executing action
 
 [source,groovy]
 ----
-class BookController {
-    def list() {
-        log.info "Executing action $actionName"
+class ExamplesTagLib {
 
-        render(view: actionName)
+    def showActionName = { attrs, body ->
+        out << "Executing action: ${actionName}"
     }
+
 }
+----
+
+[source,xml]
+----
+<g:showActionName />
 ----
 
 

--- a/grails-doc/src/en/ref/Tag Libraries/controllerName.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/controllerName.adoc
@@ -33,14 +33,18 @@ Returns the name of the currently executing controller
 
 [source,groovy]
 ----
-class BookController {
+class ExamplesTagLib {
 
-    def list() {
-        log.info "Executing within controller $controllerName"
-
-        render(view: actionName)
+    def showControllerName = { attrs, body ->
+        out << "Executing controller: ${controllerName}"
     }
+
 }
+----
+
+[source,xml]
+----
+<g:showControllerName />
 ----
 
 

--- a/grails-doc/src/en/ref/Tag Libraries/flash.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/flash.adoc
@@ -33,17 +33,20 @@ A temporary storage map that stores objects within the session for the next requ
 
 [source,groovy]
 ----
-class BookController {
+class ExamplesTagLib {
 
-    def index() {
+    def message = {
         flash.message = "Welcome!"
-        redirect(action: 'home')
+        out << "Flash: ${flash}"
     }
 
-    def home() {}
 }
 ----
 
+[source,xml]
+----
+<g:showRequest /> // Outputs "Flash: [message:Welcome!]"
+----
 
 === Description
 

--- a/grails-doc/src/en/ref/Tag Libraries/flash.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/flash.adoc
@@ -45,7 +45,7 @@ class ExamplesTagLib {
 
 [source,xml]
 ----
-<g:showRequest /> // Outputs "Flash: [message:Welcome!]"
+<g:showRequest /> <!-- Outputs "Flash: [message:Welcome!]" -->
 ----
 
 === Description

--- a/grails-doc/src/en/ref/Tag Libraries/pageScope.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/pageScope.adoc
@@ -33,7 +33,7 @@ A reference to the binding of the GSP that the tag library is being executed wit
 
 [source,groovy]
 ----
-class BookTagLib {
+class ExamplesTagLib {
 
    def parent = { attrs, body ->
        pageScope.parent = "John"
@@ -43,6 +43,7 @@ class BookTagLib {
    def child = { attrs, body ->
        out << "My parent is ${pageScope.parent}"
    }
+
 }
 ----
 

--- a/grails-doc/src/en/ref/Tag Libraries/pageScope.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/pageScope.adoc
@@ -50,7 +50,7 @@ class ExamplesTagLib {
 [source,xml]
 ----
 <g:parent>
-    <g:child /> // Outputs "My parent is John"
+    <g:child /> <!-- Outputs "My parent is John" -->
 </g:parent>
 ----
 

--- a/grails-doc/src/en/ref/Tag Libraries/params.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/params.adoc
@@ -34,20 +34,18 @@ A mutable multi-dimensional map (hash) of request (CGI) parameters.
 To obtain a request parameter called `id`:
 [source,groovy]
 ----
-class BookController {
-    def show() {
-        def book = Book.get(params.id)
+class ExamplesTagLib {
+
+    def showParameter = {
+        out << "Parameter id has the value ${params['id']}"
     }
+
 }
 ----
 
-To perform data binding (see link:{guidePath}theWebLayer.html#dataBinding[data binding] in the user guide):
-
-[source,groovy]
+[source,xml]
 ----
-def save() {
-    def book = new Book(params) // bind request parameters onto properties of book
-}
+<g:showParameter />
 ----
 
 
@@ -59,16 +57,8 @@ The standard Servlet API provides access to parameters with the `HttpServletRequ
 The `params` object can be indexed into using the array index operator or de-reference operator, so given the URL `/hello?foo=bar` you can access `foo` with
 
 ----
-println params.foo
+params['id']
 ----
 
 The params object can also be used to bind request parameters onto the properties of a domain class using either the constructor or the link:{domainClassesRefFromRef}properties.html[properties] property:
 
-[source,groovy]
-----
-def book = new Book(params)
-book = Book.get(1)
-book.properties = params
-----
-
-For further reading see link:{guidePath}theWebLayer.html#dataBinding[data binding] in the user guide.

--- a/grails-doc/src/en/ref/Tag Libraries/request.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/request.adoc
@@ -25,7 +25,7 @@ under the License.
 === Purpose
 
 
-The link:{servletApiRefFromRef}request.html[request] object is an instance of the Servlet API's {javaee}javax/servlet/http/HttpServletRequest.html[HttpServletRequest] class
+The link:{servletApiRefFromRef}request.html[request] object is an instance of the Servlet API's {jakartaee}jakarta/servlet/http/HttpServletRequest.html[HttpServletRequest] class
 
 
 === Examples
@@ -46,6 +46,6 @@ class BookController {
 === Description
 
 
-The {javaee}javax/servlet/http/HttpServletRequest.html[HttpServletRequest] class is useful for, amongst other things, obtaining request headers, storing request scoped attributes and establishing information about the client. Refer to the Servlet API's javadocs for further information.
+The {jakartaee}jakarta/servlet/http/HttpServletRequest.html[HttpServletRequest] class is useful for, amongst other things, obtaining request headers, storing request scoped attributes and establishing information about the client. Refer to the Servlet API's javadocs for further information.
 
 NOTE: The additional methods added to the link:{servletApiRefFromRef}request.html[request] object are documented in the Grails Servlet API reference guide

--- a/grails-doc/src/en/ref/Tag Libraries/request.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/request.adoc
@@ -33,15 +33,19 @@ The link:{servletApiRefFromRef}request.html[request] object is an instance of th
 
 [source,groovy]
 ----
-class BookController {
-    def list() {
-        log.info "User agent: ${request.getHeader("User-Agent")}"
+class ExamplesTagLib {
 
-        render(view: actionName)
+    def showRequest = { attrs, body ->
+        out << "Request ${request.getHeader('User-Agent')}"
     }
+
 }
 ----
 
+[source,xml]
+----
+<g:showRequest />
+----
 
 === Description
 

--- a/grails-doc/src/en/ref/Tag Libraries/response.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/response.adoc
@@ -25,7 +25,7 @@ under the License.
 === Purpose
 
 
-The {grailsdocs}ref/Servlet%20API/response.html[response] object is an instance of the Servlet API's {javaee}javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class
+The link:{servletApiRefFromRef}response.html[response] object is an instance of the Servlet API's {jakartaee}jakarta/servlet/http/HttpServletResponse.html[HttpServletResponse] class
 
 
 === Examples
@@ -45,6 +45,6 @@ class BookController {
 === Description
 
 
-The Servlet API's `HttpServletResponse` class can be used within Grails to perform all typical activities such as writing out binary data, writing directly to the response and sending error response codes to name but a few. Refer to the documentation on the {javaee}javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class in the Servlet API for more information.
+The Servlet API's `HttpServletResponse` class can be used within Grails to perform all typical activities such as writing out binary data, writing directly to the response and sending error response codes to name but a few. Refer to the documentation on the {jakartaee}jakarta/servlet/http/HttpServletResponse.html[HttpServletResponse] class in the Servlet API for more information.
 
 NOTE: The additional methods added to the link:{servletApiRefFromRef}response.html[response] object are documented in the Grails Servlet API reference guide

--- a/grails-doc/src/en/ref/Tag Libraries/response.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/response.adoc
@@ -33,11 +33,12 @@ The link:{servletApiRefFromRef}response.html[response] object is an instance of 
 
 [source,groovy]
 ----
-class BookController {
-    def downloadFile() {
-        byte[] bytes = // read bytes
-        response.outputStream << bytes
+class ExamplesTagLib {
+
+    def setHeader = {
+        response.setHeader('Content-Type', 'text/html; charset=utf-8')
     }
+
 }
 ----
 

--- a/grails-doc/src/en/ref/Tag Libraries/servletContext.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/servletContext.adoc
@@ -25,7 +25,7 @@ under the License.
 === Purpose
 
 
-The link:{servletApiRefFromRef}servletContext.html[servletContext] object is an instance of the Servlet API's {javaee}javax/servlet/ServletContext.html[ServletContext] class.
+The link:{servletApiRefFromRef}servletContext.html[servletContext] object is an instance of the Servlet API's {jakartaee}jakarta/servlet/ServletContext.html[ServletContext] class.
 
 
 === Examples
@@ -52,6 +52,6 @@ class BookController {
 === Description
 
 
-The Servlet API's {javaee}javax/servlet/ServletContext.html[ServletContext] is useful for, amongst other things, storing global application attributes, reading local server resources and establishing information about the servlet container.
+The Servlet API's {jakartaee}jakarta/servlet/ServletContext.html[ServletContext] is useful for, amongst other things, storing global application attributes, reading local server resources and establishing information about the servlet container.
 
 NOTE: Grails adds additional methods to the standard Servlet API's link:{servletApiRefFromRef}servletContext.html[servletContext] object. See link for details.

--- a/grails-doc/src/en/ref/Tag Libraries/servletContext.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/servletContext.adoc
@@ -36,7 +36,7 @@ The link:{servletApiRefFromRef}servletContext.html[servletContext] object is an 
 class ExamplesTagLib {
 
     def doSomething = {
-        out << "Servlet major version: ${servletContext.majorVersion    }"
+        out << "Servlet major version: ${servletContext.majorVersion}"
     }
 
 }

--- a/grails-doc/src/en/ref/Tag Libraries/servletContext.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/servletContext.adoc
@@ -33,18 +33,12 @@ The link:{servletApiRefFromRef}servletContext.html[servletContext] object is an 
 
 [source,groovy]
 ----
-class BookController {
-    def doSomething() {
-        def input
-        try {
-            input = servletContext.getResourceAsStream("/WEB-INF/myscript.groovy")
-            def result = new GroovyShell().evaluate(input.text)
-            render result
-        }
-        finally {
-            input.close()
-        }
+class ExamplesTagLib {
+
+    def doSomething = {
+        out << "Servlet major version: ${servletContext.majorVersion    }"
     }
+
 }
 ----
 

--- a/grails-doc/src/en/ref/Tag Libraries/session.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/session.adoc
@@ -25,7 +25,7 @@ under the License.
 === Purpose
 
 
-The {grailsdocs}ref/Servlet%20API/session.html[session] object is an instance of the Servlet API's {javaee}javax/servlet/http/HttpSession.html[HttpSession] class
+The link:{servletApiRefFromRef}session.html[session] object is an instance of the Servlet API's {jakartaee}jakarta/servlet/http/HttpSession.html[HttpSession] class
 
 
 === Examples
@@ -49,6 +49,6 @@ class UserController {
 === Description
 
 
-The {javaee}javax/servlet/http/HttpSession.html[HttpSession] class is useful for associated session data with a client.
+The {jakartaee}jakarta/servlet/http/HttpSession.html[HttpSession] class is useful for associated session data with a client.
 
 NOTE: The additional methods added to the link:{servletApiRefFromRef}session.html[session] object are documented in the Grails Servlet API reference guide

--- a/grails-doc/src/en/ref/Tag Libraries/session.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/session.adoc
@@ -35,21 +35,23 @@ The link:{servletApiRefFromRef}session.html[session] object is an instance of th
 ----
 class ExampleTagLib {
 
-    // List all attributes and their values for the current session
-    def listSessionAttributes = { Map params ->
-        out << params.get("name") << ' : ' << session.getAttribute(params.get("name"))
-    }
+     def oncePerSession = { Map attrs, body ->
+        def key = (attrs.key ?: 'default').toString()
+        def sessionKey = "taglib.oncePerSession.${key}"
 
+        if (!session.getAttribute(sessionKey)) {
+            session.setAttribute(sessionKey, true)
+            out << body()
+        }
+    }
 }
 ----
 
 [source,xml]
 ----
-<ul>
-    <g:each var="elm" in="${session.getAttributeNames()}">
-        <li><g:listSessionAttributes name="${elm}" /></li>
-    </g:each>
-</ul>
+<g:oncePerSession key="promo">
+    <div class="promo">Free shipping this week!</div>
+</g:oncePerSession>
 ----
 
 

--- a/grails-doc/src/en/ref/Tag Libraries/session.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/session.adoc
@@ -35,12 +35,21 @@ The link:{servletApiRefFromRef}session.html[session] object is an instance of th
 ----
 class ExampleTagLib {
 
-    def logout = {
-        log.info "User agent: " + request.getHeader("User-Agent")
-        session.invalidate()
+    // List all attributes and their values for the current session
+    def listSessionAttributes = { Map params ->
+        out << params.get("name") << ' : ' << session.getAttribute(params.get("name"))
     }
 
 }
+----
+
+[source,xml]
+----
+<ul>
+    <g:each var="elm" in="${session.getAttributeNames()}">
+        <li><g:listSessionAttributes name="${elm}" /></li>
+    </g:each>
+</ul>
 ----
 
 

--- a/grails-doc/src/en/ref/Tag Libraries/session.adoc
+++ b/grails-doc/src/en/ref/Tag Libraries/session.adoc
@@ -33,15 +33,13 @@ The link:{servletApiRefFromRef}session.html[session] object is an instance of th
 
 [source,groovy]
 ----
-class UserController {
+class ExampleTagLib {
 
-    def logout() {
+    def logout = {
         log.info "User agent: " + request.getHeader("User-Agent")
         session.invalidate()
-        redirect(action: "login")
     }
 
-    def login() {}
 }
 ----
 


### PR DESCRIPTION
Fixes

- Examples of using inherited properties in Tag Libraries uses Controllers (except in pageScope page)
- Links are broken in request, response, servletContext and session pages

As reported in this issue https://github.com/apache/grails-core/issues/15254