### PR TITLE
Docs - various documentation related chores/cleanups

### DIFF
--- a/grails-data-hibernate5/docs/src/docs/asciidoc/gettingStarted/outsideGrails.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/gettingStarted/outsideGrails.adoc
@@ -66,7 +66,7 @@ Map configuration = [
     'hibernate.hbm2ddl.auto':'create-drop',
     'dataSource.url':'jdbc:h2:mem:myDB'
 ]
-HibernateDatastore datastore = new HibernateDatastore( configuration, Person)
+HibernateDatastore datastore = new HibernateDatastore(configuration, Person)
 ----
 
 For more information on how to configure GORM see the <<configuration, Configuration>> section.

--- a/grails-doc/src/en/guide/cache/cacheUsage/cacheConfiguration.adoc
+++ b/grails-doc/src/en/guide/cache/cacheUsage/cacheConfiguration.adoc
@@ -28,7 +28,7 @@ There are a few configuration options for the plugin; these are specified in
 *Property*,*Default*,*Description*
 grails.cache.enabled,`true`,Whether to enable the plugin
 grails.cache.clearAtStartup,`false`,Whether to clear all caches at startup
-grails.cache.cacheManager,lGrailsConcurrentMapCacheManager,Cache Manager to use. Default cache manager uses Spring Frameworks ConcurrentMapCache which might grow limitless. If you cannot predict how many cache entries you are going to generate use "GrailsConcurrentLinkedMapCacheManager" instead which uses com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap and limits by default to 10000 entries per cache.
+grails.cache.cacheManager,GrailsConcurrentMapCacheManager,Cache Manager to use. Default cache manager uses Spring Frameworks ConcurrentMapCache which might grow limitless. If you cannot predict how many cache entries you are going to generate use "GrailsConcurrentLinkedMapCacheManager" instead which uses com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap and limits by default to 10000 entries per cache.
 |===
 
 The cache implementation used by this plugin is very simple, so there aren't

--- a/grails-doc/src/en/guide/contributing.adoc
+++ b/grails-doc/src/en/guide/contributing.adoc
@@ -17,4 +17,4 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-Grails is an open source project with an active community, and we rely heavily on that community to help make Grails better. For details on how to contribute or interact with the Grails Developers, please see the [Contribution Guide](https://github.com/apache/grails-core/blob/HEAD/CONTRIBUTING.md) on GitHub.
+Grails is an open source project with an active community, and we rely heavily on that community to help make Grails better. For details on how to contribute or interact with the Grails Developers, please see the https://github.com/apache/grails-core/blob/HEAD/CONTRIBUTING.md[Contribution Guide] on GitHub.

--- a/grails-doc/src/en/guide/plugins/artefactApi/customArtefacts.adoc
+++ b/grails-doc/src/en/guide/plugins/artefactApi/customArtefacts.adoc
@@ -39,4 +39,4 @@ The best way to understand how both the handler and wrapper classes work is to l
 * https://github.com/apache/grails-quartz/blob/master/src/main/groovy/grails/plugins/quartz/DefaultGrailsJobClass.java[DefaultGrailsJobClass]
 * https://github.com/apache/grails-quartz/blob/master/src/main/groovy/grails/plugins/quartz/JobArtefactHandler.groovy[JobArtefactHandler]
 
-Another example is the https://github.com/pledbrook/grails-shiro[Shiro plugin] which adds a realm artefact.
+Another example is the https://github.com/nerdErg/grails-shiro[Shiro plugin] which adds a realm artefact.

--- a/grails-doc/src/en/guide/profiles/pluginProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/pluginProfile.adoc
@@ -81,7 +81,7 @@ Provided Features:
 * maven-publish - Publish Artifacts to Maven Central
 * asset-pipeline - Adds Asset Pipeline to a Grails project
 * events - Adds support for the Grails EventBus abstraction
-* geb2 - Adds Geb dependencies to run functional tests.
+* geb2 - Adds Geb dependencies to run functional tests
 * gsp - Adds support for GSP to the project
 * hibernate5 - Adds GORM for Hibernate 5 to the project
 * json-views - Adds support for JSON Views to the project

--- a/grails-doc/src/en/guide/profiles/profileProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/profileProfile.adoc
@@ -82,7 +82,7 @@ Provided Features:
 --------------------
 * asset-pipeline - Adds Asset Pipeline to a Grails project
 * events - Adds support for the Grails EventBus abstraction
-* geb2 - Adds Geb dependencies to run functional tests.
+* geb2 - Adds Geb dependencies to run functional tests
 * gsp - Adds support for GSP to the project
 * hibernate5 - Adds GORM for Hibernate 5 to the project
 * json-views - Adds support for JSON Views to the project

--- a/grails-doc/src/en/guide/profiles/restAPIPluginProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/restAPIPluginProfile.adoc
@@ -86,7 +86,7 @@ Provided Features:
 * maven-publish - Publish Artifacts to Maven Central
 * asset-pipeline - Adds Asset Pipeline to a Grails project
 * events - Adds support for the Grails EventBus abstraction
-* geb2 - Adds Geb dependencies to run functional tests.
+* geb2 - Adds Geb dependencies to run functional tests
 * gsp - Adds support for GSP to the project
 * hibernate5 - Adds GORM for Hibernate 5 to the project
 * json-views - Adds support for JSON Views to the project

--- a/grails-doc/src/en/guide/profiles/restAPIProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/restAPIProfile.adoc
@@ -82,7 +82,7 @@ Provided Features:
 * security - Adds Spring Security REST to the project
 * asset-pipeline - Adds Asset Pipeline to a Grails project
 * events - Adds support for the Grails EventBus abstraction
-* geb2 - Adds Geb dependencies to run functional tests.
+* geb2 - Adds Geb dependencies to run functional tests
 * gsp - Adds support for GSP to the project
 * hibernate5 - Adds GORM for Hibernate 5 to the project
 * json-views - Adds support for JSON Views to the project

--- a/grails-doc/src/en/guide/profiles/webPluginProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/webPluginProfile.adoc
@@ -84,7 +84,7 @@ Provided Features:
 --------------------
 * asset-pipeline - Adds Asset Pipeline to a Grails project
 * events - Adds support for the Grails EventBus abstraction
-* geb2 - Adds Geb dependencies to run functional tests.
+* geb2 - Adds Geb dependencies to run functional tests
 * gsp - Adds support for GSP to the project
 * hibernate5 - Adds GORM for Hibernate 5 to the project
 * json-views - Adds support for JSON Views to the project

--- a/grails-doc/src/en/guide/profiles/webProfile.adoc
+++ b/grails-doc/src/en/guide/profiles/webProfile.adoc
@@ -81,7 +81,7 @@ Provided Features:
 --------------------
 * asset-pipeline - Adds Asset Pipeline to a Grails project
 * events - Adds support for the Grails EventBus abstraction
-* geb2 - Adds Geb dependencies to run functional tests.
+* geb2 - Adds Geb dependencies to run functional tests
 * gsp - Adds support for GSP to the project
 * hibernate5 - Adds GORM for Hibernate 5 to the project
 * json-views - Adds support for JSON Views to the project

--- a/grails-profiles/base/features/geb2/feature.yml
+++ b/grails-profiles/base/features/geb2/feature.yml
@@ -1,4 +1,4 @@
-description: Adds Geb dependencies to run functional tests.
+description: Adds Geb dependencies to run functional tests
 build:
     plugins:
 dependencies:


### PR DESCRIPTION
Fix Markdown links syntax, should be Asciidoctor

Shiro Plugin has a new maintainer - changed link

Fixed typo: (l)GrailsConcurrentMapCacheManager

Minor code example clean up

Consistent descriptions - only Geb2 had ending '.'