### PR TITLE
Fix #15163: remove grails-docs-core from docs build

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation platform("org.apache.grails:grails-gradle-bom:$projectVersion")
     implementation 'org.apache.grails.gradle:grails-publish'
     implementation 'cloud.wondrify:asset-pipeline-gradle'
-    implementation 'org.apache.grails:grails-docs-core'
+    implementation project(':grails-docs-core')
     implementation 'org.apache.grails:grails-gradle-plugins'
     implementation 'org.asciidoctor:asciidoctor-gradle-jvm'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin'

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -43,7 +43,7 @@ ext {
 
 dependencies {
     implementation platform(project(':grails-bom'))
-    implementation 'org.apache.grails:grails-docs-core'
+    implementation project(':grails-docs-core')
     implementation 'org.apache.groovy:groovy'
 
     // Used to surface versions for groovydoc


### PR DESCRIPTION
This PR addresses an issue where the grails-core repository was attempting to use the published org.apache.grails:grails-docs-core dependency which was removed in PR #15163 . The grails-docs-core functionality still exists in the codebase as a local build-logic component but was incorrectly referenced as a published artifact.

Changes Made

grails-doc/build.gradle: Updated dependency from 'org.apache.grails:grails-docs-core' to project(':grails-docs-core')
buildSrc/build.gradle: Updated dependency from 'org.apache.grails:grails-docs-core' to project(':grails-docs-core')

Context

The grails-docs-core module provides documentation generation functionality including:
FetchTagsTask - For fetching Git tags
CreateReleaseDropDownTask - For creating release dropdowns in documentation
PublishGuideTask - For publishing guides
This functionality continues to work as expected but now uses the local project dependency instead of trying to download a non-existent published artifact.

Impact

Fixes build failures when trying to resolve the removed published dependency
Maintains all existing documentation generation functionality
Aligns with the project's architecture of keeping build logic in the build-logic module