### PR TITLE
Add matomo groovydocs 15133

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation platform("org.apache.grails:grails-gradle-bom:$projectVersion")
     implementation 'org.apache.grails.gradle:grails-publish'
     implementation 'cloud.wondrify:asset-pipeline-gradle'
-    implementation project(':grails-docs-core')
+    implementation 'org.apache.grails:grails-docs-core'
     implementation 'org.apache.grails:grails-gradle-plugins'
     implementation 'org.asciidoctor:asciidoctor-gradle-jvm'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation platform("org.apache.grails:grails-gradle-bom:$projectVersion")
     implementation 'org.apache.grails.gradle:grails-publish'
     implementation 'cloud.wondrify:asset-pipeline-gradle'
-    implementation 'org.apache.grails:grails-docs-core'
+    implementation project(':grails-docs-core')
     implementation 'org.apache.grails:grails-gradle-plugins'
     implementation 'org.asciidoctor:asciidoctor-gradle-jvm'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin'

--- a/gradle/docs-dependencies.gradle
+++ b/gradle/docs-dependencies.gradle
@@ -61,6 +61,23 @@ tasks.withType(Groovydoc).configureEach { Groovydoc gdoc ->
     gdoc.processScripts = false
     gdoc.noTimestamp = true
     gdoc.noVersionStamp = false
+    gdoc.footer = '''<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->'''
 
     doFirst {
         def gebVersion = resolveProjectVersion('geb-spock')

--- a/grails-data-docs/stage/build.gradle
+++ b/grails-data-docs/stage/build.gradle
@@ -25,6 +25,23 @@ apply from: rootProject.layout.projectDirectory.file('gradle/docs-dependencies.g
 combinedGroovydoc.configure { Groovydoc task ->
     task.windowTitle = "Grails Data Mapping API - ${projectVersion}"
     task.docTitle = "Grails Data Mapping API - ${projectVersion}"
+    task.footer = '''<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->'''
 
     Set<Project> docProjects = rootProject.subprojects.findAll {
         it.name in [

--- a/grails-data-hibernate5/docs/build.gradle
+++ b/grails-data-hibernate5/docs/build.gradle
@@ -96,6 +96,23 @@ tasks.withType(Groovydoc).configureEach {
             .collect { ":${it.name}:groovydoc" })
 
     it.docTitle = "GORM for Hibernate 5 - $project.version"
+    it.footer = '''<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->'''
 
     def sourceFiles = coreProjects.collect {
         rootProject.layout.projectDirectory.files("$it/src/main/groovy")

--- a/grails-data-mongodb/docs/build.gradle
+++ b/grails-data-mongodb/docs/build.gradle
@@ -105,6 +105,23 @@ tasks.withType(Groovydoc).configureEach { Groovydoc groovydoc ->
             .findAll { it.findProperty('gormApiDocs') }
             .collect { ":${it.name}:groovydoc" })
     groovydoc.docTitle = "GORM for MongoDB - $project.version"
+    groovydoc.footer = '''<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->'''
 
     def sourceFiles = coreProjects.collect {
         layout.projectDirectory.files("$it/src/main/groovy")

--- a/grails-data-neo4j/docs/build.gradle
+++ b/grails-data-neo4j/docs/build.gradle
@@ -125,6 +125,23 @@ task cleanAsciidoc(type: Delete, dependsOn: copyDocs) {
 tasks.withType(Groovydoc) {
     dependsOn(fetchSource)
     docTitle = "GORM for Neo4j - ${project.version}"
+    footer = '''<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->'''
     destinationDir = project.file("build/docs/api")
 
     def files

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -63,6 +63,23 @@ apply from: rootProject.layout.projectDirectory.file('gradle/docs-dependencies.g
 combinedGroovydoc.configure { Groovydoc gdoc ->
     gdoc.windowTitle = "Grails $projectVersion"
     gdoc.docTitle = "Grails $projectVersion"
+    gdoc.footer = '''<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->'''
 
     def docProjects = rootProject.subprojects
             .findAll { it.findProperty('includeInApiDocs') }

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -43,7 +43,7 @@ ext {
 
 dependencies {
     implementation platform(project(':grails-bom'))
-    implementation project(':grails-docs-core')
+    implementation 'org.apache.grails:grails-docs-core'
     implementation 'org.apache.groovy:groovy'
 
     // Used to surface versions for groovydoc

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -43,7 +43,7 @@ ext {
 
 dependencies {
     implementation platform(project(':grails-bom'))
-    implementation 'org.apache.grails:grails-docs-core'
+    implementation project(':grails-docs-core')
     implementation 'org.apache.groovy:groovy'
 
     // Used to surface versions for groovydoc

--- a/grails-forge/gradle.properties
+++ b/grails-forge/gradle.properties
@@ -60,10 +60,6 @@ spotlessVersion=6.25.0
 testRetryVersion=1.6.2
 typesafeConfigVersion=1.4.3
 
-# Build dependency versions not managed by BOMs (needed for buildSrc)
-apacheRatVersion=0.8.1
-gradleCycloneDxPluginVersion=2.4.1
-
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G

--- a/grails-forge/gradle.properties
+++ b/grails-forge/gradle.properties
@@ -60,6 +60,10 @@ spotlessVersion=6.25.0
 testRetryVersion=1.6.2
 typesafeConfigVersion=1.4.3
 
+# Build dependency versions not managed by BOMs (needed for buildSrc)
+apacheRatVersion=0.8.1
+gradleCycloneDxPluginVersion=2.4.1
+
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G

--- a/grails-forge/gradle/doc-config.gradle
+++ b/grails-forge/gradle/doc-config.gradle
@@ -16,6 +16,22 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
+configurations.register('documentation') {
+    canBeConsumed = false
+    canBeResolved = true
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+    }
+}
+
+dependencies {
+    documentation "org.codehaus.groovy:groovy-templates:$groovyVersion"
+    documentation "org.codehaus.groovy:groovy-dateutil:$groovyVersion"
+}
+
 tasks.withType(Groovydoc).configureEach {
     classpath += project.configurations.documentation
     windowTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"

--- a/grails-forge/gradle/doc-config.gradle
+++ b/grails-forge/gradle/doc-config.gradle
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 tasks.withType(Groovydoc).configureEach {
     classpath += project.configurations.documentation
     windowTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"

--- a/grails-forge/gradle/doc-config.gradle
+++ b/grails-forge/gradle/doc-config.gradle
@@ -1,41 +1,24 @@
-/*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- */
-
-configurations.register('documentation') {
-    canBeConsumed = false
-    canBeResolved = true
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-    }
-}
-
-dependencies {
-    documentation "org.codehaus.groovy:groovy-templates:$groovyVersion"
-    documentation "org.codehaus.groovy:groovy-dateutil:$groovyVersion"
-}
-
 tasks.withType(Groovydoc).configureEach {
     classpath += project.configurations.documentation
     windowTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"
     docTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"
+    footer = '''<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->'''
     access = GroovydocAccess.PROTECTED
     includeAuthor = false
     includeMainForScripts = false

--- a/grails-gradle/gradle/docs-config.gradle
+++ b/grails-gradle/gradle/docs-config.gradle
@@ -52,6 +52,23 @@ groovydocTask.configure { Groovydoc it ->
     it.processScripts = false
     it.noTimestamp = true
     it.noVersionStamp = false
+    it.footer = '''<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->'''
     it.destinationDir = project.file('build/docs/api')
 }
 


### PR DESCRIPTION
Add Apache/Matomo Analytics to grails-data docs and both sets of groovydocs (#15133)This PR addresses issue #15133 by adding Apache/Matomo analytics tracking to all HTML files generated by groovydoc for API documentation.

Summary of Changes

Added Matomo analytics code to all groovydoc configurations across the Grails codebase
Ensured comprehensive coverage of all API documentation generation paths
Maintained privacy-conscious settings (setDoNotTrack and disableCookies)

Files Updated

The following groovydoc configurations have been updated to include the Matomo analytics code in the footer:
gradle/docs-dependencies.gradle - Global groovydoc configuration
grails-gradle/gradle/docs-config.gradle - Grails Gradle plugin documentation
grails-doc/build.gradle - Main API documentation aggregation
grails-data-docs/stage/build.gradle - Grails data mapping API docs
grails-data-hibernate5/docs/build.gradle - GORM for Hibernate API docs
grails-data-mongodb/docs/build.gradle - GORM for MongoDB API docs
grails-data-neo4j/docs/build.gradle - GORM for Neo4j API docs
grails-forge/gradle/doc-config.gradle - Grails Forge documentation
The Matomo analytics code has been injected using the footer property of the Groovydoc task, ensuring it appears on every generated HTML page while preserving the existing privacy settings.