### PR TITLE
#15302 - fix(breaking) property name resolution when generating grails boms

### DIFF
--- a/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/CoordinateHolder.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/CoordinateHolder.groovy
@@ -26,7 +26,7 @@ import groovy.transform.ToString
 @EqualsAndHashCode(includes = ['groupId', 'artifactId'])
 @CompileStatic
 @ToString
-class CoordinateHolder {
+class CoordinateHolder implements Serializable {
 
     String groupId
     String artifactId

--- a/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/CoordinateVersionHolder.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/CoordinateVersionHolder.groovy
@@ -43,4 +43,14 @@ class CoordinateVersionHolder extends CoordinateHolder {
 
         "$groupId:$artifactId:$version" as String
     }
+    
+    static CoordinateVersionHolder create(String coordinates) {
+        coordinates.split(':').with { String[] parts ->
+            new CoordinateVersionHolder(
+                groupId: parts[0],
+                artifactId: parts[1],
+                version: parts[2]
+            )
+        }
+    }
 }

--- a/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/ExtractDependenciesTask.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/ExtractDependenciesTask.groovy
@@ -148,7 +148,6 @@ abstract class ExtractDependenciesTask extends DefaultTask {
 
             ExtractedDependencyConstraint extractConstraint = propertyNameCalculator.calculate(groupId, artifactId, artifactVersion, false) ?: new ExtractedDependencyConstraint(groupId: groupId, artifactId: artifactId, version: artifactVersion)
             extractConstraint.source = getProjectName().get()
-            extractConstraint.versionPropertyReference = "\${${artifactId.replaceAll('-', '.')}.version}"
             constraints.put(new CoordinateHolder(groupId: extractConstraint.groupId, artifactId: extractConstraint.artifactId), extractConstraint)
         }
     }

--- a/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/ExtractDependenciesTask.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/ExtractDependenciesTask.groovy
@@ -60,7 +60,7 @@ abstract class ExtractDependenciesTask extends DefaultTask {
     abstract RegularFileProperty getDestination()
 
     @Input
-    abstract MapProperty<String,String> getVersions()
+    abstract MapProperty<String, String> getVersions()
 
     @Input
     abstract Property<String> getConfigurationName()
@@ -76,6 +76,12 @@ abstract class ExtractDependenciesTask extends DefaultTask {
 
     @Input
     abstract Property<String> getProjectName()
+
+    @Input
+    abstract MapProperty<String, String> getForcedGroupPrefixes()
+
+    @Input
+    abstract MapProperty<String, String> getProjectCoordinateProperties()
 
     void setConfiguration(NamedDomainObjectProvider<Configuration> config) {
         dependencyArtifacts.from(config)
@@ -101,6 +107,13 @@ abstract class ExtractDependenciesTask extends DefaultTask {
                 getDefinitions().get(),
                 getVersions().get()
         )
+        for (Map.Entry<String, String> entry : getForcedGroupPrefixes().get().entrySet()) {
+            propertyNameCalculator.addForcedGroupPrefix(entry.key, entry.value)
+        }
+        for (Map.Entry<String, String> entry : getProjectCoordinateProperties().get().entrySet()) {
+            CoordinateVersionHolder coordinates = CoordinateVersionHolder.create(entry.key)
+            propertyNameCalculator.addProject(coordinates.groupId, coordinates.artifactId, coordinates.version, entry.value)
+        }
 
         Configuration configuration = project.configurations.named(configurationName.get()).get()
         if (!configuration.canBeResolved) {
@@ -148,13 +161,15 @@ abstract class ExtractDependenciesTask extends DefaultTask {
 
             ExtractedDependencyConstraint extractConstraint = propertyNameCalculator.calculate(groupId, artifactId, artifactVersion, false) ?: new ExtractedDependencyConstraint(groupId: groupId, artifactId: artifactId, version: artifactVersion)
             extractConstraint.source = getProjectName().get()
-            constraints.put(new CoordinateHolder(groupId: extractConstraint.groupId, artifactId: extractConstraint.artifactId), extractConstraint)
+
+            CoordinateHolder coordinates = new CoordinateHolder(groupId: extractConstraint.groupId, artifactId: extractConstraint.artifactId)
+            constraints.put(coordinates, extractConstraint)
         }
     }
 
     private Map<CoordinateHolder, List<CoordinateHolder>> determineExclusions(Configuration configuration) {
         Map<CoordinateHolder, List<CoordinateHolder>> exclusions = [:].withDefault { [] }
-        for (Dependency dep  : configuration.allDependencies) {
+        for (Dependency dep : configuration.allDependencies) {
             if (dep instanceof ModuleDependency) {
                 CoordinateHolder foundCoordinate = new CoordinateHolder(groupId: dep.group, artifactId: dep.name)
                 dep.excludeRules.each { ExcludeRule exclusionRule ->
@@ -167,7 +182,7 @@ abstract class ExtractDependenciesTask extends DefaultTask {
     }
 
     private void populateInheritedConstraints(Configuration configuration, Map<CoordinateHolder, List<CoordinateHolder>> exclusions, Map<CoordinateHolder, ExtractedDependencyConstraint> constraints, PropertyNameCalculator propertyNameCalculator) {
-        for (DependencyResult result  : configuration.incoming.resolutionResult.allDependencies) {
+        for (DependencyResult result : configuration.incoming.resolutionResult.allDependencies) {
             if (!(result instanceof ResolvedDependencyResult)) {
                 throw new GradleException('Dependencies should be resolved prior to running this task.')
             }

--- a/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/PropertyNameCalculator.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/apache/grails/gradle/tasks/bom/PropertyNameCalculator.groovy
@@ -34,11 +34,16 @@ class PropertyNameCalculator {
     final Map<String, String> keysToCoordinates = [:]
     final Map<String, ExtractedDependencyConstraint> definitions = [:]
     final Map<String, String> versions = [:]
+    final Map<String, String> forceGroupPrefixes = [:]
 
     PropertyNameCalculator(Map<String, String> platformDefinitions, Map<String, String> definitions, Map<String, String> definitionVersions) {
         this.platformDefinitions.putAll(populate(platformDefinitions, keysToPlatformCoordinates))
         this.definitions.putAll(populate(definitions, keysToCoordinates))
         this.versions.putAll(definitionVersions)
+    }
+
+    void addForcedGroupPrefix(String groupId, String groupPrefix) {
+        forceGroupPrefixes.put(groupId, groupPrefix)
     }
 
     void addProjects(Collection<Project> projects) {
@@ -48,16 +53,21 @@ class PropertyNameCalculator {
             }
 
             String artifactId = (project.findProperty('pomArtifactId') ?: project.name)
-            String baseVersionName = artifactId.replaceAll('-', '.')
-            String versionName = "${baseVersionName}.version" as String
-            String coordinates = "${project.group}:${artifactId}:${project.version}" as String
-            ExtractedDependencyConstraint constraint = new ExtractedDependencyConstraint(coordinates as String)
-            constraint.versionPropertyReference = "\${${versionName}}" as String
-
-            definitions.put(coordinates, constraint)
-            keysToCoordinates.put(coordinates, baseVersionName)
-            versions.put(versionName, project.version as String)
+            String baseVersionName = artifactId.replaceAll('[.]', '-')
+            addProject(project.group, artifactId, project.version as String, baseVersionName)
         }
+    }
+
+    void addProject(String groupId, String artifactId, String version, String baseBomPropertyName) {
+        String baseVersionName = forceGroupPrefixes.containsKey(groupId) ? "${forceGroupPrefixes.get(groupId)}-${baseBomPropertyName}" : baseBomPropertyName
+        String versionName = "${baseVersionName}.version" as String
+        String coordinates = "${groupId}:${artifactId}:${version}" as String
+        ExtractedDependencyConstraint constraint = new ExtractedDependencyConstraint(coordinates as String)
+        constraint.versionPropertyReference = "\${${versionName}}" as String
+
+        definitions.put(coordinates, constraint)
+        keysToCoordinates.put(coordinates, baseVersionName)
+        versions.put(versionName, version)
     }
 
     private static Map<String, ExtractedDependencyConstraint> populate(Map<String, String> definitions, Map<String, String> keyMappings) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,7 +51,7 @@ ext {
     gradleBomDependencies = [
             'ant'                    : "org.apache.ant:ant:${gradleBomDependencyVersions['ant.version']}",
             'ant-junit'              : "org.apache.ant:ant-junit:${gradleBomDependencyVersions['ant.version']}",
-            'asciidoctorj-gradle-jvm': "org.asciidoctor:asciidoctor-gradle-jvm:${gradleBomDependencyVersions['asciidoctor-gradle-jvm.version']}",
+            'asciidoctor-gradle-jvm' : "org.asciidoctor:asciidoctor-gradle-jvm:${gradleBomDependencyVersions['asciidoctor-gradle-jvm.version']}",
             'asciidoctorj'           : "org.asciidoctor:asciidoctorj:${gradleBomDependencyVersions['asciidoctorj.version']}",
             'asset-pipeline-gradle'  : "cloud.wondrify:asset-pipeline-gradle:${gradleBomDependencyVersions['asset-pipeline-gradle.version']}",
             'byte-buddy'             : "net.bytebuddy:byte-buddy:${gradleBomDependencyVersions['byte-buddy.version']}",
@@ -106,7 +106,7 @@ ext {
             'liquibase-hibernate5'     : "org.liquibase:liquibase:${bomDependencyVersions['liquibase-hibernate5.version']}",
             'liquibase-hibernate5-cdi' : "org.liquibase:liquibase-cdi:${bomDependencyVersions['liquibase-hibernate5.version']}",
             'liquibase-hibernate5-core': "org.liquibase:liquibase-core:${bomDependencyVersions['liquibase-hibernate5.version']}",
-            'liquibase-hibernate5-ext' : "org.liquibase.ext:liquibase5-hibernate:${bomDependencyVersions['liquibase-hibernate5.version']}",
+            'liquibase-hibernate5-ext' : "org.liquibase.ext:liquibase-hibernate5:${bomDependencyVersions['liquibase-hibernate5.version']}",
             'mongodb-bson'             : "org.mongodb:bson:${bomDependencyVersions['mongodb.version']}",
             'mongodb-driver-core'      : "org.mongodb:mongodb-driver-core:${bomDependencyVersions['mongodb.version']}",
             'mongodb-driver-sync'      : "org.mongodb:mongodb-driver-sync:${bomDependencyVersions['mongodb.version']}",

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -182,7 +182,7 @@ ext {
                         pomProperties.put(extractedConstraint.versionPropertyName, inlineVersion)
                     }
 
-                    if (gradle.includedBuilds*.any { it.name == artifactId && groupId.startsWith('org.apache.grails') }) {
+                    if (gradle.includedBuilds.flatten().any { it.name == artifactId && groupId.startsWith('org.apache.grails') }) {
                         String baseVersionName = artifactId.replaceAll('-', '.')
                         String versionName = "${baseVersionName}.version" as String
                         dep.version[0].value = "\${${versionName}}" as String

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -41,6 +41,13 @@ javaPlatform {
 ext {
     isReleaseBuild = System.getenv('GRAILS_PUBLISH_RELEASE') == 'true'
     isPublishedExternal = System.getenv().containsKey('NEXUS_PUBLISH_STAGING_PROFILE_ID')
+    // TODO: It should be possible to pull these build names using includedBuild, but I haven't found a way to do so
+    gradleBuildProjects = [
+            'grails-gradle-plugins',
+            'grails-gradle-model',
+            'grails-gradle-common',
+            'grails-gradle-tasks',
+    ]
 }
 
 dependencies {
@@ -67,15 +74,18 @@ dependencies {
                 continue // ignore self & test projects
             }
 
+            boolean publishedProject = subproject.pluginManager.hasPlugin('org.apache.grails.gradle.grails-publish-profile') || subproject.pluginManager.hasPlugin('org.apache.grails.gradle.grails-publish')
+            if (!publishedProject) {
+                continue
+            }
+
             api project(":${subproject.path}")
         }
 
         // since we're duplicating the bom instead of inheriting we have to add the grails-gradle projects
-        // TODO: It should be possible to pull these build names using includedBuild, but I haven't found a way to do so
-        api "org.apache.grails:grails-gradle-plugins:${projectVersion}"
-        api "org.apache.grails.gradle:grails-gradle-model:${projectVersion}"
-        api "org.apache.grails.gradle:grails-gradle-common:${projectVersion}"
-        api "org.apache.grails:grails-gradle-tasks:${projectVersion}"
+        for (String dependency : project.ext.gradleBuildProjects) {
+            api "org.apache.grails.gradle:${dependency}:${projectVersion}"
+        }
 
         // because we are not yet publishing hibernate6, just force the hibernate5 version for now
         api("org.liquibase:liquibase-core") {
@@ -108,14 +118,34 @@ tasks.register('extractConstraints', ExtractDependenciesTask).configure { Extrac
     rootProject.subprojects.each { p ->
         evaluationDependsOn(p.path)
     }
-    it.projectArtifactIds.set(project.provider{
+    it.projectArtifactIds.set(project.provider {
         Map<String, String> artifactIdMappings = [:]
 
         rootProject.subprojects.each { p ->
             artifactIdMappings[p.name] = p.findProperty('pomArtifactId') ?: p.name
         }
 
+        for (String artifactId : project.ext.gradleBuildProjects) {
+            artifactIdMappings[artifactId] = artifactId
+        }
+
         artifactIdMappings
+    })
+    it.forcedGroupPrefixes.set(['org.apache.grails.profiles': 'grails-profile'])
+    it.projectCoordinateProperties.set(project.provider {
+        Map<String, String> projectCoordinates = [:]
+
+        rootProject.subprojects.each { p ->
+            String artifactId = p.findProperty('pomArtifactId') as String ?: p.name
+            String baseVersionName = artifactId.replaceAll('[.]', '-')
+            projectCoordinates["${p.group}:${ artifactId}:${p.version}" as String] = baseVersionName
+        }
+
+        for (String artifactId : project.ext.gradleBuildProjects) {
+            projectCoordinates["org.apache.grails.gradle:${artifactId}:${project.version}" as String] = artifactId
+        }
+
+        projectCoordinates
     })
 
     it.dependsOn(project.tasks.named('generateMetadataFileForMavenPublication'), project.tasks.named('generatePomFileForMavenPublication'))
@@ -158,6 +188,13 @@ ext {
         def depMgmt = root.dependencyManagement?.getAt(0)
         def deps = depMgmt?.dependencies?.getAt(0)
         if (deps) {
+            PropertyNameCalculator propertyNameCalculator = new PropertyNameCalculator(combinedPlatforms, combinedDependencies, combinedVersions)
+            propertyNameCalculator.addForcedGroupPrefix('org.apache.grails.profiles', 'grails-profile')
+            propertyNameCalculator.addProjects(rootProject.subprojects)
+            for (String gradleArtifactId : project.ext.gradleBuildProjects) {
+                propertyNameCalculator.addProject('org.apache.grails.gradle', gradleArtifactId, project.version as String, gradleArtifactId)
+            }
+
             Map<String, String> pomProperties = [:]
             deps.dependency.each { dep ->
                 String groupId = dep.groupId.text().trim()
@@ -170,8 +207,6 @@ ext {
                 }
 
                 if (inlineVersion) {
-                    PropertyNameCalculator propertyNameCalculator = new PropertyNameCalculator(combinedPlatforms, combinedDependencies, combinedVersions)
-                    propertyNameCalculator.addProjects(rootProject.subprojects)
                     ExtractedDependencyConstraint extractedConstraint = propertyNameCalculator.calculate(groupId, artifactId, inlineVersion, isBom)
                     if (extractedConstraint?.versionPropertyReference) {
                         // use the property reference instead of the hard coded version so that it can be
@@ -180,13 +215,6 @@ ext {
 
                         // Add an entry in the <properties> node with the actual version number
                         pomProperties.put(extractedConstraint.versionPropertyName, inlineVersion)
-                    }
-
-                    if (gradle.includedBuilds.flatten().any { it.name == artifactId && groupId.startsWith('org.apache.grails') }) {
-                        String baseVersionName = artifactId.replaceAll('-', '.')
-                        String versionName = "${baseVersionName}.version" as String
-                        dep.version[0].value = "\${${versionName}}" as String
-                        pomProperties.put(versionName, inlineVersion)
                     }
                 } else if (!inlineVersion) {
                     throw new GradleException("Dependency $groupId:$artifactId does not have a version.")

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -104,6 +104,82 @@ You can override a version in the BOM by setting the associated Gradle property.
 The possible gradle properties are generated as part of this documentation.
 Please see link:{versionsRef}Grails BOM.html[Grails BOM Dependencies] for a quick reference.
 
+===== 4.1 BOM Property Changes
+
+The initial Grails 7.0.0 release had an issue where properties in the bom were not correctly populated. The 7.0.4 release restored properties, but the naming was inconsistent and duplicated. Later versions of Grails 7 reworked the properties for the following reasons:
+
+* to follow previous naming strategies used by Grails 6 and earlier.
+* to remove duplicate properties.
+* to clearly delineate between profile dependencies.
+* to remove non-published projects.
+* to fix invalid versions for properties used by asciidoctor & rxjava.
+
+Detailed differences follow in subsequent sections.
+
+===== 4.2 Property Name Standardization
+
+In the prior 7.0.0 Grails versions, there were numerous duplicated properties for third-party dependencies, with one variant using hyphens (e.g., byte-buddy.version) and an identical one using dots (e.g., byte.buddy.version), both set to the same value. This applies to properties like:
+
+    asset-pipeline-gradle.version / asset.pipeline.gradle.version
+    byte-buddy.version / byte.buddy.version
+    commons-text.version / commons.text.version
+    directory-watcher.version / directory.watcher.version
+    grails-publish-plugin.version / grails.publish.version (though this is slightly inconsistent in naming)
+    javaparser-core.version / javaparser.core.version
+    bootstrap-icons.version / bootstrap.icons.version (literal duplicate entries)
+    commons-codec.version / commons.codec.version
+    geb-spock.version / geb.spock.version
+    asset-pipeline-bom.version / asset.pipeline.bom.version
+    spock.version / spock.bom.version (values match but names differ slightly)
+    jackson.version / jackson.bom.version
+    groovy.version / groovy.bom.version
+    selenium.version / selenium.bom.version
+
+To resolve this duplication and standardize naming conventions, the Grails team has consolidated these properties. All dotted variants have been removed. Only the hyphenated forms are retained (e.g., byte-buddy.version, asset-pipeline-gradle.version).
+
+Additionally, Grails-specific properties in earlier Grails 7 versions used dots in their names (e.g., grails.async.version, grails.data.hibernate5.version). These have been refactored to use hyphens instead (e.g., grails-async.version, grails-data-hibernate5.version). This aligns them with the third-party property naming convention.
+
+These changes eliminate redundancy and enforce consistency across the Grails bom & the boms it inherits.
+
+===== 4.3 Profile Properties are renamed
+
+In previous Grails 7 versions, profile-specific properties were not prefixed with `grails-profile`.  These have been corrected as follows:
+
+    base.version - grails-profile-base.version
+    plugin.version - grails-profile-plugin.version
+    profile.version - grails-profile-profile.version
+    rest.api.version - grails-profile-rest-api.version
+    rest.api.plugin.version - grails-profile-rest-api-plugin.version
+    web.version - grails-profile-web.version
+    web.plugin.version - grails-profile-web-plugin.version
+
+===== 4.4 Removal of Redundant or Unused Properties
+
+Several groups of related properties have been consolidated or removed in later Grails 7 versions:
+
+* Liquibase: (liquibase-hibernate5.version, liquibase.version, liquibase.cdi.version, liquibase.core.version, liquibase5.hibernate.version) have been replaced by `liquibase-hibernate5.version`
+* MongoDB: (mongodb.version, bson.version, mongodb.driver.core.version, mongodb.driver.sync.version, bson.record.codec.version) have been replaced by `mongodb.version`
+* Sitemesh: (starter-sitemesh.version, spring.boot.starter.sitemesh.version) have been consolidated to `starter-sitemesh.version`
+* Ant: (ant.version and ant.junit.version) have been consolidated to `ant.version`
+* Spring Boot sub-components: (spring.boot.cli.version and spring.boot.gradle.plugin.version) have been consolidated to use `spring-boot.version`
+* Asciidoctor Gradle: asciidoctor.gradle.jvm.version was renamed to `asciidoctor-gradle-jvm.version`
+* Spring Boot dependencies: `spring.boot.dependencies.version` was renamed to `spring-boot.version`
+* Liquibase Hibernate: liquibase.hibernate5.version & liquibase-hibernate5.version were consolidated to liquibase-hibernate5.version
+
+===== 4.5 Specific Property Value Changes
+
+rxjava properties were incorrect previously, they are now fixed per the below:
+
+* `rxjava.version` (for RxJava 1.x, groupId io.reactivex) was set to 3.1.11 instead of 1.3.8
+* `rxjava2.version` (for RxJava 2.x, groupId io.reactivex.rxjava2) was set to 3.1.11 instead of 2.2.21
+* `rxjava3.version` (for RxJava 3.x, groupId io.reactivex.rxjava3) was set to 3.1.11 and remains 3.1.11
+
+===== 4.6 Additions and Refinements in <dependencyManagement>
+
+Several boms are imported and previously used customized property names for them. They now align with a single property name.  Most importantly, `spring-boot-dependencies` now uses `${spring-boot.version}` (aligning with the removal of spring.boot.dependencies.version).
+
+All published Grails projects continue to have separate properties to allow for overriding their versions individually.
+
 ==== 5. Coordinate Changes
 
 Grails has transitioned to the Apache Software Foundation (ASF).


### PR DESCRIPTION
This ended up being a breaking change.  The artifact id was driving the version name instead of the calculate property name.  I can change all of the property names to match to minimize this change, or we can go with the property name fix.  

This is the current grails-bom:
https://central.sonatype.com/artifact/org.apache.grails/grails-bom

This is with my changes: 
[update-grails-bom.xml](https://github.com/user-attachments/files/24685075/update-grails-bom.xml)

Take a look at dependencies.gradle and you'll notice that the key of the maps are now correctly the property name instead of artifact id.  

Other changes after the initial feedback: 
* ascidoctor & liquibase hibernate ext had the wrong keyvalues
* I checked the generated Versions adoc and I believe it now matches the pom values
* I've added a forced 'grails-profile' to the profile property names
