### PR TITLE
Update asset-pipeline and WebJars require paths

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -25,7 +25,7 @@ ext {
             'ant.version'                   : '1.10.15',
             'asciidoctor-gradle-jvm.version': '4.0.5',
             'asciidoctorj.version'          : '3.0.0',
-            'asset-pipeline-gradle.version' : '5.0.22',
+            'asset-pipeline-gradle.version' : '5.0.28',
             'byte-buddy.version'            : '1.17.7',
             'commons-text.version'          : '1.13.1',
             'directory-watcher.version'     : '0.19.1',
@@ -68,7 +68,7 @@ ext {
     ]
 
     bomDependencyVersions = [
-            'asset-pipeline-bom.version'  : '5.0.22',
+            'asset-pipeline-bom.version'  : '5.0.28',
             'bootstrap-icons.version'     : '1.13.1',
             'bootstrap.version'           : '5.3.8',
             'commons-codec.version'       : '1.18.0',

--- a/grails-data-neo4j/examples/grails3-neo4j-hibernate/grails-app/assets/javascripts/application.js
+++ b/grails-data-neo4j/examples/grails3-neo4j-hibernate/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-data-neo4j/examples/grails3-neo4j/grails-app/assets/javascripts/application.js
+++ b/grails-data-neo4j/examples/grails3-neo4j/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-forge/grails-forge-core/src/main/resources/assets/javascripts/application.js
+++ b/grails-forge/grails-forge-core/src/main/resources/assets/javascripts/application.js
@@ -5,8 +5,8 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self
 
 if (typeof jQuery !== 'undefined') {

--- a/grails-forge/grails-forge-core/src/main/resources/assets/stylesheets/application.css
+++ b/grails-forge/grails-forge-core/src/main/resources/assets/stylesheets/application.css
@@ -7,8 +7,8 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
-*= require webjars/font/bootstrap-icons.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
+*= require webjars/bootstrap-icons/%/font/bootstrap-icons.css
 *= require grails.css
 *= require_self
 */

--- a/grails-profiles/web/skeleton/grails-app/assets/javascripts/application.js
+++ b/grails-profiles/web/skeleton/grails-app/assets/javascripts/application.js
@@ -5,8 +5,8 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self
 
 if (typeof jQuery !== 'undefined') {

--- a/grails-profiles/web/skeleton/grails-app/assets/stylesheets/application.css
+++ b/grails-profiles/web/skeleton/grails-app/assets/stylesheets/application.css
@@ -7,8 +7,8 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
-*= require webjars/font/bootstrap-icons.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
+*= require webjars/bootstrap-icons/%/font/bootstrap-icons.css
 *= require grails.css
 *= require_self
 */

--- a/grails-test-examples/app1/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/app1/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better 
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/app2/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/app2/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better 
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/demo33/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/demo33/grails-app/assets/javascripts/application.js
@@ -24,8 +24,8 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/demo33/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/demo33/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
 *= require grails.css
 *= require main.css
 *= require mobile.css

--- a/grails-test-examples/geb-gebconfig/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/geb-gebconfig/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self

--- a/grails-test-examples/geb-gebconfig/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/geb-gebconfig/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
 *= require grails.css
 *= require main.css
 *= require mobile.css

--- a/grails-test-examples/geb/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/geb/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self

--- a/grails-test-examples/geb/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/geb/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
 *= require grails.css
 *= require main.css
 *= require mobile.css

--- a/grails-test-examples/gsp-layout/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/gsp-layout/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self

--- a/grails-test-examples/gsp-layout/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/gsp-layout/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
 *= require grails.css
 *= require main.css
 *= require mobile.css

--- a/grails-test-examples/gsp-sitemesh3/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/gsp-sitemesh3/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self

--- a/grails-test-examples/gsp-sitemesh3/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/gsp-sitemesh3/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
 *= require grails.css
 *= require main.css
 *= require mobile.css

--- a/grails-test-examples/hibernate5/grails-database-per-tenant/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/hibernate5/grails-database-per-tenant/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/hibernate5/grails-hibernate/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/hibernate5/grails-hibernate/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/hibernate5/grails-schema-per-tenant/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/hibernate5/grails-schema-per-tenant/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/hibernate5/issue450/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/hibernate5/issue450/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self

--- a/grails-test-examples/hibernate5/issue450/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/hibernate5/issue450/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
 *= require grails.css
 *= require main.css
 *= require mobile.css

--- a/grails-test-examples/hyphenated/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/hyphenated/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better 
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/issue-11102/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/issue-11102/grails-app/assets/javascripts/application.js
@@ -24,8 +24,8 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/issue-11102/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/issue-11102/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
 *= require grails.css
 *= require main.css
 *= require mobile.css

--- a/grails-test-examples/micronaut/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/micronaut/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self

--- a/grails-test-examples/micronaut/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/micronaut/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
 *= require grails.css
 *= require main.css
 *= require mobile.css

--- a/grails-test-examples/mongodb/base/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/mongodb/base/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/mongodb/database-per-tenant/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/mongodb/database-per-tenant/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/mongodb/gson-templates/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/mongodb/gson-templates/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better 
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/mongodb/hibernate5/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/mongodb/hibernate5/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/namespaces/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/namespaces/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better 
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 

--- a/grails-test-examples/scaffolding/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/scaffolding/grails-app/assets/javascripts/application.js
@@ -24,8 +24,8 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
-//= require webjars/dist/js/bootstrap.bundle.js
+//= require webjars/jquery/%/dist/jquery.js
+//= require webjars/bootstrap/%/dist/js/bootstrap.bundle.js
 //= require_self
 
 if (typeof jQuery !== 'undefined') {

--- a/grails-test-examples/scaffolding/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/scaffolding/grails-app/assets/stylesheets/application.css
@@ -26,8 +26,8 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/dist/css/bootstrap.css
-*= require webjars/font/bootstrap-icons.css
+*= require webjars/bootstrap/%/dist/css/bootstrap.css
+*= require webjars/bootstrap-icons/%/font/bootstrap-icons.css
 *= require grails.css
 *= require_self
 */

--- a/grails-test-examples/views-functional-tests/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/views-functional-tests/grails-app/assets/javascripts/application.js
@@ -24,7 +24,7 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better 
 // to create separate JavaScript files as needed.
 //
-//= require webjars/dist/jquery.js
+//= require webjars/jquery/%/dist/jquery.js
 //= require_tree .
 //= require_self
 


### PR DESCRIPTION
Bumped asset-pipeline-gradle and asset-pipeline-bom versions to 5.0.28 in dependencies.gradle. Updated all asset require paths in JavaScript and CSS files to use explicit WebJars package/version wildcards for jQuery, Bootstrap, and Bootstrap Icons, improving compatibility with newer WebJars conventions.