### PR TITLE
Update spring-boot.version to 3.5.10

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -38,7 +38,7 @@ ext {
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
             'gradle-spock.version'          : '2.3-groovy-3.0',
-            'spring-boot.version'           : '3.5.9',
+            'spring-boot.version'           : '3.5.10',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly


### PR DESCRIPTION
This PR upgrades Spring Boot from 3.5.9 to 3.5.10.

## Spring Boot 3.5.10 Release Highlights

### Bug Fixes
- **Improved bean condition evaluation** - Unnecessary queries to the bean factory for types that are not present have been eliminated, improving performance
- **Fixed /info endpoint for Java 25 Native Image** - VirtualThreadSchedulerMXBean support now works correctly
- **Fixed DataSourceBuilder native image support** - Oracle UCP (oracle.ucp.jdbc.PoolDataSourceImpl) can now be created in native images
- **Fixed reproducibility** - Application JARs created by the extract command are now reproducible
- **Fixed AOT processing** - Test AOT processing is no longer disabled when 'skipTests' is set

### Key Dependency Upgrades
- Hibernate 6.6.41.Final
- Logback 1.5.25
- Micrometer 1.15.8 & Micrometer Tracing 1.5.8
- PostgreSQL 42.7.9
- Spring Data BOM 2025.0.8
- Spring Integration 6.5.6
- Spring Kafka 3.3.12
- Reactor BOM 2024.0.14
- REST Assured 5.5.7
- Undertow 2.3.22.Final

### Documentation Improvements
- Updated documentation for Buildpack's AOT Cache support
- Documented support for configuring arguments passed to Docker Compose
- Clarified HazelcastConfigCustomizer javadoc

For complete release notes, see: https://github.com/spring-projects/spring-boot/releases/tag/v3.5.10