### PR TITLE
Upgrade to Gradle 8.14.4 and support Java 25 on Forge

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21, 24 ]
+        java: [ 17, 21, 25 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21, 24 ]
+        java: [ 17, 21, 25 ]
     runs-on: ubuntu-24.04
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 java=17.0.17-librca
-gradle=8.14.3
+gradle=8.14.4
 

--- a/build-logic/gradle/wrapper/gradle-wrapper.properties
+++ b/build-logic/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grails-forge/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-forge/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootVirtualThreads.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootVirtualThreads.java
@@ -39,7 +39,7 @@ public class SpringBootVirtualThreads implements SpringThreadingFeature {
 
     @Override
     public String getDescription() {
-        return "Enables Virtual Threads in Spring Boot for JDK 24+.";
+        return "Enables Virtual Threads in Spring Boot for JDK 25+.";
     }
 
     @Override
@@ -51,8 +51,8 @@ public class SpringBootVirtualThreads implements SpringThreadingFeature {
     public void apply(GeneratorContext generatorContext) {
         Map<String, Object> config = generatorContext.getConfiguration();
 
-        // Enable by default only for JDK 24+
-        config.put("spring.threads.virtual.enabled", generatorContext.getJdkVersion().majorVersion() >= 24);
+        // Enable by default only for JDK 25+
+        config.put("spring.threads.virtual.enabled", generatorContext.getJdkVersion().majorVersion() >= 25);
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
@@ -31,9 +31,8 @@ import java.util.stream.Collectors;
 public enum JdkVersion {
     JDK_17(17),
     JDK_21(21),
-    // 24 is the current non-LTS release and will be replaced by 25 (LTS) in Sep 2025
-    // Spring Framework 6.2.x and Spring Boot 3.5.x will support 25
-    JDK_24(24);
+    // 25 is an LTS release and will be supported by Spring Framework 6.2.x and Spring Boot 3.5.x
+    JDK_25(25);
 
     public static final JdkVersion DEFAULT_OPTION = JDK_17;
 

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootVirtualThreadsSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootVirtualThreadsSpec.groovy
@@ -36,9 +36,9 @@ class SpringBootVirtualThreadsSpec extends BeanContextSpec implements CommandOut
         commandContext.configuration.get('spring.threads.virtual.enabled'.toString()) == false
     }
 
-    void "test spring boot virtual threads enabled for JDK 24+, when optional feature selected"() {
+    void "test spring boot virtual threads enabled for JDK 25+, when optional feature selected"() {
         when:
-        GeneratorContext commandContext = buildGeneratorContext(['spring-boot-virtual-threads'], new Options(TestFramework.DEFAULT_OPTION, JdkVersion.JDK_24))
+        GeneratorContext commandContext = buildGeneratorContext(['spring-boot-virtual-threads'], new Options(TestFramework.DEFAULT_OPTION, JdkVersion.JDK_25))
 
         then:
         commandContext.configuration.get('spring.threads.virtual.enabled'.toString()) == true

--- a/grails-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grails-profiles/base/skeleton/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-profiles/base/skeleton/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grails-profiles/profile/skeleton/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-profiles/profile/skeleton/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update Gradle wrapper to 8.14.4 across all modules:
- gradle/wrapper/gradle-wrapper.properties
- grails-forge/gradle/wrapper/gradle-wrapper.properties
- build-logic/gradle/wrapper/gradle-wrapper.properties
- grails-gradle/gradle/wrapper/gradle-wrapper.properties
- grails-profiles/base/skeleton/gradle/wrapper/gradle-wrapper.properties
- grails-profiles/profile/skeleton/gradle/wrapper/gradle-wrapper.properties
- .sdkmanrc

Gradle 8.14.4 addresses two security vulnerabilities:
- GHSA-mqwm-5m85-gmcv: Failure to disable repositories failing to answer
- GHSA-w78c-w6vf-rw82: Failure to disable repositories with unknown host

Additional fixes in 8.14.4:
- #34365: Gradle doesn't stop forked processes
- #35125: Precompiled script plugin with @file annotation
- #35184: Different fingerprints in compile classpath
- #35228: Fix dependency resolution issues
- #35288: Include GradleDslBaseScriptModel
- #36326: Improve repository disabling logic
- #36396: Add partial cgroups v2 support
- #36420: Improve Java 25 support

Update Java version from 24 to 25:
- GitHub workflows: CI matrix now tests against Java 17, 21, 25
- grails-forge: JdkVersion enum updated from JDK_24 to JDK_25
- SpringBootVirtualThreads: Updated threshold for virtual threads

Release: https://github.com/gradle/gradle/releases/tag/v8.14.4