### PR TITLE
Add clearConstraintsMapCache() public API to Validateable trait

### DIFF
--- a/grails-geb/src/testFixtures/groovy/grails/plugin/geb/serviceloader/ServiceRegistry.groovy
+++ b/grails-geb/src/testFixtures/groovy/grails/plugin/geb/serviceloader/ServiceRegistry.groovy
@@ -24,7 +24,7 @@ import groovy.transform.CompileStatic
  * A service registry that loads and caches different service types using the Java
  * {@link java.util.ServiceLoader}, while allowing overriding which instance to return.
  * <p>
- * This class provides thread-safe service loading and caching, supporting parallel test execution.
+ * This class provides thread-safe service loading and caching to prevent test environment pollution.
  * It provides both automatic service discovery through {@link java.util.ServiceLoader}
  * and explicit replacement of the returned service instance for customization.
  * </p>

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectNoDataSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectNoDataSpec.groovy
@@ -20,6 +20,7 @@
 package org.grails.web.commandobjects
 
 import grails.testing.web.GrailsWebUnitTest
+import org.grails.validation.ConstraintEvalUtils
 import spock.lang.Specification
 
 class CommandObjectNoDataSpec extends Specification implements GrailsWebUnitTest {
@@ -29,6 +30,26 @@ class CommandObjectNoDataSpec extends Specification implements GrailsWebUnitTest
             isProg inList: ['Emerson', 'Lake', 'Palmer']
         }
     }}
+
+    /**
+     * Clear the static constraints cache for Artist class.
+     * This is necessary because the Validateable trait caches constraints in a static field,
+     * and in parallel test execution, the constraints may be evaluated before doWithConfig()
+     * has registered the shared constraint 'isProg'.
+     *
+     * Also clear ConstraintEvalUtils.defaultConstraintsMap which caches shared constraints
+     * globally. In parallel test execution, another test's config may have been cached,
+     * causing the 'isProg' shared constraint to not be found.
+     */
+    def setup() {
+        ConstraintEvalUtils.clearDefaultConstraints()
+        Artist.clearConstraintsMapCache()
+    }
+
+    def cleanup() {
+        ConstraintEvalUtils.clearDefaultConstraints()
+        Artist.clearConstraintsMapCache()
+    }
 
     void "test shared constraint"() {
         when:

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectNoDataSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectNoDataSpec.groovy
@@ -33,12 +33,12 @@ class CommandObjectNoDataSpec extends Specification implements GrailsWebUnitTest
 
     /**
      * Clear the static constraints cache for Artist class.
-     * This is necessary because the Validateable trait caches constraints in a static field,
-     * and in parallel test execution, the constraints may be evaluated before doWithConfig()
+     * This prevents test environment pollution because the Validateable trait caches
+     * constraints in a static field, and constraints may be evaluated before doWithConfig()
      * has registered the shared constraint 'isProg'.
      *
      * Also clear ConstraintEvalUtils.defaultConstraintsMap which caches shared constraints
-     * globally. In parallel test execution, another test's config may have been cached,
+     * globally. Without this cleanup, another test's config may have been cached,
      * causing the 'isProg' shared constraint to not be found.
      */
     def setup() {

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectsSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectsSpec.groovy
@@ -41,12 +41,12 @@ class CommandObjectsSpec extends Specification implements ControllerUnitTest<Tes
 
     /**
      * Clear the static constraints cache for classes that use shared constraints.
-     * This is necessary because the Validateable trait caches constraints in a static field,
-     * and in parallel test execution, the constraints may be evaluated before doWithConfig()
+     * This prevents test environment pollution because the Validateable trait caches
+     * constraints in a static field, and constraints may be evaluated before doWithConfig()
      * has registered the shared constraint 'isProg'.
      *
      * Also clear ConstraintEvalUtils.defaultConstraintsMap which caches shared constraints
-     * globally. In parallel test execution, another test's config may have been cached,
+     * globally. Without this cleanup, another test's config may have been cached,
      * causing the 'isProg' shared constraint to not be found.
      */
     def setup() {

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectsSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectsSpec.groovy
@@ -23,6 +23,7 @@ import grails.artefact.Artefact
 import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import grails.validation.Validateable
+import org.grails.validation.ConstraintEvalUtils
 import spock.lang.Issue
 import spock.lang.Specification
 
@@ -37,6 +38,28 @@ class CommandObjectsSpec extends Specification implements ControllerUnitTest<Tes
             isProg inList: ['Emerson', 'Lake', 'Palmer']
         }
     }}
+
+    /**
+     * Clear the static constraints cache for classes that use shared constraints.
+     * This is necessary because the Validateable trait caches constraints in a static field,
+     * and in parallel test execution, the constraints may be evaluated before doWithConfig()
+     * has registered the shared constraint 'isProg'.
+     *
+     * Also clear ConstraintEvalUtils.defaultConstraintsMap which caches shared constraints
+     * globally. In parallel test execution, another test's config may have been cached,
+     * causing the 'isProg' shared constraint to not be found.
+     */
+    def setup() {
+        ConstraintEvalUtils.clearDefaultConstraints()
+        Artist.clearConstraintsMapCache()
+        ArtistSubclass.clearConstraintsMapCache()
+    }
+
+    def cleanup() {
+        ConstraintEvalUtils.clearDefaultConstraints()
+        Artist.clearConstraintsMapCache()
+        ArtistSubclass.clearConstraintsMapCache()
+    }
 
     void "Test command object with date binding"() {
         setup:

--- a/grails-validation/src/main/groovy/grails/validation/Validateable.groovy
+++ b/grails-validation/src/main/groovy/grails/validation/Validateable.groovy
@@ -104,6 +104,19 @@ trait Validateable {
     }
 
     /**
+     * Clears the cached constraints map, forcing re-evaluation on next access.
+     * This is useful in testing scenarios where shared constraints may need
+     * to be re-evaluated after configuration changes, particularly during
+     * parallel test execution.
+     *
+     * @since 7.1
+     */
+    @Generated
+    static void clearConstraintsMapCache() {
+        constraintsMapInternal = null
+    }
+
+    /**
      * Validate the object
      *
      * @return True if it is valid

--- a/grails-validation/src/main/groovy/grails/validation/Validateable.groovy
+++ b/grails-validation/src/main/groovy/grails/validation/Validateable.groovy
@@ -105,9 +105,9 @@ trait Validateable {
 
     /**
      * Clears the cached constraints map, forcing re-evaluation on next access.
-     * This is useful in testing scenarios where shared constraints may need
-     * to be re-evaluated after configuration changes, particularly during
-     * parallel test execution.
+     * This is useful in testing scenarios to prevent test environment pollution
+     * where shared constraints may need to be re-evaluated after configuration
+     * changes.
      *
      * @since 7.1
      */

--- a/grails-validation/src/test/groovy/grails/validation/ValidateableTraitAdHocSpec.groovy
+++ b/grails-validation/src/test/groovy/grails/validation/ValidateableTraitAdHocSpec.groovy
@@ -27,6 +27,20 @@ import spock.lang.Specification
 
 class ValidateableTraitAdHocSpec extends Specification {
 
+    /**
+     * Clear the static constraints cache for classes that use shared constraints.
+     * This is necessary because the Validateable trait caches constraints in a static field,
+     * and in parallel test execution, the constraints may be evaluated before configuration
+     * has registered the shared constraints.
+     */
+    void setup() {
+        PersonAdHocSharedConstraintsValidateable.clearConstraintsMapCache()
+    }
+
+    void cleanup() {
+        PersonAdHocSharedConstraintsValidateable.clearConstraintsMapCache()
+    }
+
     void 'Test that pre-declared constraints can be used'() {
         given:
         def person = new PersonAdHocValidateable(name: nameValue, age: ageValue)

--- a/grails-validation/src/test/groovy/grails/validation/ValidateableTraitAdHocSpec.groovy
+++ b/grails-validation/src/test/groovy/grails/validation/ValidateableTraitAdHocSpec.groovy
@@ -29,8 +29,8 @@ class ValidateableTraitAdHocSpec extends Specification {
 
     /**
      * Clear the static constraints cache for classes that use shared constraints.
-     * This is necessary because the Validateable trait caches constraints in a static field,
-     * and in parallel test execution, the constraints may be evaluated before configuration
+     * This prevents test environment pollution because the Validateable trait caches
+     * constraints in a static field, and constraints may be evaluated before configuration
      * has registered the shared constraints.
      */
     void setup() {

--- a/grails-validation/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
+++ b/grails-validation/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
@@ -36,6 +36,20 @@ import java.lang.reflect.Method
  */
 class ValidateableTraitSpec extends Specification {
 
+    /**
+     * Clear the static constraints cache for classes that use shared constraints.
+     * This is necessary because the Validateable trait caches constraints in a static field,
+     * and in parallel test execution, the constraints may be evaluated before configuration
+     * has registered the shared constraints.
+     */
+    void setup() {
+        SharedConstraintsValidateable.clearConstraintsMapCache()
+    }
+
+    void cleanup() {
+        SharedConstraintsValidateable.clearConstraintsMapCache()
+    }
+
     void 'Test validate can be invoked in a unit test with no special configuration'() {
         when: 'an object is valid'
         def validateable = new MyValidateable(name: 'Kirk', age: 47, town: 'STL')

--- a/grails-validation/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
+++ b/grails-validation/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
@@ -38,8 +38,8 @@ class ValidateableTraitSpec extends Specification {
 
     /**
      * Clear the static constraints cache for classes that use shared constraints.
-     * This is necessary because the Validateable trait caches constraints in a static field,
-     * and in parallel test execution, the constraints may be evaluated before configuration
+     * This prevents test environment pollution because the Validateable trait caches
+     * constraints in a static field, and constraints may be evaluated before configuration
      * has registered the shared constraints.
      */
     void setup() {


### PR DESCRIPTION
## Summary

Add a new static method `clearConstraintsMapCache()` to the `Validateable` trait that allows clearing the cached constraints map, forcing re-evaluation on next access.

## Motivation

The `Validateable` trait caches evaluated constraints in a private static field `constraintsMapInternal`. During parallel test execution, constraints may be evaluated before `doWithConfig()` has registered shared constraints, causing test failures where shared constraint names (like `'isProg'`) are not found.

This new public API method enables proper test isolation by allowing tests to clear the constraint cache in setup/cleanup methods.

## API Addition

```groovy
/**
 * Clears the cached constraints map, forcing re-evaluation on next access.
 * This is useful in testing scenarios where shared constraints may need
 * to be re-evaluated after configuration changes, particularly during
 * parallel test execution.
 *
 * @since 7.1
 */
@Generated
static void clearConstraintsMapCache()
```

## Usage Example

```groovy
class CommandObjectsSpec extends Specification implements ControllerUnitTest<TestController> {
    
    Closure doWithConfig() {{ config ->
        config['grails.gorm.default.constraints'] = {
            isProg inList: ['Emerson', 'Lake', 'Palmer']
        }
    }}

    def setup() {
        ConstraintEvalUtils.clearDefaultConstraints()
        Artist.clearConstraintsMapCache()
    }

    def cleanup() {
        ConstraintEvalUtils.clearDefaultConstraints()
        Artist.clearConstraintsMapCache()
    }
}
```

## Why This is a Feature (7.1)

Per the Grails versioning policy, adding a new public method to a trait is a backward-compatible feature addition that belongs in a MINOR release (7.1.x), not a PATCH release (7.0.x).

A companion change in PR #15335 (targeting 7.0.x) uses reflection to achieve the same test isolation without modifying the public API.

## Files Changed

- `grails-validation/src/main/groovy/grails/validation/Validateable.groovy` - Add new `clearConstraintsMapCache()` method
- `grails-validation/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy` - Add test isolation
- `grails-validation/src/test/groovy/grails/validation/ValidateableTraitAdHocSpec.groovy` - Add test isolation
- `grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectsSpec.groovy` - Add test isolation
- `grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectNoDataSpec.groovy` - Add test isolation