### PR TITLE
Apply transactional AST transformation to accessor methods in non-domain classes

### DIFF
--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/transform/AbstractMethodDecoratingTransformation.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/transform/AbstractMethodDecoratingTransformation.groovy
@@ -109,18 +109,9 @@ abstract class AbstractMethodDecoratingTransformation extends AbstractGormASTTra
         Map<String, ClassNode> genericsSpec = GenericsUtils.createGenericsSpec(classNode)
         List<MethodNode> methods = new ArrayList<MethodNode>(classNode.getMethods())
 
-        List<String> setterMethodNames = []
+        List<String> removedSetterMethodNames = []
         Iterator<MethodNode> methodNodeIterator = methods.iterator()
-        boolean isDomain = AstUtils.isDomainClass(classNode)
-        if (isDomain) {
-            while (methodNodeIterator.hasNext()) {
-                MethodNode md = methodNodeIterator.next()
-                if (isSetter(md)) {
-                    setterMethodNames.add(md.name)
-                    methodNodeIterator.remove()
-                }
-            }
-        }
+        removeSetterMethods(classNode, methodNodeIterator, removedSetterMethodNames)
 
         for (MethodNode md in methods) {
             String methodName = md.name
@@ -140,12 +131,12 @@ abstract class AbstractMethodDecoratingTransformation extends AbstractGormASTTra
 
                 if (METHOD_NAME_EXCLUDES.contains(methodName)) continue
 
-                if (isDomain && isGetter(md)) {
+                if (!removedSetterMethodNames.isEmpty() && isGetter(md)) {
                     final String propertyName = NameUtils.getPropertyNameForGetterOrSetter(md.name)
                     final String setterName = NameUtils.getSetterName(propertyName)
 
                     //If a setter exists for the getter, don't apply the transformation
-                    if (setterMethodNames.contains(setterName)) continue
+                    if (removedSetterMethodNames.contains(setterName)) continue
                 }
 
                 // don't apply to methods added by traits
@@ -398,4 +389,23 @@ abstract class AbstractMethodDecoratingTransformation extends AbstractGormASTTra
         return excludedAnnotation
     }
 
+    private static void removeSetterMethods(ClassNode classNode, Iterator<MethodNode> methodNodeIterator, List<String> setterMethodNames) {
+        boolean shouldExcludeSetters =
+                AstUtils.isDomainClass(classNode) || isGettersAndSettersIncluded()
+        if (!shouldExcludeSetters) return
+
+        while (methodNodeIterator.hasNext()) {
+            MethodNode methodNode = methodNodeIterator.next()
+            if (isSetter(methodNode)) {
+                setterMethodNames.add(methodNode.name)
+                methodNodeIterator.remove()
+            }
+        }
+    }
+
+    private static boolean isGettersAndSettersIncluded() {
+        return Boolean.parseBoolean(
+                System.getenv("GRAILS_TRANSACTIONAL_AST_INCLUDE_GETTERS_SETTERS")
+        )
+    }
 }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/transform/AbstractMethodDecoratingTransformation.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/transform/AbstractMethodDecoratingTransformation.groovy
@@ -45,6 +45,7 @@ import org.codehaus.groovy.transform.trait.Traits
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 
+import org.grails.datastore.mapping.reflect.AstUtils
 import org.grails.datastore.mapping.reflect.NameUtils
 
 import static org.codehaus.groovy.ast.ClassHelper.VOID_TYPE
@@ -110,11 +111,14 @@ abstract class AbstractMethodDecoratingTransformation extends AbstractGormASTTra
 
         List<String> setterMethodNames = []
         Iterator<MethodNode> methodNodeIterator = methods.iterator()
-        while (methodNodeIterator.hasNext()) {
-            MethodNode md = methodNodeIterator.next()
-            if (isSetter(md)) {
-                setterMethodNames.add(md.name)
-                methodNodeIterator.remove()
+        boolean isDomain = AstUtils.isDomainClass(classNode)
+        if (isDomain) {
+            while (methodNodeIterator.hasNext()) {
+                MethodNode md = methodNodeIterator.next()
+                if (isSetter(md)) {
+                    setterMethodNames.add(md.name)
+                    methodNodeIterator.remove()
+                }
             }
         }
 
@@ -136,7 +140,7 @@ abstract class AbstractMethodDecoratingTransformation extends AbstractGormASTTra
 
                 if (METHOD_NAME_EXCLUDES.contains(methodName)) continue
 
-                if (isGetter(md)) {
+                if (isDomain && isGetter(md)) {
                     final String propertyName = NameUtils.getPropertyNameForGetterOrSetter(md.name)
                     final String setterName = NameUtils.getSetterName(propertyName)
 

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/transform/AbstractMethodDecoratingTransformation.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/transform/AbstractMethodDecoratingTransformation.groovy
@@ -45,6 +45,9 @@ import org.codehaus.groovy.transform.trait.Traits
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 import org.grails.datastore.mapping.reflect.AstUtils
 import org.grails.datastore.mapping.reflect.NameUtils
 
@@ -84,6 +87,8 @@ abstract class AbstractMethodDecoratingTransformation extends AbstractGormASTTra
 
     private static final Set<String> METHOD_NAME_EXCLUDES = new HashSet<String>(Arrays.asList('afterPropertiesSet', 'destroy'))
     private static final Set<String> ANNOTATION_NAME_EXCLUDES = new HashSet<String>(Arrays.asList(PostConstruct.getName(), PreDestroy.getName(), 'grails.web.controllers.ControllerMethod'))
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AbstractMethodDecoratingTransformation)
     /**
      * Key used to store within the original method node metadata, all previous decorated methods
      */
@@ -397,6 +402,11 @@ abstract class AbstractMethodDecoratingTransformation extends AbstractGormASTTra
         while (methodNodeIterator.hasNext()) {
             MethodNode methodNode = methodNodeIterator.next()
             if (isSetter(methodNode)) {
+                LOG.debug(
+                        "Removing setter method '{}' from transactional AST processing for class '{}'",
+                        methodNode.name,
+                        classNode.name
+                )
                 setterMethodNames.add(methodNode.name)
                 methodNodeIterator.remove()
             }


### PR DESCRIPTION

Currently, methods whose names start with `get*` or `set*` are explicitly excluded
from transactional method decoration by `AbstractMethodDecoratingTransformation`.

While this behavior makes sense for stateful objects such as GORM domain classes
(where getters/setters may trigger lazy-loading, hydration, or expected exceptions),
it can lead to surprising behavior in stateless or prototype-scoped beans, especially
Services and background jobs.

In these cases, annotating a method like `setAsDeleted()` or `getOrCreate()` with
`@Transactional` silently results in the method *not* participating in a transaction,
which may cause data to be flushed and persisted even when an exception is thrown.

This behavior is non-obvious and has been reported as a gotcha by multiple users
(see #14539).

### Proposed change

Introduce an **opt-in mechanism** to allow accessor-style methods (`get*` / `set*`)
to be wrapped in transactional logic when explicitly requested.

This preserves the existing default behavior (no transactional decoration for
accessors), while allowing advanced use cases—such as stateless services,
batch jobs, and background processes—to opt in safely.

---

### Rationale

The original exclusion of getters and setters is reasonable for domain classes
and other stateful objects, where invoking accessors inside a transaction can
lead to unexpected side effects.

However, in stateless service-style beans, accessor-prefixed methods are often
used as semantic operations rather than property accessors, and excluding them
from transactional decoration can result in silent and hard-to-debug data
consistency issues.

Making this behavior opt-in avoids breaking existing assumptions while giving
developers an explicit and predictable escape hatch.

---

### Related discussions

- https://github.com/apache/grails-core/issues/14539
- https://grails.slack.com/archives/C07M0GTDE/p1765557083792879
