### PR TITLE
7.1.x Fix for UrlMapping greedy not working when no id is present

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/UrlMappingData.java
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/UrlMappingData.java
@@ -75,4 +75,14 @@ public interface UrlMappingData {
      * @return Whether the parameter before the optional extension should use greedy matching (last-dot split)
      */
     boolean hasGreedyExtensionParam();
+
+    /**
+     * Returns the token index (0-based) of the greedy parameter, or -1 if no greedy parameter exists.
+     * This is used to determine if a specific logical URL includes the greedy parameter.
+     *
+     * @return The index of the greedy token, or -1 if none
+     */
+    default int getGreedyTokenIndex() {
+        return -1;
+    }
 }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingData.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingData.java
@@ -47,6 +47,7 @@ public class DefaultUrlMappingData implements UrlMappingData {
     private List<Boolean> optionalTokens = new ArrayList<>();
     private boolean hasOptionalExtension;
     private boolean hasGreedyExtensionParam;
+    private int greedyTokenIndex = -1;
 
     public DefaultUrlMappingData(String urlPattern) {
         Assert.hasLength(urlPattern, "Argument [urlPattern] cannot be null or blank");
@@ -69,6 +70,11 @@ public class DefaultUrlMappingData implements UrlMappingData {
     @Override
     public boolean hasGreedyExtensionParam() {
         return hasGreedyExtensionParam;
+    }
+
+    @Override
+    public int getGreedyTokenIndex() {
+        return greedyTokenIndex;
     }
 
     private String[] tokenizeUrlPattern(String urlPattern) {
@@ -105,6 +111,8 @@ public class DefaultUrlMappingData implements UrlMappingData {
                 // Can be either (*)+ for required greedy or (*)+? for optional greedy
                 if (beforeExtension.endsWith("+") || beforeExtension.endsWith("+?")) {
                     hasGreedyExtensionParam = true;
+                    // The greedy token is the last token (before extension is stripped)
+                    greedyTokenIndex = tokens.length - 1;
                     // Remove the + (keep ? if it follows)
                     if (beforeExtension.endsWith("+?")) {
                         // (*)+? -> (*)?  (optional greedy)

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -245,11 +245,13 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                 // happen any time a URL mapping ends with a pattern like
                 // /$someVariable(.$someExtension)
                 pattern += "/([^/]+)\\.([^/.]+)?";
-            } else if (urlData.hasGreedyExtensionParam() && urlData.hasOptionalExtension()) {
+            } else if (urlData.hasGreedyExtensionParam() && urlData.hasOptionalExtension()
+                       && shouldApplyGreedyForUrl(url, urlData.getGreedyTokenIndex())) {
                 // Handle greedy extension param (+ marker): match everything up to the last dot
                 // The key is to make the entire dot+extension group optional using (?: )?
                 // For /(*)+(\.(*))?  we want regex: /(.+?)(?:\.([^/.]+))?  (required, greedy)
                 // For /(*)?+(\.(*))?  we want regex: /(.+?)?(?:\.([^/.]+))? (optional, greedy)
+                // Only apply greedy regex if this logical URL actually includes the greedy token
                 String processed = urlEnd
                         .replace("/(*)?(\\.(*))?", "/(.+?)?(?:\\.([^/.]+))?")   // Optional greedy: (*)?+
                         .replace("/(*)(\\.(*))?", "/(.+?)(?:\\.([^/.]+))?");    // Required greedy: (*)+
@@ -272,6 +274,26 @@ public class RegexUrlMapping extends AbstractUrlMapping {
         }
 
         return regex;
+    }
+
+    /**
+     * Determines if greedy regex should be applied for a given logical URL.
+     * Greedy regex should only be applied when the logical URL includes the greedy token.
+     * This is determined by counting the path segments (slashes) in the URL.
+     *
+     * @param url The logical URL being processed
+     * @param greedyTokenIndex The 0-based index of the greedy token
+     * @return true if greedy regex should be applied, false otherwise
+     */
+    private boolean shouldApplyGreedyForUrl(String url, int greedyTokenIndex) {
+        if (greedyTokenIndex < 0) {
+            return false;
+        }
+        // Count the number of path segments by counting slashes
+        // A URL with N slashes has N tokens (e.g., /a/b/c has 3 slashes and 3 tokens)
+        int slashCount = org.springframework.util.StringUtils.countOccurrencesOf(url, "/");
+        // The greedy token at index N is present only if there are at least N+1 slashes
+        return slashCount > greedyTokenIndex;
     }
 
     /**

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -245,8 +245,8 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                 // happen any time a URL mapping ends with a pattern like
                 // /$someVariable(.$someExtension)
                 pattern += "/([^/]+)\\.([^/.]+)?";
-            } else if (urlData.hasGreedyExtensionParam() && urlData.hasOptionalExtension()
-                       && shouldApplyGreedyForUrl(url, urlData.getGreedyTokenIndex())) {
+            } else if (urlData.hasGreedyExtensionParam() && urlData.hasOptionalExtension() &&
+                       shouldApplyGreedyForUrl(url, urlData.getGreedyTokenIndex())) {
                 // Handle greedy extension param (+ marker): match everything up to the last dot
                 // The key is to make the entire dot+extension group optional using (?: )?
                 // For /(*)+(\.(*))?  we want regex: /(.+?)(?:\.([^/.]+))?  (required, greedy)

--- a/grails-web-url-mappings/src/test/groovy/grails/web/mapping/UrlMappingsWithGreedyExtensionSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/grails/web/mapping/UrlMappingsWithGreedyExtensionSpec.groovy
@@ -227,4 +227,223 @@ class UrlMappingsWithGreedyExtensionSpec extends AbstractUrlMappingsSpec {
             info.urlData.hasGreedyExtensionParam()
             info.urlData.hasOptionalExtension()
     }
+
+    void "Test that greedy id with optional action matches controller-only URL with format"() {
+        given: "A complex URL mapping with optional action and optional greedy id"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$controller/$action?/$id+?(.$format)?"()
+            }
+
+        when: "Matching a URL with just controller and format (no action, no id)"
+            def info = urlMappingsHolder.match('/mobile.json')
+
+        then: "The controller and format are correctly extracted without greedy behavior affecting controller"
+            info != null
+            info.parameters.controller == 'mobile'
+            info.parameters.action == null
+            info.parameters.id == null
+            info.parameters.format == 'json'
+    }
+
+    void "Test that greedy id works correctly when all parameters are present"() {
+        given: "A complex URL mapping with optional action and optional greedy id"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$controller/$action?/$id+?(.$format)?"()
+            }
+
+        when: "Matching a URL with all parameters including id with dots"
+            def info = urlMappingsHolder.match('/user/show/bob.smith.json')
+
+        then: "The greedy id captures everything up to the last dot"
+            info != null
+            info.parameters.controller == 'user'
+            info.parameters.action == 'show'
+            info.parameters.id == 'bob.smith'
+            info.parameters.format == 'json'
+    }
+
+    void "Test that greedy id does not affect controller when only controller and action are present"() {
+        given: "A complex URL mapping with optional action and optional greedy id"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$controller/$action?/$id+?(.$format)?"()
+            }
+
+        when: "Matching a URL with controller and action only"
+            def info = urlMappingsHolder.match('/user/show.json')
+
+        then: "The controller and action are correctly extracted with format"
+            info != null
+            info.parameters.controller == 'user'
+            info.parameters.action == 'show'
+            info.parameters.id == null
+            info.parameters.format == 'json'
+    }
+
+    void "Test that controller with dots is handled correctly without greedy id"() {
+        given: "A complex URL mapping with optional action and optional greedy id"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$controller/$action?/$id+?(.$format)?"()
+            }
+
+        when: "Matching a URL with controller containing dots and format"
+            def info = urlMappingsHolder.match('/test.test.json')
+
+        then: "The URL /test.test.json should NOT apply greedy to controller"
+            info != null
+            println "DEBUG: controller=${info.parameters.controller}, action=${info.parameters.action}, id=${info.parameters.id}, format=${info.parameters.format}"
+            // The greedy + modifier only applies to $id, not $controller
+            // So /test.test.json should be parsed using non-greedy behavior:
+            // controller=test, format=test.json
+            info.parameters.controller == 'test'
+            info.parameters.action == null
+            info.parameters.id == null
+            info.parameters.format == 'test.json'
+    }
+
+    void "Test greedy id with no explicit format - what happens with bob.smith"() {
+        given: "A complex URL mapping with optional action and optional greedy id"
+            def urlMappingsHolder = getUrlMappingsHolder {
+                "/$controller/$action?/$id+?(.$format)?"()
+            }
+
+        when: "Matching a URL where the id contains a dot but there's no real format"
+            def info = urlMappingsHolder.match('/user/show/bob.smith')
+
+        then: "Check what actually happens - does .smith become the format?"
+            info != null
+            println "DEBUG bob.smith: controller=${info.parameters.controller}, action=${info.parameters.action}, id=${info.parameters.id}, format=${info.parameters.format}"
+            // With greedy matching, the last dot is treated as format separator
+            // So bob.smith becomes id=bob, format=smith
+            // This is the expected (though perhaps surprising) behavior of greedy matching
+            info.parameters.controller == 'user'
+            info.parameters.action == 'show'
+            info.parameters.id == 'bob'
+            info.parameters.format == 'smith'
+    }
+
+    void "Test non-greedy vs greedy behavior with bob.smith"() {
+        given: "Both greedy and non-greedy mappings"
+            def greedyHolder = getUrlMappingsHolder {
+                "/$controller/$action/$id+(.$format)?"()
+            }
+            def nonGreedyHolder = getUrlMappingsHolder {
+                "/$controller/$action/$id(.$format)?"()
+            }
+
+        when: "Matching the same URL"
+            def greedyInfo = greedyHolder.match('/user/show/bob.smith')
+            def nonGreedyInfo = nonGreedyHolder.match('/user/show/bob.smith')
+
+        then: "Greedy splits at last dot, non-greedy at first dot"
+            println "GREEDY:     id=${greedyInfo.parameters.id}, format=${greedyInfo.parameters.format}"
+            println "NON-GREEDY: id=${nonGreedyInfo.parameters.id}, format=${nonGreedyInfo.parameters.format}"
+
+            // Greedy: splits at LAST dot
+            greedyInfo.parameters.id == 'bob'
+            greedyInfo.parameters.format == 'smith'
+
+            // Non-greedy: splits at FIRST dot
+            nonGreedyInfo.parameters.id == 'bob'
+            nonGreedyInfo.parameters.format == 'smith'
+            // Wait - they're the same for single dot! Let's check with multiple dots
+    }
+
+    void "Test non-greedy vs greedy with multiple dots in id"() {
+        given: "Both greedy and non-greedy mappings"
+            def greedyHolder = getUrlMappingsHolder {
+                "/$controller/$action/$id+(.$format)?"()
+            }
+            def nonGreedyHolder = getUrlMappingsHolder {
+                "/$controller/$action/$id(.$format)?"()
+            }
+
+        when: "Matching URL with multiple dots"
+            def greedyInfo = greedyHolder.match('/user/show/bob.smith.jones')
+            def nonGreedyInfo = nonGreedyHolder.match('/user/show/bob.smith.jones')
+
+        then: "Greedy splits at last dot, non-greedy at first dot"
+            println "GREEDY (bob.smith.jones):     id=${greedyInfo.parameters.id}, format=${greedyInfo.parameters.format}"
+            println "NON-GREEDY (bob.smith.jones): id=${nonGreedyInfo.parameters.id}, format=${nonGreedyInfo.parameters.format}"
+
+            // Greedy: splits at LAST dot - id gets bob.smith, format gets jones
+            greedyInfo.parameters.id == 'bob.smith'
+            greedyInfo.parameters.format == 'jones'
+
+            // Non-greedy: splits at FIRST dot - id gets bob, format gets smith.jones
+            nonGreedyInfo.parameters.id == 'bob'
+            nonGreedyInfo.parameters.format == 'smith.jones'
+    }
+
+    void "Test format constraint to reject invalid formats"() {
+        given: "A mapping with format constraint to only allow known formats"
+            def holder = getUrlMappingsHolder {
+                "/$controller/$action/$id+(.$format)?" {
+                    constraints {
+                        format(inList: ['json', 'xml', 'html', 'csv'])
+                    }
+                }
+            }
+
+        when: "Matching URL where last segment is not a valid format"
+            def infoWithInvalidFormat = holder.match('/user/show/bob.smith')
+            def infoWithValidFormat = holder.match('/user/show/bob.smith.json')
+
+        then: "Invalid format should not match, valid format should work"
+            println "bob.smith (invalid format): ${infoWithInvalidFormat}"
+            println "bob.smith.json (valid format): id=${infoWithValidFormat?.parameters?.id}, format=${infoWithValidFormat?.parameters?.format}"
+
+            // With constraint, 'smith' is not a valid format so it should fail to match
+            infoWithInvalidFormat == null
+
+            // With valid format extension, it works
+            infoWithValidFormat != null
+            infoWithValidFormat.parameters.id == 'bob.smith'
+            infoWithValidFormat.parameters.format == 'json'
+    }
+
+    void "Test two mappings - greedy with format constraint plus fallback"() {
+        given: "Two mappings - greedy with format constraint first, plain fallback second"
+            def holder = getUrlMappingsHolder {
+                // First: greedy with format constraint for valid formats
+                "/$controller/$action/$id+(.$format)?" {
+                    constraints {
+                        format(inList: ['json', 'xml', 'html', 'csv'])
+                    }
+                }
+                // Fallback: captures id with dots when no valid format
+                "/$controller/$action/$id"()
+            }
+
+        when: "Testing various URLs"
+            def bobSmith = holder.match('/user/show/bob.smith')
+            def bobSmithJson = holder.match('/user/show/bob.smith.json')
+            def bobSmithJones = holder.match('/user/show/bob.smith.jones')
+            def bobSmithJonesXml = holder.match('/user/show/bob.smith.jones.xml')
+
+        then: "URLs with valid formats use greedy, others use fallback"
+            println "bob.smith:           id=${bobSmith?.parameters?.id}, format=${bobSmith?.parameters?.format}"
+            println "bob.smith.json:      id=${bobSmithJson?.parameters?.id}, format=${bobSmithJson?.parameters?.format}"
+            println "bob.smith.jones:     id=${bobSmithJones?.parameters?.id}, format=${bobSmithJones?.parameters?.format}"
+            println "bob.smith.jones.xml: id=${bobSmithJonesXml?.parameters?.id}, format=${bobSmithJonesXml?.parameters?.format}"
+
+            // bob.smith - 'smith' is not valid format, fallback captures whole id
+            bobSmith != null
+            bobSmith.parameters.id == 'bob.smith'
+            bobSmith.parameters.format == null
+
+            // bob.smith.json - 'json' is valid, greedy captures bob.smith as id
+            bobSmithJson != null
+            bobSmithJson.parameters.id == 'bob.smith'
+            bobSmithJson.parameters.format == 'json'
+
+            // bob.smith.jones - 'jones' is not valid, fallback captures whole id
+            bobSmithJones != null
+            bobSmithJones.parameters.id == 'bob.smith.jones'
+            bobSmithJones.parameters.format == null
+
+            // bob.smith.jones.xml - 'xml' is valid, greedy captures bob.smith.jones as id
+            bobSmithJonesXml != null
+            bobSmithJonesXml.parameters.id == 'bob.smith.jones'
+            bobSmithJonesXml.parameters.format == 'xml'
+    }
 }

--- a/grails-web-url-mappings/src/test/groovy/grails/web/mapping/UrlMappingsWithGreedyExtensionSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/grails/web/mapping/UrlMappingsWithGreedyExtensionSpec.groovy
@@ -290,7 +290,6 @@ class UrlMappingsWithGreedyExtensionSpec extends AbstractUrlMappingsSpec {
 
         then: "The URL /test.test.json should NOT apply greedy to controller"
             info != null
-            println "DEBUG: controller=${info.parameters.controller}, action=${info.parameters.action}, id=${info.parameters.id}, format=${info.parameters.format}"
             // The greedy + modifier only applies to $id, not $controller
             // So /test.test.json should be parsed using non-greedy behavior:
             // controller=test, format=test.json
@@ -309,9 +308,8 @@ class UrlMappingsWithGreedyExtensionSpec extends AbstractUrlMappingsSpec {
         when: "Matching a URL where the id contains a dot but there's no real format"
             def info = urlMappingsHolder.match('/user/show/bob.smith')
 
-        then: "Check what actually happens - does .smith become the format?"
+        then: "With greedy matching, the last dot is treated as format separator"
             info != null
-            println "DEBUG bob.smith: controller=${info.parameters.controller}, action=${info.parameters.action}, id=${info.parameters.id}, format=${info.parameters.format}"
             // With greedy matching, the last dot is treated as format separator
             // So bob.smith becomes id=bob, format=smith
             // This is the expected (though perhaps surprising) behavior of greedy matching
@@ -335,9 +333,6 @@ class UrlMappingsWithGreedyExtensionSpec extends AbstractUrlMappingsSpec {
             def nonGreedyInfo = nonGreedyHolder.match('/user/show/bob.smith')
 
         then: "Greedy splits at last dot, non-greedy at first dot"
-            println "GREEDY:     id=${greedyInfo.parameters.id}, format=${greedyInfo.parameters.format}"
-            println "NON-GREEDY: id=${nonGreedyInfo.parameters.id}, format=${nonGreedyInfo.parameters.format}"
-
             // Greedy: splits at LAST dot
             greedyInfo.parameters.id == 'bob'
             greedyInfo.parameters.format == 'smith'
@@ -362,9 +357,6 @@ class UrlMappingsWithGreedyExtensionSpec extends AbstractUrlMappingsSpec {
             def nonGreedyInfo = nonGreedyHolder.match('/user/show/bob.smith.jones')
 
         then: "Greedy splits at last dot, non-greedy at first dot"
-            println "GREEDY (bob.smith.jones):     id=${greedyInfo.parameters.id}, format=${greedyInfo.parameters.format}"
-            println "NON-GREEDY (bob.smith.jones): id=${nonGreedyInfo.parameters.id}, format=${nonGreedyInfo.parameters.format}"
-
             // Greedy: splits at LAST dot - id gets bob.smith, format gets jones
             greedyInfo.parameters.id == 'bob.smith'
             greedyInfo.parameters.format == 'jones'
@@ -389,9 +381,6 @@ class UrlMappingsWithGreedyExtensionSpec extends AbstractUrlMappingsSpec {
             def infoWithValidFormat = holder.match('/user/show/bob.smith.json')
 
         then: "Invalid format should not match, valid format should work"
-            println "bob.smith (invalid format): ${infoWithInvalidFormat}"
-            println "bob.smith.json (valid format): id=${infoWithValidFormat?.parameters?.id}, format=${infoWithValidFormat?.parameters?.format}"
-
             // With constraint, 'smith' is not a valid format so it should fail to match
             infoWithInvalidFormat == null
 
@@ -421,11 +410,6 @@ class UrlMappingsWithGreedyExtensionSpec extends AbstractUrlMappingsSpec {
             def bobSmithJonesXml = holder.match('/user/show/bob.smith.jones.xml')
 
         then: "URLs with valid formats use greedy, others use fallback"
-            println "bob.smith:           id=${bobSmith?.parameters?.id}, format=${bobSmith?.parameters?.format}"
-            println "bob.smith.json:      id=${bobSmithJson?.parameters?.id}, format=${bobSmithJson?.parameters?.format}"
-            println "bob.smith.jones:     id=${bobSmithJones?.parameters?.id}, format=${bobSmithJones?.parameters?.format}"
-            println "bob.smith.jones.xml: id=${bobSmithJonesXml?.parameters?.id}, format=${bobSmithJonesXml?.parameters?.format}"
-
             // bob.smith - 'smith' is not valid format, fallback captures whole id
             bobSmith != null
             bobSmith.parameters.id == 'bob.smith'


### PR DESCRIPTION
Follow up to https://github.com/apache/grails-core/pull/15213

```groovy
"/$controller/$action?/$id?(.$format)?"
```

resulted in `/user.json` not matching. only `/user` would match. This fixes that.

Is seems like the best pathway forward to support formats and string $id's with .'s is the following mapping:

```groovy
  // First: greedy with format constraint                                                                                              
  "/$controller/$action/$id+(.$format)?" {                                                                                             
      constraints {                                                                                                                    
          format(inList: ['json', 'xml', 'html', 'csv'])                                                                               
      }                                                                                                                                
  }                                                                                                                                    
  // Second: fallback for IDs with dots but no valid format                                                                            
  "/$controller/$action/$id"()  
```

  | URL | id | format | Which mapping? |                                                                                               
  |-----|-----|--------|----------------|                                                                                              
  | `/user/show/bob.smith` | `bob.smith` | `null` | Fallback (no valid format) |                                                       
  | `/user/show/bob.smith.json` | `bob.smith` | `json` | Greedy (valid format) |                                                       
  | `/user/show/bob.smith.jones` | `bob.smith.jones` | `null` | Fallback (no valid format) |                                           
  | `/user/show/bob.smith.jones.xml` | `bob.smith.jones` | `xml` | Greedy (valid format) |  