### PR TITLE
7.1.x - Simplify star imports check

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -18,6 +18,8 @@
  */
 package org.grails.gradle.plugin.core
 
+import java.util.zip.ZipFile
+
 import grails.util.BuildSettings
 import grails.util.Environment
 import grails.util.GrailsNameUtils
@@ -270,28 +272,23 @@ ${importStatements}
      * @param className The fully qualified class name to look for (e.g., 'grails.gorm.annotation.CreatedDate')
      * @return true if the class is found on the classpath
      */
-    protected boolean isClassOnClasspath(FileCollection classpath, String className) {
-        String classPath = className.replace('.', '/') + '.class'
-        for (File file : classpath.files) {
+    private static boolean isClassOnClasspath(FileCollection classpath, String className) {
+        def classEntry = className.replace('.', '/') + '.class'
+        classpath.files.any { f ->
             try {
-                if (file.isFile() && file.name.endsWith('.jar')) {
-                    def zip = new java.util.zip.ZipFile(file)
-                    try {
-                        if (zip.getEntry(classPath) != null) {
-                            return true
-                        }
-                    } finally {
-                        zip.close()
+                if (f.file && f.name.endsWith('.jar')) {
+                    new ZipFile(f).withCloseable { zip ->
+                        zip.getEntry(classEntry) != null
                     }
-                } else if (file.isDirectory()) {
-                    if (new File(file, classPath).exists()) {
-                        return true
-                    }
+                } else if (f.directory) {
+                    new File(f, classEntry).exists()
+                } else {
+                    false
                 }
             } catch (Exception ignored) {
+                false
             }
         }
-        return false
     }
 
     protected void excludeDependencies(Project project) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -234,13 +234,13 @@ class GrailsGradlePlugin extends GroovyPlugin {
             // Always add jakarta.validation.constraints
             starImports.add('jakarta.validation.constraints')
 
-            // Check for grails-datamapping-core (grails.gorm.annotation.*)
-            if (hasDependency(project, 'compileClasspath', 'org.apache.grails.data', 'grails-datamapping-core')) {
+            // Check for grails.gorm.annotation.* classes on classpath
+            if (isClassOnClasspath(compile.classpath, 'grails.gorm.annotation.CreatedDate')) {
                 starImports.add('grails.gorm.annotation')
             }
 
-            // Check for grails-scaffolding (grails.plugin.scaffolding.annotation.*)
-            if (hasDependency(project, 'compileClasspath', 'org.apache.grails', 'grails-scaffolding')) {
+            // Check for grails.plugin.scaffolding.annotation.* classes on classpath
+            if (isClassOnClasspath(compile.classpath, 'grails.plugin.scaffolding.annotation.Scaffold')) {
                 starImports.add('grails.plugin.scaffolding.annotation')
             }
         }
@@ -263,29 +263,35 @@ ${importStatements}
     }
 
     /**
-     * Check if a dependency is present in the configuration hierarchy.
-     * This checks all dependencies including those from parent configurations via extendsFrom.
+     * Check if a class exists on the given classpath.
+     * This detects classes from any source: direct dependencies, transitive dependencies, or local jars.
      *
-     * @param project The Gradle project
-     * @param configurationName The configuration to check (e.g., 'compileClasspath')
-     * @param group The dependency group (e.g., 'org.apache.grails.data')
-     * @param name The dependency name (e.g., 'grails-datamapping-core')
-     * @return true if the dependency is present in the configuration hierarchy
+     * @param classpath The FileCollection representing the classpath to search
+     * @param className The fully qualified class name to look for (e.g., 'grails.gorm.annotation.CreatedDate')
+     * @return true if the class is found on the classpath
      */
-    protected boolean hasDependency(Project project, String configurationName, String group, String name) {
-        try {
-            def configuration = project.configurations.findByName(configurationName)
-            if (configuration == null) {
-                return false
+    protected boolean isClassOnClasspath(FileCollection classpath, String className) {
+        String classPath = className.replace('.', '/') + '.class'
+        for (File file : classpath.files) {
+            try {
+                if (file.isFile() && file.name.endsWith('.jar')) {
+                    def zip = new java.util.zip.ZipFile(file)
+                    try {
+                        if (zip.getEntry(classPath) != null) {
+                            return true
+                        }
+                    } finally {
+                        zip.close()
+                    }
+                } else if (file.isDirectory()) {
+                    if (new File(file, classPath).exists()) {
+                        return true
+                    }
+                }
+            } catch (Exception ignored) {
             }
-
-            return configuration.allDependencies.any { d ->
-                d.group == group && d.name == name
-            }
-        } catch (Exception e) {
-            project.logger.debug("Failed to check for dependency ${group}:${name} in ${configurationName}: ${e.message}")
-            return false
         }
+        return false
     }
 
     protected void excludeDependencies(Project project) {


### PR DESCRIPTION
Rather than searching the dependency hierarchy, just check to see if the class is in the classpath.

enabled by: 
```gradle
grails {
    importGrailsCommonAnnotations = true
}
```