### PR TITLE
Update Develocity server URLs to develocity.apache.org

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -89,7 +89,7 @@ jobs:
           echo "VALUE<<EOF" >> $GITHUB_OUTPUT
           echo "def isAuthenticated = System.getenv('GRAILS_DEVELOCITY_ACCESS_KEY ') != null" >> $GITHUB_OUTPUT
           echo "develocity {" >> $GITHUB_OUTPUT
-          echo "    server = 'https://ge.grails.org'" >> $GITHUB_OUTPUT
+          echo "    server = 'https://develocity.apache.org'" >> $GITHUB_OUTPUT
           echo "    buildScan {" >> $GITHUB_OUTPUT
           echo "        tag('groovy')" >> $GITHUB_OUTPUT
           echo "        tag('grails-core')" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 # Apache Grails
 
 [![Documentation](https://img.shields.io/badge/Documentation-595959)](https://grails.apache.org/docs/)
-[![Develocity](https://img.shields.io/badge/Develocity-06A0CE?logo=Gradle&labelColor=06A0CE)](https://ge.grails.org/scans)
+[![Develocity](https://img.shields.io/badge/Develocity-06A0CE?logo=Gradle&labelColor=06A0CE)](https://develocity.apache.org/scans)
 [![CI](https://github.com/apache/grails-core/actions/workflows/gradle.yml/badge.svg?event=push)](https://github.com/apache/grails-core/actions/workflows/gradle.yml)
 [![Groovy Joint Validation Build](https://github.com/apache/grails-core/actions/workflows/groovy-joint-workflow.yml/badge.svg?event=push)](https://github.com/apache/grails-core/actions/workflows/groovy-joint-workflow.yml)
 [![Users Mailing List](https://img.shields.io/badge/Users_Mailing_List-feb571)](https://lists.apache.org/list.html?users@grails.apache.org)

--- a/build-logic/settings.gradle
+++ b/build-logic/settings.gradle
@@ -71,7 +71,7 @@ if (isReproducibleBuild) {
 }
 
 develocity {
-	server = 'https://ge.grails.org'
+	server = 'https://develocity.apache.org'
 	buildScan {
 		publishing.onlyIf { it.authenticated }
 		uploadInBackground = isLocal

--- a/grails-data-graphql/settings.gradle
+++ b/grails-data-graphql/settings.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 gradleEnterprise {
-    server = 'https://ge.grails.org'
+    server = 'https://develocity.apache.org'
     buildScan {
         publishAlwaysIf(System.getenv('CI') == 'true')
         publishIfAuthenticated()

--- a/grails-data-neo4j/settings.gradle
+++ b/grails-data-neo4j/settings.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 gradleEnterprise {
-    server = 'https://ge.grails.org'
+    server = 'https://develocity.apache.org'
     buildScan {
         publishAlwaysIf(System.getenv('CI') == 'true')
         publishIfAuthenticated()
@@ -39,7 +39,7 @@ buildCache {
     remote(HttpBuildCache) {
         push = System.getenv('CI') == 'true'
         enabled = true
-        url = 'https://ge.grails.org/cache/'
+        url = 'https://develocity.apache.org/cache/'
         credentials {
             username = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER')
             password = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY')

--- a/grails-forge/settings.gradle
+++ b/grails-forge/settings.gradle
@@ -38,7 +38,7 @@ def isLocal = !isCI
 def isReproducibleBuild = System.getenv('SOURCE_DATE_EPOCH') != null
 
 develocity {
-    server = 'https://ge.grails.org'
+    server = 'https://develocity.apache.org'
     buildScan {
         tag('grails')
         tag('grails-forge')

--- a/grails-gradle/settings.gradle
+++ b/grails-gradle/settings.gradle
@@ -41,7 +41,7 @@ if (isReproducibleBuild) {
 }
 
 develocity {
-	server = 'https://ge.grails.org'
+	server = 'https://develocity.apache.org'
 	buildScan {
 		tag('grails')
 		tag('grails-gradle-plugins')

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,7 +45,7 @@ if (isReproducibleBuild) {
 }
 
 develocity {
-    server = 'https://ge.grails.org'
+    server = 'https://develocity.apache.org'
     buildScan {
         tag('grails')
         tag('grails-core')


### PR DESCRIPTION
Replaced all instances of 'https://ge.grails.org' with 'https://develocity.apache.org' in build configuration files, workflow, and documentation. This ensures consistency and points to the new Develocity server endpoint.

`${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}` will need to be updated

local test:  https://develocity.apache.org/s/v5eykli7qunlw

Related PRs:

https://github.com/apache/grails-github-actions/pull/63
https://github.com/apache/grails-static-website/pull/423
https://github.com/apache/grails-gradle-publish/pull/24/
https://github.com/apache/grails-forge-ui/pull/79/
https://github.com/apache/grails-redis/pull/203
https://github.com/apache/grails-spring-security/pull/1199
https://github.com/apache/grails-quartz/pull/168