### PR TITLE
Set build-mount-path to /home/runner

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -46,6 +46,7 @@ jobs:
           remove-haskell: 'true' # Remove Haskell (~1 GB savings)
           remove-codeql: 'true'  # Remove CodeQL (~500 MB savings)
           remove-docker-images: 'false'  # Prune Docker if used (~1-2 GB savings)
+          build-mount-path: '/home/runner'
       - name: "📥 Checkout repository"
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Add the build-mount-path input to the workflow runner configuration, setting it to '/home/runner'. This explicitly defines the mount path for build operations on the runner environment, helping ensure consistent workspace paths during the docs publish job.