### PR TITLE
feat(grails-gradle): move indy configuration from generated apps to Gradle plugin

### DIFF
--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -61,13 +61,24 @@ In your gradle file, you can force a dependency upgrade via this code:
   }
 ----
 
-* By default, Groovy 4 switches away from callsite optimizations and uses invokedynamic instead. This can result in performance regressions compared to Grails 6. Groovy 5 will remove the ability to disable invokedynamic, but to disable it for Groovy 4, modify your `build.gradle` to include the following:
+* By default, Groovy 4 switches away from callsite optimizations and uses invokedynamic instead. This can result in performance regressions compared to Grails 6. The Grails Gradle Plugin now automatically disables invokedynamic for all `GroovyCompile` tasks (see https://github.com/apache/grails-core/issues/15293[#15293]). If you have a manual `tasks.withType(GroovyCompile)` block in your `build.gradle` that sets `indy = false`, you can safely remove it:
+
+[source,groovy]
+.build.gradle - remove this block (no longer needed)
+----
+  // This is now handled by the Grails Gradle Plugin - remove it
+  tasks.withType(GroovyCompile).configureEach {
+        groovyOptions.optimizationOptions.indy = false
+  }
+----
+
+To re-enable invokedynamic, use the `grails` extension in your `build.gradle`:
 
 [source,groovy]
 .build.gradle
 ----
-  tasks.withType(GroovyCompile).configureEach {
-        groovyOptions.optimizationOptions.indy = false
+  grails {
+      indy = true
   }
 ----
 

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -61,7 +61,7 @@ In your gradle file, you can force a dependency upgrade via this code:
   }
 ----
 
-* By default, Groovy 4 switches away from callsite optimizations and uses invokedynamic instead. This can result in performance regressions compared to Grails 6. The Grails Gradle Plugin now automatically disables invokedynamic for all `GroovyCompile` tasks (see https://github.com/apache/grails-core/issues/15293[#15293]). If you have a manual `tasks.withType(GroovyCompile)` block in your `build.gradle` that sets `indy = false`, you can safely remove it:
+* By default, Groovy 4 switches away from callsite optimizations and uses invokedynamic instead. This can result in performance regressions compared to Grails 6. The Grails Gradle Plugins now automatically disables invokedynamic for all `GroovyCompile` tasks (see https://github.com/apache/grails-core/issues/15293[#15293]). If you have a manual `tasks.withType(GroovyCompile)` block in your `build.gradle` that sets `indy = false`, you can safely remove it:
 
 [source,groovy]
 .build.gradle - remove this block (no longer needed)

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -142,7 +142,3 @@ assets {
 
 }
 
-// https://github.com/apache/grails-core/issues/15321
-tasks.withType(GroovyCompile).configureEach {
-    groovyOptions.optimizationOptions.indy = false
-}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -86,6 +86,10 @@ class GrailsExtension {
      */
     final Property<Boolean> indy
 
+    void setIndy(boolean enabled) {
+        this.indy.set(enabled)
+    }
+
     DependencyHandler getPlugins() {
         if (pluginDefiner == null) {
             pluginDefiner = new PluginDefiner(project)

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -23,6 +23,7 @@ import groovy.transform.CompileStatic
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.provider.Property
 import org.gradle.util.internal.ConfigureUtil
 
 import grails.util.Environment
@@ -42,6 +43,7 @@ class GrailsExtension {
     GrailsExtension(Project project) {
         this.project = project
         this.pluginDefiner = new PluginDefiner(project)
+        this.indy = project.objects.property(Boolean).convention(false)
     }
 
     /**
@@ -75,6 +77,14 @@ class GrailsExtension {
      * Gradle property is enforced.
      */
     boolean micronautAutoSetup = true
+
+    /**
+     * Whether to enable Groovy's invokedynamic (indy) bytecode instruction for dynamic Groovy method dispatch.
+     * Disabled by default to improve performance (see GitHub issue #15293).
+     * When enabled, Groovy uses JVM invokedynamic instead of traditional callsite caching.
+     * To enable invokedynamic in build.gradle: grails { indy = true }
+     */
+    final Property<Boolean> indy
 
     DependencyHandler getPlugins() {
         if (pluginDefiner == null) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -184,8 +184,13 @@ class GrailsGradlePlugin extends GroovyPlugin {
     private void configureGroovyCompiler(Project project) {
         Provider<RegularFile> groovyCompilerConfigFile = project.layout.buildDirectory.file('grailsGroovyCompilerConfig.groovy')
 
+        GrailsExtension grailsExtension = project.extensions.findByType(GrailsExtension)
+
         project.tasks.withType(GroovyCompile).configureEach { GroovyCompile c ->
             c.outputs.file(groovyCompilerConfigFile)
+
+            // Configure indy option from GrailsExtension
+            c.groovyOptions.optimizationOptions.indy = grailsExtension?.indy?.getOrElse(false) ?: false
 
             Closure<String> userScriptGenerator = getGroovyCompilerScript(c, project)
             c.doFirst {
@@ -214,6 +219,14 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 """
                 combinedFile.write(combinedScripts)
                 c.groovyOptions.configurationScript = combinedFile
+            }
+        }
+
+        // Log indy status once per project after evaluation
+        project.afterEvaluate {
+            if (!grailsExtension?.indy?.getOrElse(false)) {
+                project.logger.lifecycle('Grails: Groovy invokedynamic (indy) is disabled to improve performance (see issue #15293).')
+                project.logger.lifecycle('        To enable invokedynamic: grails { indy = true } in build.gradle')
             }
         }
     }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -189,9 +189,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
         project.tasks.withType(GroovyCompile).configureEach { GroovyCompile c ->
             c.outputs.file(groovyCompilerConfigFile)
 
-            // Configure indy option from GrailsExtension
-            c.groovyOptions.optimizationOptions.indy = grailsExtension?.indy?.getOrElse(false) ?: false
-
             Closure<String> userScriptGenerator = getGroovyCompilerScript(c, project)
             c.doFirst {
                 // This isn't ideal - we're performing configuration at execution time, but the alternative would be having
@@ -222,9 +219,13 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
         }
 
-        // Log indy status once per project after evaluation
+        // Configure indy and log status after evaluation so user's grails { } block has been applied
         project.afterEvaluate {
-            if (!grailsExtension?.indy?.getOrElse(false)) {
+            boolean indyEnabled = grailsExtension?.indy?.getOrElse(false) ?: false
+            project.tasks.withType(GroovyCompile).configureEach { GroovyCompile c ->
+                c.groovyOptions.optimizationOptions.indy = indyEnabled
+            }
+            if (!indyEnabled) {
                 project.logger.lifecycle('Grails: Groovy invokedynamic (indy) is disabled to improve performance (see issue #15293).')
                 project.logger.lifecycle('        To enable invokedynamic: grails { indy = true } in build.gradle')
             }

--- a/grails-profiles/base/skeleton/build.gradle
+++ b/grails-profiles/base/skeleton/build.gradle
@@ -27,7 +27,3 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
 
-// https://github.com/apache/grails-core/issues/15321
-tasks.withType(GroovyCompile).configureEach {
-    groovyOptions.optimizationOptions.indy = false
-}


### PR DESCRIPTION
## Summary

Move the Groovy invokedynamic (indy) configuration from generated `build.gradle` files to the Grails Gradle Plugin, centralizing the setting and providing user feedback.

## Changes

- Add `indy` property to `GrailsExtension` (default: `false`)
- Configure `GroovyCompile` tasks in `GrailsGradlePlugin` to use the extension's indy setting
- Display lifecycle message explaining indy is disabled for performance and how to enable it
- Remove hardcoded `indy=false` from grails-forge template
- Remove hardcoded `indy=false` from grails-profiles base skeleton

## User Experience

The message appears **once per project** during configuration:

```
> Configure project :
Grails: Groovy invokedynamic (indy) is disabled to improve performance (see issue #15293).
        To enable invokedynamic: grails { indy = true } in build.gradle
```

Users can enable indy in their `build.gradle`:

```groovy
grails {
    indy = true
}
```

## Testing

- ✅ grails-gradle-plugins compiles successfully
- ✅ grails-forge-core compiles successfully  
- ✅ Message appears once during project configuration
- ✅ Application starts and runs correctly

Closes #15321

## Documentation

- Updated the upgrade guide (`upgrading60x.adoc`) to reflect that the Grails Gradle Plugin now handles indy configuration automatically
- Users upgrading are instructed to remove the manual `tasks.withType(GroovyCompile)` block from their `build.gradle`
- Documents the new `grails { indy = true }` extension for re-enabling invokedynamic