### PR TITLE
Include jakarta.servlet-api in CLI runtime classpath

### DIFF
--- a/grails-shell-cli/build.gradle
+++ b/grails-shell-cli/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-loader-tools'
     compileOnly 'org.springframework:spring-web'
     api 'org.springframework.boot:spring-boot-cli'
-    compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    implementation 'jakarta.servlet:jakarta.servlet-api'
     compileOnly "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
 
     // Maven Resolver API & friends


### PR DESCRIPTION
## Summary

- Fix `NoClassDefFoundError` for `jakarta/servlet/ServletRequest` when `grailsw` compiles custom scripts in `src/main/scripts/`

## Problem

The `grails-cli` shadow JAR bundles `grails-web-common` (which registers `HttpServletRequestExtension` as a Groovy extension module), but `jakarta.servlet-api` is declared as `compileOnly` in `grails-shell-cli`. This means the servlet API classes are excluded from the fat JAR.

When the CLI's `GroovyScriptCommandFactory` compiles custom command scripts, the Groovy compiler auto-discovers the `HttpServletRequestExtension` from the fat JAR's classpath. Initializing this extension requires `jakarta.servlet.ServletRequest`, which is missing — causing all `grailsw` commands to fail when custom scripts exist in `src/main/scripts/`.

## Fix

Change `jakarta.servlet-api` from `compileOnly` to `implementation` in `grails-shell-cli/build.gradle` so it is included in the shadow JAR's runtime classpath.

## Reproduction

1. Create a Grails 7 project with any custom script in `src/main/scripts/`
2. Run `./grailsw dbm-gorm-diff` (or any grailsw command)
3. Observe: `Failed to compile <script>.groovy: Unable to configure org.grails.web.mime.HttpServletRequestExtension due to missing dependency jakarta/servlet/ServletRequest`