### PR TITLE
fix: GormEnhancer.allQualifiers() overrides explicit datasource declarations for MultiTenant entities

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiTenantMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiTenantMultiDataSourceSpec.groovy
@@ -18,6 +18,13 @@
  */
 package org.grails.orm.hibernate.connections
 
+import org.hibernate.Session
+import org.hibernate.dialect.H2Dialect
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
 import grails.gorm.MultiTenant
 import grails.gorm.annotation.Entity
 import grails.gorm.services.Service
@@ -29,11 +36,6 @@ import org.grails.datastore.mapping.core.DatastoreUtils
 import org.grails.datastore.mapping.multitenancy.MultiTenancySettings
 import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
 import org.grails.orm.hibernate.HibernateDatastore
-import org.hibernate.Session
-import org.hibernate.dialect.H2Dialect
-import spock.lang.AutoCleanup
-import spock.lang.Shared
-import spock.lang.Specification
 
 /**
  * Tests GORM Data Service auto-implemented CRUD methods when both DISCRIMINATOR
@@ -53,6 +55,7 @@ import spock.lang.Specification
  * @see PartitionedMultiTenancySpec for basic DISCRIMINATOR multi-tenancy
  * @see MultipleDataSourceConnectionsSpec for Data Services on secondary datasource without multi-tenancy
  */
+@RestoreSystemProperties
 class DataServiceMultiTenantMultiDataSourceSpec extends Specification {
 
     @Shared @AutoCleanup HibernateDatastore datastore
@@ -78,115 +81,112 @@ class DataServiceMultiTenantMultiDataSourceSpec extends Specification {
     MetricService metricService
 
     void setup() {
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant1")
-        metricService = datastore.getDatastoreForConnection("analytics").getService(MetricService)
+        tenant = 'tenant1'
+        metricService = datastore
+                .getDatastoreForConnection('analytics')
+                .getService(MetricService)
         metricService.deleteAll()
         // Also clean tenant2 data
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
+        tenant = 'tenant2'
         metricService.deleteAll()
         // Reset to tenant1 for tests
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant1")
-    }
-
-    void cleanup() {
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "")
+        tenant = 'tenant1'
     }
 
     void "schema is created on analytics datasource"() {
-        expect: "The analytics datasource connects to the analyticsDB H2 database"
+        expect: 'The analytics datasource connects to the analyticsDB H2 database'
         Metric.analytics.withNewSession { Session s ->
-            assert s.connection().metaData.getURL() == "jdbc:h2:mem:analyticsDB"
+            assert s.connection().metaData.getURL() == 'jdbc:h2:mem:analyticsDB'
             return true
         }
 
-        and: "The default datasource connects to a different database"
+        and: 'The default datasource connects to a different database'
         datastore.withNewSession { Session s ->
-            assert s.connection().metaData.getURL() == "jdbc:h2:mem:grailsDB"
+            assert s.connection().metaData.getURL() == 'jdbc:h2:mem:grailsDB'
             return true
         }
     }
 
     void "save routes to analytics datasource with tenant isolation"() {
-        when: "A metric is saved under tenant1"
-        Metric saved = metricService.save(new Metric(name: "page_views", amount: 100))
+        when: 'A metric is saved under tenant1'
+        def saved = metricService.save(new Metric(name: 'page_views', amount: 100))
 
-        then: "The metric is persisted with an ID"
+        then: 'The metric is persisted with an ID'
         saved != null
         saved.id != null
-        saved.name == "page_views"
+        saved.name == 'page_views'
         saved.amount == 100
 
-        and: "The metric is retrievable via the analytics datasource qualifier"
+        and: 'The metric is retrievable via the analytics datasource qualifier'
         Metric.analytics.withNewSession {
             Metric.analytics.get(saved.id) != null
         }
     }
 
     void "get retrieves from analytics datasource"() {
-        given: "A metric saved to the analytics datasource"
-        Metric saved = metricService.save(new Metric(name: "sessions", amount: 42))
+        given: 'A metric saved to the analytics datasource'
+        def saved = metricService.save(new Metric(name: 'sessions', amount: 42))
 
-        when: "The metric is retrieved by ID"
-        Metric found = metricService.get(saved.id)
+        when: 'The metric is retrieved by ID'
+        def found = metricService.get(saved.id)
 
-        then: "The correct metric is returned"
+        then: 'The correct metric is returned'
         found != null
         found.id == saved.id
-        found.name == "sessions"
+        found.name == 'sessions'
         found.amount == 42
     }
 
     void "count returns count scoped to current tenant"() {
-        given: "Metrics saved under tenant1"
-        metricService.save(new Metric(name: "alpha", amount: 1))
-        metricService.save(new Metric(name: "beta", amount: 2))
+        given: 'Metrics saved under tenant1'
+        metricService.save(new Metric(name: 'alpha', amount: 1))
+        metricService.save(new Metric(name: 'beta', amount: 2))
 
-        and: "Metrics saved under tenant2"
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
-        metricService.save(new Metric(name: "gamma", amount: 3))
+        and: 'Metrics saved under tenant2'
+        tenant = 'tenant2'
+        metricService.save(new Metric(name: 'gamma', amount: 3))
 
-        when: "Counting under tenant1"
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant1")
-        Long count1 = metricService.count()
+        when: 'Counting under tenant1'
+        tenant = 'tenant1'
+        def count1 = metricService.count()
 
-        and: "Counting under tenant2"
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
-        Long count2 = metricService.count()
+        and: 'Counting under tenant2'
+        tenant = 'tenant2'
+        def count2 = metricService.count()
 
-        then: "Each tenant sees only its own data"
+        then: 'Each tenant sees only its own data'
         count1 == 2
         count2 == 1
     }
 
     void "delete removes from analytics datasource"() {
-        given: "A metric saved under tenant1"
-        Metric saved = metricService.save(new Metric(name: "disposable", amount: 0))
-        Long id = saved.id
+        given: 'A metric saved under tenant1'
+        def saved = metricService.save(new Metric(name: 'disposable', amount: 0))
+        def id = saved.id
 
-        when: "The metric is deleted"
+        when: 'The metric is deleted'
         metricService.delete(id)
 
-        then: "The metric is no longer retrievable"
+        then: 'The metric is no longer retrievable'
         metricService.get(id) == null
         metricService.count() == 0
     }
 
     void "findByName routes to analytics datasource with tenant isolation"() {
-        given: "Same-named metrics under different tenants"
-        metricService.save(new Metric(name: "shared_name", amount: 100))
+        given: 'Same-named metrics under different tenants'
+        metricService.save(new Metric(name: 'shared_name', amount: 100))
+        tenant = 'tenant2'
+        metricService.save(new Metric(name: 'shared_name', amount: 200))
 
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
-        metricService.save(new Metric(name: "shared_name", amount: 200))
+        when: 'Finding by name under tenant1'
+        tenant = 'tenant1'
+        def found1 = metricService.findByName('shared_name')
 
-        when: "Finding by name under tenant1"
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant1")
-        Metric found1 = metricService.findByName("shared_name")
+        and: 'Finding by name under tenant2'
+        tenant = 'tenant2'
+        def found2 = metricService.findByName('shared_name')
 
-        and: "Finding by name under tenant2"
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
-        Metric found2 = metricService.findByName("shared_name")
-
-        then: "Each tenant gets its own metric"
+        then: 'Each tenant gets its own metric'
         found1 != null
         found1.amount == 100
 
@@ -195,31 +195,35 @@ class DataServiceMultiTenantMultiDataSourceSpec extends Specification {
     }
 
     void "GormEnhancer resolves analytics qualifier for MultiTenant entity with explicit datasource"() {
-        when: "Looking up the static API without specifying a connection"
-        GormStaticApi<Metric> api = GormEnhancer.findStaticApi(Metric)
+        when: 'Looking up the static API without specifying a connection'
+        def api = GormEnhancer.findStaticApi(Metric)
 
-        then: "The API is registered and functional (schema exists on correct datasource)"
+        then: 'The API is registered and functional (schema exists on correct datasource)'
         api != null
 
-        when: "Using the explicit analytics qualifier"
-        GormStaticApi<Metric> analyticsApi = GormEnhancer.findStaticApi(Metric, 'analytics')
+        when: 'Using the explicit analytics qualifier'
+        def analyticsApi = GormEnhancer.findStaticApi(Metric, 'analytics')
 
-        then: "The analytics API is also registered"
+        then: 'The analytics API is also registered'
         analyticsApi != null
     }
 
     void "GormEnhancer aggregate HQL routes to analytics datasource"() {
-        given: "Multiple metrics saved under tenant1"
-        metricService.save(new Metric(name: "alpha", amount: 10))
-        metricService.save(new Metric(name: "beta", amount: 20))
-        metricService.save(new Metric(name: "gamma", amount: 30))
+        given: 'Multiple metrics saved under tenant1'
+        metricService.save(new Metric(name: 'alpha', amount: 10))
+        metricService.save(new Metric(name: 'beta', amount: 20))
+        metricService.save(new Metric(name: 'gamma', amount: 30))
 
-        when: "Using GormEnhancer for an aggregate query"
-        List results = metricService.getTotalAmountAbove(15)
+        when: 'Using GormEnhancer for an aggregate query'
+        def results = metricService.getTotalAmountAbove(15)
 
-        then: "The HQL executes against the analytics datasource"
+        then: 'The HQL executes against the analytics datasource'
         results.size() == 1
         results[0] == 50  // 20 + 30
+    }
+    
+    private static void setTenant(String tenantId) {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, tenantId)
     }
 }
 
@@ -264,7 +268,7 @@ interface MetricDataService {
  * and custom methods route to the secondary datasource.
  */
 @Service(Metric)
-@Transactional(connection = "analytics")
+@Transactional(connection = 'analytics')
 abstract class MetricService implements MetricDataService {
 
     /**

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiTenantMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiTenantMultiDataSourceSpec.groovy
@@ -51,7 +51,7 @@ import spock.lang.Specification
  * - Tenant isolation: same-named data under different tenants stays separate
  *
  * @see PartitionedMultiTenancySpec for basic DISCRIMINATOR multi-tenancy
- * @see DataServiceMultiDataSourceSpec for Data Services on secondary datasource without multi-tenancy
+ * @see MultipleDataSourceConnectionsSpec for Data Services on secondary datasource without multi-tenancy
  */
 class DataServiceMultiTenantMultiDataSourceSpec extends Specification {
 
@@ -115,6 +115,11 @@ class DataServiceMultiTenantMultiDataSourceSpec extends Specification {
         saved.id != null
         saved.name == "page_views"
         saved.amount == 100
+
+        and: "The metric is retrievable via the analytics datasource qualifier"
+        Metric.analytics.withNewSession {
+            Metric.analytics.get(saved.id) != null
+        }
     }
 
     void "get retrieves from analytics datasource"() {
@@ -187,6 +192,20 @@ class DataServiceMultiTenantMultiDataSourceSpec extends Specification {
 
         found2 != null
         found2.amount == 200
+    }
+
+    void "GormEnhancer resolves analytics qualifier for MultiTenant entity with explicit datasource"() {
+        when: "Looking up the static API without specifying a connection"
+        GormStaticApi<Metric> api = GormEnhancer.findStaticApi(Metric)
+
+        then: "The API is registered and functional (schema exists on correct datasource)"
+        api != null
+
+        when: "Using the explicit analytics qualifier"
+        GormStaticApi<Metric> analyticsApi = GormEnhancer.findStaticApi(Metric, 'analytics')
+
+        then: "The analytics API is also registered"
+        analyticsApi != null
     }
 
     void "GormEnhancer aggregate HQL routes to analytics datasource"() {

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiTenantMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiTenantMultiDataSourceSpec.groovy
@@ -1,0 +1,274 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.orm.hibernate.connections
+
+import grails.gorm.MultiTenant
+import grails.gorm.annotation.Entity
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.gorm.GormEntity
+import org.grails.datastore.gorm.GormStaticApi
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.datastore.mapping.multitenancy.MultiTenancySettings
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
+import org.grails.orm.hibernate.HibernateDatastore
+import org.hibernate.Session
+import org.hibernate.dialect.H2Dialect
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Tests GORM Data Service auto-implemented CRUD methods when both DISCRIMINATOR
+ * multi-tenancy and a non-default datasource are configured on the same domain.
+ *
+ * This combination triggers the allQualifiers() bug: when MultiTenant is present,
+ * allQualifiers() returns tenant IDs instead of datasource names, causing schema
+ * creation and query routing to go to the wrong database.
+ *
+ * Covers:
+ * - Schema creation on the correct (analytics) datasource for MultiTenant domains
+ * - save(), get(), delete(), count() with tenant isolation on secondary datasource
+ * - findBy* dynamic finders with tenant isolation on secondary datasource
+ * - GormEnhancer escape-hatch for aggregate HQL on secondary datasource
+ * - Tenant isolation: same-named data under different tenants stays separate
+ *
+ * @see PartitionedMultiTenancySpec for basic DISCRIMINATOR multi-tenancy
+ * @see DataServiceMultiDataSourceSpec for Data Services on secondary datasource without multi-tenancy
+ */
+class DataServiceMultiTenantMultiDataSourceSpec extends Specification {
+
+    @Shared @AutoCleanup HibernateDatastore datastore
+
+    void setupSpec() {
+        Map config = [
+                "grails.gorm.multiTenancy.mode": MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR,
+                "grails.gorm.multiTenancy.tenantResolverClass": SystemPropertyTenantResolver,
+                'dataSource.url': "jdbc:h2:mem:grailsDB;LOCK_TIMEOUT=10000",
+                'dataSource.dbCreate': 'create-drop',
+                'dataSource.dialect': H2Dialect.name,
+                'dataSource.formatSql': 'true',
+                'hibernate.flush.mode': 'COMMIT',
+                'hibernate.cache.queries': 'true',
+                'hibernate.hbm2ddl.auto': 'create-drop',
+                'dataSources.analytics': [url: "jdbc:h2:mem:analyticsDB;LOCK_TIMEOUT=10000"],
+        ]
+
+        datastore = new HibernateDatastore(
+                DatastoreUtils.createPropertyResolver(config), Metric)
+    }
+
+    MetricService metricService
+
+    void setup() {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant1")
+        metricService = datastore.getDatastoreForConnection("analytics").getService(MetricService)
+        metricService.deleteAll()
+        // Also clean tenant2 data
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
+        metricService.deleteAll()
+        // Reset to tenant1 for tests
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant1")
+    }
+
+    void cleanup() {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "")
+    }
+
+    void "schema is created on analytics datasource"() {
+        expect: "The analytics datasource connects to the analyticsDB H2 database"
+        Metric.analytics.withNewSession { Session s ->
+            assert s.connection().metaData.getURL() == "jdbc:h2:mem:analyticsDB"
+            return true
+        }
+
+        and: "The default datasource connects to a different database"
+        datastore.withNewSession { Session s ->
+            assert s.connection().metaData.getURL() == "jdbc:h2:mem:grailsDB"
+            return true
+        }
+    }
+
+    void "save routes to analytics datasource with tenant isolation"() {
+        when: "A metric is saved under tenant1"
+        Metric saved = metricService.save(new Metric(name: "page_views", amount: 100))
+
+        then: "The metric is persisted with an ID"
+        saved != null
+        saved.id != null
+        saved.name == "page_views"
+        saved.amount == 100
+    }
+
+    void "get retrieves from analytics datasource"() {
+        given: "A metric saved to the analytics datasource"
+        Metric saved = metricService.save(new Metric(name: "sessions", amount: 42))
+
+        when: "The metric is retrieved by ID"
+        Metric found = metricService.get(saved.id)
+
+        then: "The correct metric is returned"
+        found != null
+        found.id == saved.id
+        found.name == "sessions"
+        found.amount == 42
+    }
+
+    void "count returns count scoped to current tenant"() {
+        given: "Metrics saved under tenant1"
+        metricService.save(new Metric(name: "alpha", amount: 1))
+        metricService.save(new Metric(name: "beta", amount: 2))
+
+        and: "Metrics saved under tenant2"
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
+        metricService.save(new Metric(name: "gamma", amount: 3))
+
+        when: "Counting under tenant1"
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant1")
+        Long count1 = metricService.count()
+
+        and: "Counting under tenant2"
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
+        Long count2 = metricService.count()
+
+        then: "Each tenant sees only its own data"
+        count1 == 2
+        count2 == 1
+    }
+
+    void "delete removes from analytics datasource"() {
+        given: "A metric saved under tenant1"
+        Metric saved = metricService.save(new Metric(name: "disposable", amount: 0))
+        Long id = saved.id
+
+        when: "The metric is deleted"
+        metricService.delete(id)
+
+        then: "The metric is no longer retrievable"
+        metricService.get(id) == null
+        metricService.count() == 0
+    }
+
+    void "findByName routes to analytics datasource with tenant isolation"() {
+        given: "Same-named metrics under different tenants"
+        metricService.save(new Metric(name: "shared_name", amount: 100))
+
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
+        metricService.save(new Metric(name: "shared_name", amount: 200))
+
+        when: "Finding by name under tenant1"
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant1")
+        Metric found1 = metricService.findByName("shared_name")
+
+        and: "Finding by name under tenant2"
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "tenant2")
+        Metric found2 = metricService.findByName("shared_name")
+
+        then: "Each tenant gets its own metric"
+        found1 != null
+        found1.amount == 100
+
+        found2 != null
+        found2.amount == 200
+    }
+
+    void "GormEnhancer aggregate HQL routes to analytics datasource"() {
+        given: "Multiple metrics saved under tenant1"
+        metricService.save(new Metric(name: "alpha", amount: 10))
+        metricService.save(new Metric(name: "beta", amount: 20))
+        metricService.save(new Metric(name: "gamma", amount: 30))
+
+        when: "Using GormEnhancer for an aggregate query"
+        List results = metricService.getTotalAmountAbove(15)
+
+        then: "The HQL executes against the analytics datasource"
+        results.size() == 1
+        results[0] == 50  // 20 + 30
+    }
+}
+
+/**
+ * Metric domain mapped to the 'analytics' datasource with DISCRIMINATOR multi-tenancy.
+ * This combination triggers the allQualifiers() bug when both MultiTenant and
+ * a non-default datasource are configured.
+ */
+@Entity
+class Metric implements GormEntity<Metric>, MultiTenant<Metric> {
+    Long id
+    Long version
+    String tenantId
+    String name
+    Integer amount
+
+    static mapping = {
+        datasource 'analytics'
+    }
+
+    static constraints = {
+        name blank: false
+        amount min: 0
+    }
+}
+
+/**
+ * Data Service interface for Metric - all methods auto-implemented by GORM.
+ */
+interface MetricDataService {
+    Metric get(Serializable id)
+    Metric save(Metric metric)
+    void delete(Serializable id)
+    Long count()
+    Metric findByName(String name)
+    List<Metric> findAllByAmountGreaterThan(Integer amount)
+}
+
+/**
+ * Abstract class that binds MetricDataService to the 'analytics' datasource.
+ * The @Transactional(connection = "analytics") ensures all auto-implemented methods
+ * and custom methods route to the secondary datasource.
+ */
+@Service(Metric)
+@Transactional(connection = "analytics")
+abstract class MetricService implements MetricDataService {
+
+    /**
+     * Statically compiled access to the analytics datasource via GormEnhancer.
+     */
+    private GormStaticApi<Metric> getAnalyticsApi() {
+        GormEnhancer.findStaticApi(Metric, 'analytics')
+    }
+
+    /**
+     * Delete all metrics for the current tenant from the analytics datasource.
+     */
+    void deleteAll() {
+        analyticsApi.executeUpdate('delete from Metric')
+    }
+
+    /**
+     * Aggregate query - calculates total amount of metrics above a threshold.
+     */
+    List getTotalAmountAbove(Integer minAmount) {
+        analyticsApi.executeQuery(
+            'select sum(m.amount) from Metric m where m.amount > :minAmount',
+            [minAmount: minAmount]
+        )
+    }
+}

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
@@ -180,7 +180,23 @@ class GormEnhancer implements Closeable {
     List<String> allQualifiers(Datastore datastore, PersistentEntity entity) {
         List<String> qualifiers = new ArrayList<>()
         qualifiers.addAll(ConnectionSourcesSupport.getConnectionSourceNames(entity))
-        if ((MultiTenant.isAssignableFrom(entity.javaClass) || qualifiers.contains(ConnectionSource.ALL)) && (datastore instanceof ConnectionSourcesProvider)) {
+
+        // For MultiTenant entities OR entities declared with ConnectionSource.ALL,
+        // expand qualifiers to include all available connection sources — BUT only
+        // if the entity does not have an explicit non-DEFAULT datasource declaration.
+        //
+        // When a MultiTenant entity declares `datasource 'secondary'`, that explicit
+        // mapping must be preserved. Expanding to all connections causes silent
+        // data routing to the wrong database (the DEFAULT datasource) for
+        // DISCRIMINATOR multi-tenancy mode.
+        boolean isMultiTenant = MultiTenant.isAssignableFrom(entity.javaClass)
+        boolean hasExplicitAll = qualifiers.contains(ConnectionSource.ALL)
+        boolean hasExplicitNonDefaultDatasource = isMultiTenant &&
+                !hasExplicitAll &&
+                qualifiers.size() > 0 &&
+                !qualifiers.equals(ConnectionSourcesSupport.DEFAULT_CONNECTION_SOURCE_NAMES)
+
+        if ((isMultiTenant || hasExplicitAll) && !hasExplicitNonDefaultDatasource && (datastore instanceof ConnectionSourcesProvider)) {
             qualifiers.clear()
             qualifiers.add(ConnectionSource.DEFAULT)
 

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/GormEnhancerAllQualifiersSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/GormEnhancerAllQualifiersSpec.groovy
@@ -1,0 +1,204 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm
+
+import spock.lang.Specification
+
+import grails.gorm.MultiTenant
+import org.grails.datastore.mapping.config.Entity
+import org.grails.datastore.mapping.core.Datastore
+import org.grails.datastore.mapping.core.connections.ConnectionSource
+import org.grails.datastore.mapping.core.connections.ConnectionSources
+import org.grails.datastore.mapping.core.connections.ConnectionSourcesProvider
+import org.grails.datastore.mapping.model.ClassMapping
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.datastore.mapping.model.PersistentEntity
+
+/**
+ * Tests for {@link GormEnhancer#allQualifiers(Datastore, PersistentEntity)} to verify
+ * that explicit datasource declarations on MultiTenant entities are preserved.
+ *
+ * <p>Prior to the fix, {@code allQualifiers()} would unconditionally expand qualifiers
+ * to all connection sources for any {@link MultiTenant} entity, even when the entity
+ * declared an explicit non-default datasource (e.g., {@code datasource 'secondary'}).
+ * This caused silent data routing to the wrong database under DISCRIMINATOR multi-tenancy.</p>
+ */
+class GormEnhancerAllQualifiersSpec extends Specification {
+
+    /**
+     * Create a GormEnhancer with a minimal mock datastore (no entities registered).
+     */
+    private GormEnhancer createEnhancer() {
+        def mappingContext = Mock(MappingContext) {
+            getPersistentEntities() >> []
+        }
+        def datastore = Mock(Datastore) {
+            getMappingContext() >> mappingContext
+        }
+        new GormEnhancer(datastore)
+    }
+
+    /**
+     * Create a mock PersistentEntity with the specified java class and datasource list.
+     * Uses a real {@link Entity} instance (concrete Groovy class) and mocks for interfaces.
+     */
+    private PersistentEntity mockEntity(Class javaClass, List<String> datasources) {
+        def mappedForm = new Entity()
+        mappedForm.datasources = datasources
+        def classMapping = Mock(ClassMapping) {
+            getMappedForm() >> mappedForm
+        }
+        Mock(PersistentEntity) {
+            getJavaClass() >> javaClass
+            getMapping() >> classMapping
+            getName() >> javaClass.name
+        }
+    }
+
+    /**
+     * Create a mock datastore that also implements ConnectionSourcesProvider,
+     * returning the specified connection source names.
+     */
+    private Datastore mockMultiConnectionDatastore(List<String> connectionNames) {
+        def connectionSourceMocks = connectionNames.collect { name ->
+            Mock(ConnectionSource) {
+                getName() >> name
+            }
+        }
+        def allSources = Mock(ConnectionSources) {
+            getAllConnectionSources() >> connectionSourceMocks
+        }
+        Mock(TestConnectionSourcesProviderDatastore) {
+            getConnectionSources() >> allSources
+        }
+    }
+
+    void "MultiTenant entity with explicit non-default datasource preserves qualifier"() {
+        given: "a MultiTenant entity with datasource 'secondary'"
+        def enhancer = createEnhancer()
+        def entity = mockEntity(MultiTenantSecondaryEntity, ['secondary'])
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'secondary'])
+
+        when:
+        def qualifiers = enhancer.allQualifiers(datastore, entity)
+
+        then: "the explicit 'secondary' qualifier is preserved, not replaced with DEFAULT + all"
+        qualifiers == ['secondary']
+    }
+
+    void "MultiTenant entity with default datasource expands to all qualifiers"() {
+        given: "a MultiTenant entity on the default datasource"
+        def enhancer = createEnhancer()
+        def entity = mockEntity(MultiTenantDefaultEntity, [ConnectionSource.DEFAULT])
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'secondary', 'reporting'])
+
+        when:
+        def qualifiers = enhancer.allQualifiers(datastore, entity)
+
+        then: "qualifiers expand to DEFAULT + all non-default connection sources"
+        qualifiers.contains(ConnectionSource.DEFAULT)
+        qualifiers.contains('secondary')
+        qualifiers.contains('reporting')
+        qualifiers.size() == 3
+    }
+
+    void "MultiTenant entity with ALL datasource expands to all qualifiers"() {
+        given: "a MultiTenant entity declared with ConnectionSource.ALL"
+        def enhancer = createEnhancer()
+        def entity = mockEntity(MultiTenantAllEntity, [ConnectionSource.ALL])
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'secondary'])
+
+        when:
+        def qualifiers = enhancer.allQualifiers(datastore, entity)
+
+        then: "qualifiers expand to DEFAULT + all non-default connection sources"
+        qualifiers.contains(ConnectionSource.DEFAULT)
+        qualifiers.contains('secondary')
+        qualifiers.size() == 2
+    }
+
+    void "non-MultiTenant entity with explicit datasource preserves qualifier"() {
+        given: "a non-MultiTenant entity with datasource 'secondary'"
+        def enhancer = createEnhancer()
+        def entity = mockEntity(NonMultiTenantSecondaryEntity, ['secondary'])
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'secondary'])
+
+        when:
+        def qualifiers = enhancer.allQualifiers(datastore, entity)
+
+        then: "the explicit qualifier is preserved"
+        qualifiers == ['secondary']
+    }
+
+    void "non-MultiTenant entity with default datasource keeps default only"() {
+        given: "a non-MultiTenant entity on the default datasource"
+        def enhancer = createEnhancer()
+        def entity = mockEntity(NonMultiTenantDefaultEntity, [ConnectionSource.DEFAULT])
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'secondary'])
+
+        when:
+        def qualifiers = enhancer.allQualifiers(datastore, entity)
+
+        then: "only DEFAULT qualifier is returned"
+        qualifiers == [ConnectionSource.DEFAULT]
+    }
+
+    void "non-MultiTenant entity with ALL datasource expands to all qualifiers"() {
+        given: "a non-MultiTenant entity declared with ConnectionSource.ALL"
+        def enhancer = createEnhancer()
+        def entity = mockEntity(NonMultiTenantAllEntity, [ConnectionSource.ALL])
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'secondary'])
+
+        when:
+        def qualifiers = enhancer.allQualifiers(datastore, entity)
+
+        then: "qualifiers expand to DEFAULT + all non-default connection sources"
+        qualifiers.contains(ConnectionSource.DEFAULT)
+        qualifiers.contains('secondary')
+        qualifiers.size() == 2
+    }
+
+    void "MultiTenant entity with multiple explicit datasources preserves all qualifiers"() {
+        given: "a MultiTenant entity with multiple explicit datasources"
+        def enhancer = createEnhancer()
+        def entity = mockEntity(MultiTenantMultiDsEntity, ['analytics', 'reporting'])
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'analytics', 'reporting', 'other'])
+
+        when:
+        def qualifiers = enhancer.allQualifiers(datastore, entity)
+
+        then: "the explicit qualifiers are preserved, not expanded"
+        qualifiers == ['analytics', 'reporting']
+    }
+
+    // --- Stub entity classes ---
+
+    static class MultiTenantSecondaryEntity implements MultiTenant<MultiTenantSecondaryEntity> {}
+    static class MultiTenantDefaultEntity implements MultiTenant<MultiTenantDefaultEntity> {}
+    static class MultiTenantAllEntity implements MultiTenant<MultiTenantAllEntity> {}
+    static class MultiTenantMultiDsEntity implements MultiTenant<MultiTenantMultiDsEntity> {}
+    static class NonMultiTenantSecondaryEntity {}
+    static class NonMultiTenantDefaultEntity {}
+    static class NonMultiTenantAllEntity {}
+
+    /**
+     * Combined interface so Spock can mock a Datastore that also provides ConnectionSources.
+     */
+    static interface TestConnectionSourcesProviderDatastore extends Datastore, ConnectionSourcesProvider {}
+}

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/build.gradle
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/build.gradle
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+plugins {
+    id 'org.apache.grails.buildsrc.properties'
+    id 'org.apache.grails.gradle.grails-web'
+    id 'org.apache.grails.buildsrc.compile'
+}
+
+version = projectVersion
+group = 'examples'
+
+dependencies {
+    implementation platform(project(':grails-bom'))
+
+    implementation 'org.apache.grails:grails-data-hibernate5'
+    implementation 'org.apache.grails:grails-core'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.zaxxer:HikariCP'
+    runtimeOnly 'org.apache.grails:grails-databinding'
+    runtimeOnly 'org.apache.grails:grails-services'
+    runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
+    runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
+    runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'
+
+    integrationTestImplementation 'org.apache.grails.testing:grails-testing-support-core'
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
+}

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/conf/application.yml
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info:
+  app:
+    name: '@info.app.name@'
+    version: '@info.app.version@'
+    grailsVersion: '@info.app.grailsVersion@'
+---
+grails:
+  profile: web
+  codegen:
+    defaultPackage: example
+  gorm:
+    multiTenancy:
+      mode: DISCRIMINATOR
+      tenantResolverClass: org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
+  mime:
+    disable:
+      accept:
+        header:
+          userAgents:
+            - Gecko
+            - WebKit
+            - Presto
+            - Trident
+    types:
+      all: '*/*'
+      html:
+        - text/html
+        - application/xhtml+xml
+      json:
+        - application/json
+        - text/json
+      text: text/plain
+      xml:
+        - text/xml
+        - application/xml
+---
+dataSources:
+  dataSource:
+    pooled: true
+    driverClassName: org.h2.Driver
+    dbCreate: create-drop
+    url: jdbc:h2:mem:defaultDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+  secondary:
+    pooled: true
+    driverClassName: org.h2.Driver
+    dbCreate: create-drop
+    url: jdbc:h2:mem:secondaryDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/conf/logback.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+
+-->
+<configuration>
+
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/domain/example/Metric.groovy
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/domain/example/Metric.groovy
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package example
+
+import grails.gorm.MultiTenant
+import org.grails.datastore.gorm.GormEntity
+
+/**
+ * Domain class that combines DISCRIMINATOR multi-tenancy with a non-default
+ * datasource. This combination triggers the allQualifiers() bug where
+ * MultiTenant causes qualifier expansion that overrides the explicit
+ * datasource declaration, silently routing data to the wrong database.
+ */
+class Metric implements GormEntity<Metric>, MultiTenant<Metric> {
+
+    String tenantId
+    String name
+    Integer amount
+
+    static mapping = {
+        datasource 'secondary'
+    }
+
+    static constraints = {
+        name blank: false
+        amount min: 0
+    }
+}

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/init/example/Application.groovy
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/init/example/Application.groovy
@@ -1,0 +1,30 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package example
+
+import grails.boot.GrailsApp
+import grails.boot.config.GrailsAutoConfiguration
+
+class Application extends GrailsAutoConfiguration {
+
+    static void main(String[] args) {
+        GrailsApp.run(Application)
+    }
+}

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/services/example/MetricService.groovy
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/services/example/MetricService.groovy
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package example
+
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.gorm.GormStaticApi
+
+/**
+ * GORM Data Service for Metric, routed to the 'secondary' datasource
+ * via @Transactional(connection). Combines DISCRIMINATOR multi-tenancy
+ * with a non-default datasource - the scenario that triggers the
+ * allQualifiers() bug.
+ *
+ * All auto-implemented methods (save, get, delete, findByName, count)
+ * should route to the secondary datasource with proper tenant isolation.
+ */
+@Service(Metric)
+@Transactional(connection = 'secondary')
+abstract class MetricService {
+
+    abstract Metric get(Serializable id)
+
+    abstract Metric save(Metric metric)
+
+    abstract Metric delete(Serializable id)
+
+    abstract Number count()
+
+    abstract Metric findByName(String name)
+
+    abstract List<Metric> findAllByName(String name)
+
+    /**
+     * Statically compiled access to the secondary datasource via GormEnhancer.
+     */
+    private GormStaticApi<Metric> getSecondaryApi() {
+        GormEnhancer.findStaticApi(Metric, 'secondary')
+    }
+
+    /**
+     * Delete all metrics for the current tenant from the secondary datasource.
+     */
+    void deleteAll() {
+        secondaryApi.executeUpdate('delete from Metric')
+    }
+}

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/src/integration-test/groovy/functionaltests/MultiTenantMultiDataSourceSpec.groovy
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/src/integration-test/groovy/functionaltests/MultiTenantMultiDataSourceSpec.groovy
@@ -1,0 +1,177 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package functionaltests
+
+import example.Application
+import example.Metric
+import example.MetricService
+import grails.testing.mixin.integration.Integration
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
+import org.grails.orm.hibernate.HibernateDatastore
+import org.hibernate.Session
+import spock.lang.Specification
+
+/**
+ * Integration test verifying that GORM Data Service auto-implemented
+ * CRUD methods route correctly to a non-default datasource when both
+ * DISCRIMINATOR multi-tenancy and @Transactional(connection) are used.
+ *
+ * Metric implements MultiTenant and is mapped to the 'secondary' datasource.
+ * Without the allQualifiers() fix, the schema would be created on the
+ * default datasource and all operations would silently route there.
+ *
+ * The service is obtained from the secondary child datastore
+ * (not auto-wired by Spring) to ensure proper session binding.
+ *
+ * @see example.Metric
+ * @see example.MetricService
+ */
+@Integration(applicationClass = Application)
+class MultiTenantMultiDataSourceSpec extends Specification {
+
+    HibernateDatastore hibernateDatastore
+    MetricService metricService
+
+    void setup() {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant1')
+        metricService = hibernateDatastore.getDatastoreForConnection('secondary')
+                .getService(MetricService)
+        metricService.deleteAll()
+        // Also clean tenant2 data
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
+        metricService.deleteAll()
+        // Reset to tenant1 for tests
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant1')
+    }
+
+    void cleanup() {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, '')
+    }
+
+    void "schema is created on secondary datasource not default"() {
+        expect: 'The secondary datasource connects to secondaryDb'
+        Metric.secondary.withNewSession { Session s ->
+            assert s.connection().metaData.getURL() == 'jdbc:h2:mem:secondaryDb'
+            return true
+        }
+
+        and: 'The default datasource connects to defaultDb'
+        hibernateDatastore.withNewSession { Session s ->
+            assert s.connection().metaData.getURL() == 'jdbc:h2:mem:defaultDb'
+            return true
+        }
+    }
+
+    void "save routes to secondary datasource"() {
+        when:
+        Metric saved = metricService.save(new Metric(name: 'page_views', amount: 100))
+
+        then:
+        saved != null
+        saved.id != null
+        saved.name == 'page_views'
+        saved.amount == 100
+    }
+
+    void "get by ID routes to secondary datasource"() {
+        given:
+        Metric saved = metricService.save(new Metric(name: 'sessions', amount: 42))
+
+        when:
+        Metric found = metricService.get(saved.id)
+
+        then:
+        found != null
+        found.id == saved.id
+        found.name == 'sessions'
+        found.amount == 42
+    }
+
+    void "count returns count scoped to current tenant"() {
+        given: 'Metrics saved under tenant1'
+        metricService.save(new Metric(name: 'alpha', amount: 1))
+        metricService.save(new Metric(name: 'beta', amount: 2))
+
+        and: 'Metrics saved under tenant2'
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
+        metricService.save(new Metric(name: 'gamma', amount: 3))
+
+        when: 'Counting under tenant1'
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant1')
+        Long count1 = metricService.count() as Long
+
+        and: 'Counting under tenant2'
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
+        Long count2 = metricService.count() as Long
+
+        then: 'Each tenant sees only its own data'
+        count1 == 2
+        count2 == 1
+    }
+
+    void "delete removes from secondary datasource"() {
+        given:
+        Metric saved = metricService.save(new Metric(name: 'disposable', amount: 0))
+
+        when:
+        metricService.delete(saved.id)
+
+        then:
+        metricService.get(saved.id) == null
+        metricService.count() == 0
+    }
+
+    void "findByName routes to secondary datasource with tenant isolation"() {
+        given: 'Same-named metrics under different tenants'
+        metricService.save(new Metric(name: 'shared_name', amount: 100))
+
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
+        metricService.save(new Metric(name: 'shared_name', amount: 200))
+
+        when: 'Finding by name under tenant1'
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant1')
+        Metric found1 = metricService.findByName('shared_name')
+
+        and: 'Finding by name under tenant2'
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
+        Metric found2 = metricService.findByName('shared_name')
+
+        then: 'Each tenant gets its own metric'
+        found1 != null
+        found1.amount == 100
+
+        found2 != null
+        found2.amount == 200
+    }
+
+    void "findAllByName routes to secondary datasource"() {
+        given:
+        metricService.save(new Metric(name: 'duplicate', amount: 10))
+        metricService.save(new Metric(name: 'duplicate', amount: 20))
+        metricService.save(new Metric(name: 'other', amount: 30))
+
+        when:
+        List<Metric> found = metricService.findAllByName('duplicate')
+
+        then:
+        found.size() == 2
+        found.every { it.name == 'duplicate' }
+    }
+}

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/src/integration-test/groovy/functionaltests/MultiTenantMultiDataSourceSpec.groovy
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/src/integration-test/groovy/functionaltests/MultiTenantMultiDataSourceSpec.groovy
@@ -16,17 +16,19 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package functionaltests
 
-import example.Application
 import example.Metric
 import example.MetricService
+import org.hibernate.Session
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+import org.springframework.beans.factory.annotation.Autowired
+
 import grails.testing.mixin.integration.Integration
 import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
 import org.grails.orm.hibernate.HibernateDatastore
-import org.hibernate.Session
-import spock.lang.Specification
 
 /**
  * Integration test verifying that GORM Data Service auto-implemented
@@ -43,26 +45,26 @@ import spock.lang.Specification
  * @see example.Metric
  * @see example.MetricService
  */
-@Integration(applicationClass = Application)
+@Integration
+@RestoreSystemProperties
 class MultiTenantMultiDataSourceSpec extends Specification {
 
+    @Autowired
     HibernateDatastore hibernateDatastore
+
     MetricService metricService
 
     void setup() {
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant1')
-        metricService = hibernateDatastore.getDatastoreForConnection('secondary')
+        tenant = 'tenant1'
+        metricService = hibernateDatastore
+                .getDatastoreForConnection('secondary')
                 .getService(MetricService)
         metricService.deleteAll()
         // Also clean tenant2 data
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
+        tenant = 'tenant2'
         metricService.deleteAll()
         // Reset to tenant1 for tests
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant1')
-    }
-
-    void cleanup() {
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, '')
+        tenant = 'tenant1'
     }
 
     void "schema is created on secondary datasource not default"() {
@@ -81,7 +83,7 @@ class MultiTenantMultiDataSourceSpec extends Specification {
 
     void "save routes to secondary datasource"() {
         when:
-        Metric saved = metricService.save(new Metric(name: 'page_views', amount: 100))
+        def saved = metricService.save(new Metric(name: 'page_views', amount: 100))
 
         then:
         saved != null
@@ -92,10 +94,10 @@ class MultiTenantMultiDataSourceSpec extends Specification {
 
     void "get by ID routes to secondary datasource"() {
         given:
-        Metric saved = metricService.save(new Metric(name: 'sessions', amount: 42))
+        def saved = metricService.save(new Metric(name: 'sessions', amount: 42))
 
         when:
-        Metric found = metricService.get(saved.id)
+        def found = metricService.get(saved.id)
 
         then:
         found != null
@@ -110,16 +112,16 @@ class MultiTenantMultiDataSourceSpec extends Specification {
         metricService.save(new Metric(name: 'beta', amount: 2))
 
         and: 'Metrics saved under tenant2'
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
+        tenant = 'tenant2'
         metricService.save(new Metric(name: 'gamma', amount: 3))
 
         when: 'Counting under tenant1'
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant1')
-        Long count1 = metricService.count() as Long
+        tenant = 'tenant1'
+        def count1 = metricService.count()
 
         and: 'Counting under tenant2'
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
-        Long count2 = metricService.count() as Long
+        tenant = 'tenant2'
+        def count2 = metricService.count()
 
         then: 'Each tenant sees only its own data'
         count1 == 2
@@ -128,7 +130,7 @@ class MultiTenantMultiDataSourceSpec extends Specification {
 
     void "delete removes from secondary datasource"() {
         given:
-        Metric saved = metricService.save(new Metric(name: 'disposable', amount: 0))
+        def saved = metricService.save(new Metric(name: 'disposable', amount: 0))
 
         when:
         metricService.delete(saved.id)
@@ -146,12 +148,12 @@ class MultiTenantMultiDataSourceSpec extends Specification {
         metricService.save(new Metric(name: 'shared_name', amount: 200))
 
         when: 'Finding by name under tenant1'
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant1')
-        Metric found1 = metricService.findByName('shared_name')
+        tenant = 'tenant1'
+        def found1 = metricService.findByName('shared_name')
 
         and: 'Finding by name under tenant2'
-        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, 'tenant2')
-        Metric found2 = metricService.findByName('shared_name')
+        tenant = 'tenant2'
+        def found2 = metricService.findByName('shared_name')
 
         then: 'Each tenant gets its own metric'
         found1 != null
@@ -168,10 +170,14 @@ class MultiTenantMultiDataSourceSpec extends Specification {
         metricService.save(new Metric(name: 'other', amount: 30))
 
         when:
-        List<Metric> found = metricService.findAllByName('duplicate')
+        def found = metricService.findAllByName('duplicate')
 
         then:
         found.size() == 2
         found.every { it.name == 'duplicate' }
+    }
+
+    private static void setTenant(String tenantId) {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, tenantId)
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -283,6 +283,9 @@ project(':grails-test-examples-hibernate5-grails-hibernate-groovy-proxy').projec
 include 'grails-test-examples-hibernate5-issue450'
 project(':grails-test-examples-hibernate5-issue450').projectDir = new File(settingsDir, 'grails-test-examples/hibernate5/issue450')
 
+include 'grails-test-examples-hibernate5-grails-multitenant-multi-datasource'
+project(':grails-test-examples-hibernate5-grails-multitenant-multi-datasource').projectDir = new File(settingsDir, 'grails-test-examples/hibernate5/grails-multitenant-multi-datasource')
+
 // Mongodb
 // core
 include 'grails-data-mongodb-core'

--- a/settings.gradle
+++ b/settings.gradle
@@ -265,6 +265,8 @@ project(':grails-test-examples-hibernate5-grails-schema-per-tenant').projectDir 
 
 include 'grails-test-examples-hibernate5-grails-partitioned-multi-tenancy'
 project(':grails-test-examples-hibernate5-grails-partitioned-multi-tenancy').projectDir = new File(settingsDir, 'grails-test-examples/hibernate5/grails-partitioned-multi-tenancy')
+include 'grails-test-examples-hibernate5-grails-multitenant-multi-datasource'
+project(':grails-test-examples-hibernate5-grails-multitenant-multi-datasource').projectDir = new File(settingsDir, 'grails-test-examples/hibernate5/grails-multitenant-multi-datasource')
 
 include 'grails-test-examples-hibernate5-standalone-hibernate'
 project(':grails-test-examples-hibernate5-standalone-hibernate').projectDir = new File(settingsDir, 'grails-test-examples/hibernate5/standalone-hibernate')


### PR DESCRIPTION
## Summary

`GormEnhancer.allQualifiers()` unconditionally expands qualifiers to all connection sources for any `MultiTenant` entity, even when the entity declares an explicit non-default datasource (e.g., `datasource 'secondary'`). This causes silent data routing to the wrong database under DISCRIMINATOR multi-tenancy mode.

The fix preserves explicit datasource qualifiers for `MultiTenant` entities instead of replacing them with `DEFAULT + all connections`.

## Root Cause

In `GormEnhancer.allQualifiers()`, the `MultiTenant` check unconditionally triggers qualifier expansion:

```groovy
if ((MultiTenant.isAssignableFrom(entity.javaClass) || qualifiers.contains(ConnectionSource.ALL))
    && (datastore instanceof ConnectionSourcesProvider)) {
    qualifiers.clear()                        // CLEARS the explicit 'secondary' mapping
    qualifiers.add(ConnectionSource.DEFAULT)   // Replaces with DEFAULT
    // adds all connection sources from ConnectionSourcesProvider
}
```

This treats `MultiTenant` the same as `ConnectionSource.ALL`. It is intended for DATABASE multi-tenancy mode (each tenant = separate connection), but incorrectly fires for DISCRIMINATOR mode where all tenants share one database and the entity has an explicit non-default datasource declaration.

When `findTenantId()` returns `ConnectionSource.DEFAULT` in DISCRIMINATOR mode, `findStaticApi()` resolves to the DEFAULT qualifier - routing all data to the wrong database with no error or warning.

## Fix

A single conditional change in `GormEnhancer.allQualifiers()` (`grails-datamapping-core`):

```groovy
boolean isMultiTenant = MultiTenant.isAssignableFrom(entity.javaClass)
boolean hasExplicitAll = qualifiers.contains(ConnectionSource.ALL)
boolean hasExplicitNonDefaultDatasource = isMultiTenant &&
        !hasExplicitAll &&
        qualifiers.size() > 0 &&
        !qualifiers.equals(ConnectionSourcesSupport.DEFAULT_CONNECTION_SOURCE_NAMES)

if ((isMultiTenant || hasExplicitAll) && !hasExplicitNonDefaultDatasource
    && (datastore instanceof ConnectionSourcesProvider)) {
```

Qualifier expansion now only fires for:
- `MultiTenant` entities on the default datasource (DATABASE multi-tenancy)
- Entities declared with `ConnectionSource.ALL`

When a `MultiTenant` entity has an explicit non-default datasource (e.g., `datasource 'secondary'`), the declared qualifier is preserved.

## Steps To Reproduce

1. Create a Grails 7 app with two H2 datasources (default + secondary)
2. Configure DISCRIMINATOR multi-tenancy
3. Create a domain class that implements `MultiTenant` with `datasource 'secondary'`
4. Call `.save()` on an instance of that domain class
5. Observe that data is written to the default database, not the secondary one

**Standalone reproducer**: https://github.com/jamesfredley/grails-multitenant-datasource-bug

## Test Coverage

**21 tests across 3 levels:**

### Unit tests - `GormEnhancerAllQualifiersSpec` (7 tests)
Focused tests for `allQualifiers()` logic using mock datastores and entities:
- MultiTenant with explicit non-default datasource - preserves qualifier
- MultiTenant with default datasource - expands to all qualifiers
- MultiTenant with `ConnectionSource.ALL` - expands to all qualifiers
- Non-MultiTenant with explicit datasource - preserves qualifier
- Non-MultiTenant with default datasource - keeps default only
- Non-MultiTenant with `ConnectionSource.ALL` - expands to all qualifiers
- MultiTenant with multiple explicit datasources - preserves all qualifiers

### Hibernate integration tests - `DataServiceMultiTenantMultiDataSourceSpec` (7 tests)
Full Hibernate datastore tests with two in-memory H2 databases (default + analytics):
- Schema creation on correct (analytics) datasource
- save() routes to analytics with tenant isolation
- get() retrieves from analytics datasource
- count() scoped to current tenant on analytics
- delete() removes from analytics datasource
- findByName with tenant isolation on analytics
- GormEnhancer qualifier resolution for unqualified and explicit paths
- GormEnhancer aggregate HQL routing to analytics

### Functional test app - `MultiTenantMultiDataSourceSpec` (7 tests)
Full Grails application (`grails-multitenant-multi-datasource`) with `@Integration` tests:
- Schema creation on secondary datasource (not default)
- save() routes to secondary datasource
- get() by ID routes to secondary datasource
- count() scoped to current tenant
- delete() removes from secondary datasource
- findByName with tenant isolation on secondary
- findAllByName routes to secondary datasource

## Changed Files

| File | Change |
|------|--------|
| `grails-datamapping-core/.../GormEnhancer.groovy` | Fix: preserve explicit non-default datasource qualifiers for MultiTenant entities |
| `grails-datamapping-core/.../GormEnhancerAllQualifiersSpec.groovy` | **New**: 7 unit tests for `allQualifiers()` |
| `grails-data-hibernate5/.../DataServiceMultiTenantMultiDataSourceSpec.groovy` | **New**: 7 Hibernate integration tests |
| `grails-test-examples/.../grails-multitenant-multi-datasource/` | **New**: functional test app (domain, service, config, 7 integration tests) |
| `settings.gradle` | Register functional test app |

## Environment Information

- **Grails**: 7.0.7
- **Spring Boot**: 3.5.10
- **Groovy**: 4.0.30
- **JDK**: 17+