### PR TITLE
test: stabilize flaky scaffolding Geb tests for slow CI environments

### DIFF
--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserCommunityControllerSpec.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserCommunityControllerSpec.groovy
@@ -38,7 +38,6 @@ class UserCommunityControllerSpec extends ContainerGebSpec {
     void cleanup() {
         try {
             go 'logout'
-            waitFor { $('input', value: 'Log Out').displayed }
             $('input', value: 'Log Out').click()
         }
         catch (ignored) {

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserCommunityControllerSpec.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserCommunityControllerSpec.groovy
@@ -28,16 +28,17 @@ import grails.testing.mixin.integration.Integration
 class UserCommunityControllerSpec extends ContainerGebSpec {
 
     void setup() {
-        go '/'
         to LoginPage
         username = 'test@grails.org'
         password = 'letmein'
         loginButton.click()
+        waitFor { title != 'Please sign in' }
     }
 
     void cleanup() {
         try {
             go 'logout'
+            waitFor { $('input', value: 'Log Out').displayed }
             $('input', value: 'Log Out').click()
         }
         catch (ignored) {
@@ -50,7 +51,7 @@ class UserCommunityControllerSpec extends ContainerGebSpec {
         go 'community/user/index'
 
         then:
-        title == 'User List'
+        waitFor { title == 'User List' }
 
         and:
         !$('table.scaffold')

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserCommunityControllerSpec.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserCommunityControllerSpec.groovy
@@ -16,43 +16,35 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package com.example
 
 import com.example.pages.LoginPage
+import com.example.pages.LogoutPage
+import com.example.pages.CommunityUserListPage
 
 import grails.plugin.geb.ContainerGebSpec
 import grails.testing.mixin.integration.Integration
 
-@Integration(applicationClass = Application)
+@Integration
 class UserCommunityControllerSpec extends ContainerGebSpec {
 
     void setup() {
-        to LoginPage
-        username = 'test@grails.org'
-        password = 'letmein'
-        loginButton.click()
-        waitFor { title != 'Please sign in' }
+        to(LoginPage).login()
     }
 
     void cleanup() {
         try {
-            go 'logout'
-            $('input', value: 'Log Out').click()
-        }
-        catch (ignored) {
-            // ignored
+            to(LogoutPage).logout()
+        } catch (Exception ignore) {
+            // ignore any exceptions that occur during logout
         }
     }
 
     void "User list"() {
         when:
-        go 'community/user/index'
+        def page = to(CommunityUserListPage)
 
         then:
-        waitFor { title == 'User List' }
-
-        and:
-        !$('table.scaffold')
+        !page.scaffoldTable
     }
 }

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserControllerSpec.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserControllerSpec.groovy
@@ -38,7 +38,6 @@ class UserControllerSpec extends ContainerGebSpec {
     void cleanup() {
         try {
             go 'logout'
-            waitFor { $('input', value: 'Log Out').displayed }
             $('input', value: 'Log Out').click()
         }
         catch (ignored) {

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserControllerSpec.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserControllerSpec.groovy
@@ -28,16 +28,17 @@ import grails.testing.mixin.integration.Integration
 class UserControllerSpec extends ContainerGebSpec {
 
     void setup() {
-        go '/'
         to LoginPage
         username = 'test@grails.org'
         password = 'letmein'
         loginButton.click()
+        waitFor { title != 'Please sign in' }
     }
 
     void cleanup() {
         try {
             go 'logout'
+            waitFor { $('input', value: 'Log Out').displayed }
             $('input', value: 'Log Out').click()
         }
         catch (ignored) {
@@ -50,7 +51,7 @@ class UserControllerSpec extends ContainerGebSpec {
         go 'user/index'
 
         then:
-        title == 'User List'
+        waitFor { title == 'User List' }
 
         and:
         $('table.scaffold')

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserControllerSpec.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserControllerSpec.groovy
@@ -16,43 +16,35 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package com.example
 
 import com.example.pages.LoginPage
+import com.example.pages.LogoutPage
+import com.example.pages.UserListPage
 
 import grails.plugin.geb.ContainerGebSpec
 import grails.testing.mixin.integration.Integration
 
-@Integration(applicationClass = Application)
+@Integration
 class UserControllerSpec extends ContainerGebSpec {
 
     void setup() {
-        to LoginPage
-        username = 'test@grails.org'
-        password = 'letmein'
-        loginButton.click()
-        waitFor { title != 'Please sign in' }
+        to(LoginPage).login()
     }
 
     void cleanup() {
         try {
-            go 'logout'
-            $('input', value: 'Log Out').click()
-        }
-        catch (ignored) {
-            // ignored
+             to(LogoutPage).logout()
+        } catch (Exception ignore) {
+            // ignore any exceptions that occur during logout
         }
     }
 
     void "User list"() {
         when:
-        go 'user/index'
+        to(UserListPage)
 
         then:
-        waitFor { title == 'User List' }
-
-        and:
         $('table.scaffold')
     }
 }

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/pages/CommunityUserListPage.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/pages/CommunityUserListPage.groovy
@@ -20,22 +20,13 @@ package com.example.pages
 
 import geb.Page
 
-class LoginPage extends Page {
+class CommunityUserListPage extends Page {
 
-    static String pageTitle = 'Please sign in'
+    static String pageTitle = 'User List'
 
-    static url = 'login'
+    static url = 'community/user/index'
     static at = { title == pageTitle }
     static content = {
-        username { $('input', name: 'username') }
-        password { $('input', name: 'password') }
-        loginButton { $('button.primary') }
-    }
-
-    void login(String username = 'test@grails.org', String password = 'letmein') {
-        this.username = username
-        this.password = password
-        loginButton.click()
-        waitFor { title != pageTitle }
+        scaffoldTable(required: false) { $('table.scaffold') }
     }
 }

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/pages/LogoutPage.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/pages/LogoutPage.groovy
@@ -16,19 +16,22 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package com.example.pages
 
 import geb.Page
 
 class LogoutPage extends Page {
 
+    static String pageTitle = 'Confirm Log Out?'
+
     static url = 'logout'
-
-    static at = { title == 'Confirm Log Out?' }
-
+    static at = { title == pageTitle }
     static content = {
-        logoutForm { $('form') }
-        logoutButton { $('button', value: 'Log Out') }
+        logoutButton { $('button.primary') }
+    }
+
+    void logout() {
+        logoutButton.click()
+        waitFor { title != pageTitle }
     }
 }

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/pages/UserListPage.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/pages/UserListPage.groovy
@@ -20,22 +20,13 @@ package com.example.pages
 
 import geb.Page
 
-class LoginPage extends Page {
+class UserListPage extends Page {
 
-    static String pageTitle = 'Please sign in'
+    static String pageTitle = 'User List'
 
-    static url = 'login'
+    static url = 'user/index'
     static at = { title == pageTitle }
     static content = {
-        username { $('input', name: 'username') }
-        password { $('input', name: 'password') }
-        loginButton { $('button.primary') }
-    }
-
-    void login(String username = 'test@grails.org', String password = 'letmein') {
-        this.username = username
-        this.password = password
-        loginButton.click()
-        waitFor { title != pageTitle }
+        scaffoldTable { $('table.scaffold') }
     }
 }


### PR DESCRIPTION
## Summary

Stabilizes flaky `UserControllerSpec` and `UserCommunityControllerSpec` Geb tests in `grails-test-examples/scaffolding` that intermittently fail on slower CI runners (observed on JDK 25 in [Functional Tests (25)](https://github.com/apache/grails-core/actions/runs/22083891105/job/63814394408?pr=15393)).

## Problem

The test expects page title `User List` but intermittently gets `Please sign in` because:

1. **No wait after login** — `setup()` clicks the login button then immediately proceeds to the feature method. On slower environments, the login POST hasn't completed, so the session cookie isn't set when `go 'user/index'` executes, causing Spring Security to redirect to the login page.
2. **No waitFor on assertions** — `title == 'User List'` asserts immediately without waiting for async page load, unlike every other Geb spec in this repo.

These were the **only two Geb specs** not updated with `waitFor` patterns during the stability improvements in e8adf0143f.

## Changes

- Add `waitFor { title != 'Please sign in' }` after login click to verify auth completes before proceeding
- Wrap `title == 'User List'` assertions with `waitFor { }` for async page load handling
- Add `waitFor` for logout button visibility before clicking in `cleanup()`
- Remove redundant `go '/'` before `to LoginPage` (the `to` command navigates directly)

## Evidence

| Signal | Detail |
|--------|--------|
| Same test passed on `7.0.x` | [Run 22018179657](https://github.com/apache/grails-core/actions/runs/22018179657) ✅ |
| Same test passed on JDK 17 & 21 | Same CI run, only JDK 25 failed |
| Failure pattern | Classic auth timing flake — `Please sign in` instead of `User List` |
| Established pattern | All other Geb specs use `waitFor` extensively (see `ScaffoldingFunctionalSpec`, `FieldsValidationSpec`, `PaginationSpec`) |