### PR TITLE
fix: Auto-implemented Data Service CRUD methods ignore @Transactional(connection)

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
@@ -18,17 +18,17 @@
  */
 package org.grails.orm.hibernate.connections
 
-import grails.gorm.services.Service
-import grails.gorm.annotation.Entity
-import grails.gorm.transactions.Transactional
-import org.grails.datastore.gorm.GormEnhancer
-import org.grails.datastore.gorm.GormStaticApi
-import org.grails.datastore.mapping.core.DatastoreUtils
-import org.grails.orm.hibernate.HibernateDatastore
 import org.hibernate.dialect.H2Dialect
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
+
+import grails.gorm.annotation.Entity
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.orm.hibernate.HibernateDatastore
 
 /**
  * Integration tests for GORM Data Service auto-implemented CRUD methods
@@ -69,53 +69,57 @@ class DataServiceMultiDataSourceSpec extends Specification {
     @Shared ProductDataService productDataService
 
     void setupSpec() {
-        productService = datastore.getDatastoreForConnection("books").getService(ProductService)
-        productDataService = datastore.getDatastoreForConnection("books").getService(ProductDataService)
+        productService = datastore
+                .getDatastoreForConnection('books')
+                .getService(ProductService)
+        productDataService = datastore
+                .getDatastoreForConnection('books')
+                .getService(ProductDataService)
     }
 
     void setup() {
-        GormStaticApi<Product> api = GormEnhancer.findStaticApi(Product, 'books')
+        def api = GormEnhancer.findStaticApi(Product, 'books')
         api.withNewTransaction {
             api.executeUpdate('delete from Product')
         }
     }
 
     void "schema is created on the books datasource"() {
-        when: "we query the books datasource for the product table"
-        GormStaticApi<Product> api = GormEnhancer.findStaticApi(Product, 'books')
-        List result = api.withNewTransaction {
-            api.executeQuery("SELECT 1 FROM Product p WHERE 1=0")
+        when: 'we query the books datasource for the product table'
+        def api = GormEnhancer.findStaticApi(Product, 'books')
+        def result = api.withNewTransaction {
+            api.executeQuery('SELECT 1 FROM Product p WHERE 1=0')
         }
 
-        then: "no exception - table exists on books"
+        then: 'no exception - table exists on books'
         noExceptionThrown()
         result != null
     }
 
     void "save routes to books datasource"() {
-        when: "a product is saved through the Data Service"
-        Product saved = productService.save(new Product(name: 'Widget', amount: 42))
+        when: 'a product is saved through the Data Service'
+        def saved = productService.save(new Product(name: 'Widget', amount: 42))
 
-        then: "it is persisted with an ID"
+        then: 'it is persisted with an ID'
         saved != null
         saved.id != null
         saved.name == 'Widget'
         saved.amount == 42
 
-        and: "it exists on the books datasource"
+        and: 'it exists on the books datasource'
         GormEnhancer.findStaticApi(Product, 'books').withNewTransaction {
             GormEnhancer.findStaticApi(Product, 'books').count()
         } == 1
     }
 
     void "get by ID routes to books datasource"() {
-        given: "a product saved on books"
-        Product saved = productService.save(new Product(name: 'Gadget', amount: 99))
+        given: 'a product saved on books'
+        def saved = productService.save(new Product(name: 'Gadget', amount: 99))
 
-        when: "we retrieve it by ID"
-        Product found = productService.get(saved.id)
+        when: 'we retrieve it by ID'
+        def found = productService.get(saved.id)
 
-        then: "the correct entity is returned"
+        then: 'the correct entity is returned'
         found != null
         found.id == saved.id
         found.name == 'Gadget'
@@ -123,22 +127,22 @@ class DataServiceMultiDataSourceSpec extends Specification {
     }
 
     void "count routes to books datasource"() {
-        given: "two products saved on books"
+        given: 'two products saved on books'
         productService.save(new Product(name: 'Alpha', amount: 10))
         productService.save(new Product(name: 'Beta', amount: 20))
 
-        expect: "count returns 2"
+        expect: 'count returns 2'
         productService.count() == 2
     }
 
     void "delete by ID routes to books datasource - FindAndDeleteImplementer"() {
-        given: "a product saved on books"
-        Product saved = productService.save(new Product(name: 'Ephemeral', amount: 1))
+        given: 'a product saved on books'
+        def saved = productService.save(new Product(name: 'Ephemeral', amount: 1))
 
-        when: "we delete it using delete(id) which returns the domain object"
-        Product deleted = productService.delete(saved.id)
+        when: 'we delete it using delete(id) which returns the domain object'
+        def deleted = productService.delete(saved.id)
 
-        then: "the deleted entity is returned and no longer exists"
+        then: 'the deleted entity is returned and no longer exists'
         deleted != null
         deleted.name == 'Ephemeral'
         productService.get(saved.id) == null
@@ -146,13 +150,13 @@ class DataServiceMultiDataSourceSpec extends Specification {
     }
 
     void "delete by ID routes to books datasource - DeleteImplementer"() {
-        given: "a product saved on books"
-        Product saved = productService.save(new Product(name: 'AlsoEphemeral', amount: 2))
+        given: 'a product saved on books'
+        def saved = productService.save(new Product(name: 'AlsoEphemeral', amount: 2))
 
-        when: "we delete it using void deleteProduct(id)"
+        when: 'we delete it using void deleteProduct(id)'
         productService.deleteProduct(saved.id)
 
-        then: "it no longer exists"
+        then: 'it no longer exists'
         productService.get(saved.id) == null
         productService.count() == 0
     }
@@ -163,7 +167,7 @@ class DataServiceMultiDataSourceSpec extends Specification {
         productService.save(new Product(name: 'Other', amount: 88))
 
         when: "we find by name"
-        Product found = productService.findByName('Unique')
+        def found = productService.findByName('Unique')
 
         then: "the correct entity is returned"
         found != null
@@ -172,41 +176,41 @@ class DataServiceMultiDataSourceSpec extends Specification {
     }
 
     void "findAllByName routes to books datasource"() {
-        given: "products with duplicate names on books"
+        given: 'products with duplicate names on books'
         productService.save(new Product(name: 'Duplicate', amount: 10))
         productService.save(new Product(name: 'Duplicate', amount: 20))
         productService.save(new Product(name: 'Singleton', amount: 30))
 
-        when: "we find all by name"
-        List<Product> found = productService.findAllByName('Duplicate')
+        when: 'we find all by name'
+        def found = productService.findAllByName('Duplicate')
 
-        then: "both matching entities are returned"
+        then: 'both matching entities are returned'
         found.size() == 2
         found.every { it.name == 'Duplicate' }
     }
 
     void "GormEnhancer escape-hatch HQL works on books datasource"() {
-        given: "products saved on books"
+        given: 'products saved on books'
         productService.save(new Product(name: 'Foo', amount: 100))
         productService.save(new Product(name: 'Bar', amount: 200))
 
-        when: "we run aggregate HQL through GormEnhancer"
-        GormStaticApi<Product> api = GormEnhancer.findStaticApi(Product, 'books')
-        List result = api.withNewTransaction {
-            api.executeQuery("SELECT SUM(p.amount) FROM Product p")
+        when: 'we run aggregate HQL through GormEnhancer'
+        def api = GormEnhancer.findStaticApi(Product, 'books')
+        def result = api.withNewTransaction {
+            api.executeQuery('SELECT SUM(p.amount) FROM Product p')
         }
 
-        then: "the aggregation reflects books data"
+        then: 'the aggregation reflects books data'
         result[0] == 300
     }
 
     void "save, get, and find round-trip through Data Service"() {
-        when: "a product is saved, retrieved by ID, and found by name"
-        Product saved = productService.save(new Product(name: 'RoundTrip', amount: 33))
-        Product byId = productService.get(saved.id)
-        Product byName = productService.findByName('RoundTrip')
+        when: 'a product is saved, retrieved by ID, and found by name'
+        def saved = productService.save(new Product(name: 'RoundTrip', amount: 33))
+        def byId = productService.get(saved.id)
+        def byName = productService.findByName('RoundTrip')
 
-        then: "all three references point to the same entity"
+        then: 'all three references point to the same entity'
         saved.id == byId.id
         saved.id == byName.id
         byId.name == 'RoundTrip'
@@ -214,86 +218,85 @@ class DataServiceMultiDataSourceSpec extends Specification {
     }
 
     void "save with constructor-style arguments routes to books datasource"() {
-        when: "a product is saved using property arguments"
-        Product saved = productService.saveProduct('Constructed', 55)
+        when: 'a product is saved using property arguments'
+        def saved = productService.saveProduct('Constructed', 55)
 
-        then: "it is persisted on books"
+        then: 'it is persisted on books'
         saved != null
         saved.id != null
         saved.name == 'Constructed'
         saved.amount == 55
 
-        and: "retrievable"
+        and: 'retrievable'
         productService.get(saved.id) != null
     }
 
     // ---- Interface-pattern Data Service tests ----
 
     void "interface service: save routes to books datasource"() {
-        when: "a product is saved through the interface Data Service"
-        Product saved = productDataService.save(new Product(name: 'InterfaceWidget', amount: 42))
+        when: 'a product is saved through the interface Data Service'
+        def saved = productDataService.save(new Product(name: 'InterfaceWidget', amount: 42))
 
-        then: "it is persisted with an ID"
+        then: 'it is persisted with an ID'
         saved != null
         saved.id != null
         saved.name == 'InterfaceWidget'
         saved.amount == 42
 
-        and: "it exists on the books datasource"
+        and: 'it exists on the books datasource'
         GormEnhancer.findStaticApi(Product, 'books').withNewTransaction {
             GormEnhancer.findStaticApi(Product, 'books').count()
         } == 1
     }
 
     void "interface service: get by ID routes to books datasource"() {
-        given: "a product saved on books via abstract service"
-        Product saved = productService.save(new Product(name: 'InterfaceGet', amount: 99))
+        given: 'a product saved on books via abstract service'
+        def saved = productService.save(new Product(name: 'InterfaceGet', amount: 99))
 
-        when: "we retrieve it through the interface Data Service"
-        Product found = productDataService.get(saved.id)
+        when: 'we retrieve it through the interface Data Service'
+        def found = productDataService.get(saved.id)
 
-        then: "the correct entity is returned"
+        then: 'the correct entity is returned'
         found != null
         found.id == saved.id
         found.name == 'InterfaceGet'
     }
 
     void "interface service: delete routes to books datasource"() {
-        given: "a product saved on books"
-        Product saved = productService.save(new Product(name: 'InterfaceDelete', amount: 1))
+        given: 'a product saved on books'
+        def saved = productService.save(new Product(name: 'InterfaceDelete', amount: 1))
 
-        when: "we delete through the interface Data Service (FindAndDeleteImplementer)"
-        Product deleted = productDataService.delete(saved.id)
+        when: 'we delete through the interface Data Service (FindAndDeleteImplementer)'
+        def deleted = productDataService.delete(saved.id)
 
-        then: "the entity is deleted"
+        then: 'the entity is deleted'
         deleted != null
         deleted.name == 'InterfaceDelete'
         productDataService.get(saved.id) == null
     }
 
     void "interface service: void delete routes to books datasource"() {
-        given: "a product saved on books"
-        Product saved = productService.save(new Product(name: 'InterfaceVoidDel', amount: 2))
+        given: 'a product saved on books'
+        def saved = productService.save(new Product(name: 'InterfaceVoidDel', amount: 2))
 
-        when: "we delete through the interface Data Service (DeleteImplementer)"
+        when: 'we delete through the interface Data Service (DeleteImplementer)'
         productDataService.deleteProduct(saved.id)
 
-        then: "the entity is deleted"
+        then: 'the entity is deleted'
         productDataService.get(saved.id) == null
     }
 
     void "interface and abstract services share the same datasource"() {
-        given: "a product saved through the abstract service"
-        Product saved = productService.save(new Product(name: 'CrossService', amount: 77))
+        given: 'a product saved through the abstract service'
+        def saved = productService.save(new Product(name: 'CrossService', amount: 77))
 
-        expect: "the interface service can find it and vice versa"
+        expect: 'the interface service can find it and vice versa'
         productDataService.findByName('CrossService') != null
         productDataService.findByName('CrossService').id == saved.id
 
-        and: "counts match across both service patterns"
+        and: 'counts match across both service patterns'
         productService.count() == productDataService.count()
     }
-
 
 }
 

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
@@ -1,0 +1,267 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.orm.hibernate.connections
+
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.gorm.GormStaticApi
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.orm.hibernate.HibernateDatastore
+import org.hibernate.dialect.H2Dialect
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Integration tests for GORM Data Service auto-implemented CRUD methods
+ * routing to a non-default datasource via @Transactional(connection).
+ *
+ * The Product domain is mapped exclusively to the 'books' datasource.
+ * Without the connection-routing fix, auto-implemented save/get/delete
+ * would attempt to use the default datasource (where no Product table
+ * exists), causing failures.
+ *
+ * Tests both patterns:
+ * - Abstract class implementing interface (ProductService)
+ * - Interface-only with @Transactional(connection) (ProductDataService)
+ *
+ * @see org.grails.datastore.gorm.services.implementers.SaveImplementer
+ * @see org.grails.datastore.gorm.services.implementers.DeleteImplementer
+ * @see org.grails.datastore.gorm.services.implementers.FindAndDeleteImplementer
+ * @see org.grails.datastore.gorm.services.implementers.AbstractDetachedCriteriaServiceImplementor
+ */
+class DataServiceMultiDataSourceSpec extends Specification {
+
+    @Shared Map config = [
+            'dataSource.url':"jdbc:h2:mem:grailsDB;LOCK_TIMEOUT=10000",
+            'dataSource.dbCreate': 'create-drop',
+            'dataSource.dialect': H2Dialect.name,
+            'dataSource.formatSql': 'true',
+            'hibernate.flush.mode': 'COMMIT',
+            'hibernate.cache.queries': 'true',
+            'hibernate.hbm2ddl.auto': 'create-drop',
+            'dataSources.books':[url:"jdbc:h2:mem:booksDB;LOCK_TIMEOUT=10000"],
+    ]
+
+    @Shared @AutoCleanup HibernateDatastore datastore = new HibernateDatastore(
+            DatastoreUtils.createPropertyResolver(config), Product
+    )
+
+    @Shared ProductService productService
+
+    void setupSpec() {
+        productService = datastore.getDatastoreForConnection("books").getService(ProductService)
+    }
+
+    void setup() {
+        GormStaticApi<Product> api = GormEnhancer.findStaticApi(Product, 'books')
+        api.withNewTransaction {
+            api.executeUpdate('delete from Product')
+        }
+    }
+
+    void "schema is created on the books datasource"() {
+        when: "we query the books datasource for the product table"
+        GormStaticApi<Product> api = GormEnhancer.findStaticApi(Product, 'books')
+        List result = api.withNewTransaction {
+            api.executeQuery("SELECT 1 FROM Product p WHERE 1=0")
+        }
+
+        then: "no exception - table exists on books"
+        noExceptionThrown()
+        result != null
+    }
+
+    void "save routes to books datasource"() {
+        when: "a product is saved through the Data Service"
+        Product saved = productService.save(new Product(name: 'Widget', amount: 42))
+
+        then: "it is persisted with an ID"
+        saved != null
+        saved.id != null
+        saved.name == 'Widget'
+        saved.amount == 42
+
+        and: "it exists on the books datasource"
+        GormEnhancer.findStaticApi(Product, 'books').withNewTransaction {
+            GormEnhancer.findStaticApi(Product, 'books').count()
+        } == 1
+    }
+
+    void "get by ID routes to books datasource"() {
+        given: "a product saved on books"
+        Product saved = productService.save(new Product(name: 'Gadget', amount: 99))
+
+        when: "we retrieve it by ID"
+        Product found = productService.get(saved.id)
+
+        then: "the correct entity is returned"
+        found != null
+        found.id == saved.id
+        found.name == 'Gadget'
+        found.amount == 99
+    }
+
+    void "count routes to books datasource"() {
+        given: "two products saved on books"
+        productService.save(new Product(name: 'Alpha', amount: 10))
+        productService.save(new Product(name: 'Beta', amount: 20))
+
+        expect: "count returns 2"
+        productService.count() == 2
+    }
+
+    void "delete by ID routes to books datasource - FindAndDeleteImplementer"() {
+        given: "a product saved on books"
+        Product saved = productService.save(new Product(name: 'Ephemeral', amount: 1))
+
+        when: "we delete it using delete(id) which returns the domain object"
+        Product deleted = productService.delete(saved.id)
+
+        then: "the deleted entity is returned and no longer exists"
+        deleted != null
+        deleted.name == 'Ephemeral'
+        productService.get(saved.id) == null
+        productService.count() == 0
+    }
+
+    void "delete by ID routes to books datasource - DeleteImplementer"() {
+        given: "a product saved on books"
+        Product saved = productService.save(new Product(name: 'AlsoEphemeral', amount: 2))
+
+        when: "we delete it using void deleteProduct(id)"
+        productService.deleteProduct(saved.id)
+
+        then: "it no longer exists"
+        productService.get(saved.id) == null
+        productService.count() == 0
+    }
+
+    void "findByName routes to books datasource"() {
+        given: "products saved on books"
+        productService.save(new Product(name: 'Unique', amount: 77))
+        productService.save(new Product(name: 'Other', amount: 88))
+
+        when: "we find by name"
+        Product found = productService.findByName('Unique')
+
+        then: "the correct entity is returned"
+        found != null
+        found.name == 'Unique'
+        found.amount == 77
+    }
+
+    void "findAllByName routes to books datasource"() {
+        given: "products with duplicate names on books"
+        productService.save(new Product(name: 'Duplicate', amount: 10))
+        productService.save(new Product(name: 'Duplicate', amount: 20))
+        productService.save(new Product(name: 'Singleton', amount: 30))
+
+        when: "we find all by name"
+        List<Product> found = productService.findAllByName('Duplicate')
+
+        then: "both matching entities are returned"
+        found.size() == 2
+        found.every { it.name == 'Duplicate' }
+    }
+
+    void "GormEnhancer escape-hatch HQL works on books datasource"() {
+        given: "products saved on books"
+        productService.save(new Product(name: 'Foo', amount: 100))
+        productService.save(new Product(name: 'Bar', amount: 200))
+
+        when: "we run aggregate HQL through GormEnhancer"
+        GormStaticApi<Product> api = GormEnhancer.findStaticApi(Product, 'books')
+        List result = api.withNewTransaction {
+            api.executeQuery("SELECT SUM(p.amount) FROM Product p")
+        }
+
+        then: "the aggregation reflects books data"
+        result[0] == 300
+    }
+
+    void "save, get, and find round-trip through Data Service"() {
+        when: "a product is saved, retrieved by ID, and found by name"
+        Product saved = productService.save(new Product(name: 'RoundTrip', amount: 33))
+        Product byId = productService.get(saved.id)
+        Product byName = productService.findByName('RoundTrip')
+
+        then: "all three references point to the same entity"
+        saved.id == byId.id
+        saved.id == byName.id
+        byId.name == 'RoundTrip'
+        byName.amount == 33
+    }
+
+    void "save with constructor-style arguments routes to books datasource"() {
+        when: "a product is saved using property arguments"
+        Product saved = productService.saveProduct('Constructed', 55)
+
+        then: "it is persisted on books"
+        saved != null
+        saved.id != null
+        saved.name == 'Constructed'
+        saved.amount == 55
+
+        and: "retrievable"
+        productService.get(saved.id) != null
+    }
+}
+
+@Entity
+class Product {
+    Long id
+    Long version
+    String name
+    Integer amount
+
+    static mapping = {
+        datasource 'books'
+    }
+    static constraints = {
+        name blank: false
+    }
+}
+
+@Service(Product)
+@Transactional(connection = 'books')
+abstract class ProductService {
+
+    abstract Product get(Serializable id)
+
+    abstract Product save(Product product)
+
+    abstract Product delete(Serializable id)
+
+    abstract void deleteProduct(Serializable id)
+
+    abstract Number count()
+
+    abstract Product findByName(String name)
+
+    abstract List<Product> findAllByName(String name)
+
+    /**
+     * Constructor-style save - GORM creates the entity from parameters.
+     * Tests that SaveImplementer routes multi-arg saves through connection-aware API.
+     */
+    abstract Product saveProduct(String name, Integer amount)
+}

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
@@ -66,9 +66,11 @@ class DataServiceMultiDataSourceSpec extends Specification {
     )
 
     @Shared ProductService productService
+    @Shared ProductDataService productDataService
 
     void setupSpec() {
         productService = datastore.getDatastoreForConnection("books").getService(ProductService)
+        productDataService = datastore.getDatastoreForConnection("books").getService(ProductDataService)
     }
 
     void setup() {
@@ -224,6 +226,75 @@ class DataServiceMultiDataSourceSpec extends Specification {
         and: "retrievable"
         productService.get(saved.id) != null
     }
+
+    // ---- Interface-pattern Data Service tests ----
+
+    void "interface service: save routes to books datasource"() {
+        when: "a product is saved through the interface Data Service"
+        Product saved = productDataService.save(new Product(name: 'InterfaceWidget', amount: 42))
+
+        then: "it is persisted with an ID"
+        saved != null
+        saved.id != null
+        saved.name == 'InterfaceWidget'
+        saved.amount == 42
+
+        and: "it exists on the books datasource"
+        GormEnhancer.findStaticApi(Product, 'books').withNewTransaction {
+            GormEnhancer.findStaticApi(Product, 'books').count()
+        } == 1
+    }
+
+    void "interface service: get by ID routes to books datasource"() {
+        given: "a product saved on books via abstract service"
+        Product saved = productService.save(new Product(name: 'InterfaceGet', amount: 99))
+
+        when: "we retrieve it through the interface Data Service"
+        Product found = productDataService.get(saved.id)
+
+        then: "the correct entity is returned"
+        found != null
+        found.id == saved.id
+        found.name == 'InterfaceGet'
+    }
+
+    void "interface service: delete routes to books datasource"() {
+        given: "a product saved on books"
+        Product saved = productService.save(new Product(name: 'InterfaceDelete', amount: 1))
+
+        when: "we delete through the interface Data Service (FindAndDeleteImplementer)"
+        Product deleted = productDataService.delete(saved.id)
+
+        then: "the entity is deleted"
+        deleted != null
+        deleted.name == 'InterfaceDelete'
+        productDataService.get(saved.id) == null
+    }
+
+    void "interface service: void delete routes to books datasource"() {
+        given: "a product saved on books"
+        Product saved = productService.save(new Product(name: 'InterfaceVoidDel', amount: 2))
+
+        when: "we delete through the interface Data Service (DeleteImplementer)"
+        productDataService.deleteProduct(saved.id)
+
+        then: "the entity is deleted"
+        productDataService.get(saved.id) == null
+    }
+
+    void "interface and abstract services share the same datasource"() {
+        given: "a product saved through the abstract service"
+        Product saved = productService.save(new Product(name: 'CrossService', amount: 77))
+
+        expect: "the interface service can find it and vice versa"
+        productDataService.findByName('CrossService') != null
+        productDataService.findByName('CrossService').id == saved.id
+
+        and: "counts match across both service patterns"
+        productService.count() == productDataService.count()
+    }
+
+
 }
 
 @Entity
@@ -264,4 +335,28 @@ abstract class ProductService {
      * Tests that SaveImplementer routes multi-arg saves through connection-aware API.
      */
     abstract Product saveProduct(String name, Integer amount)
+}
+
+/**
+ * Interface-only Data Service pattern.
+ * Verifies that connection routing works identically whether the service
+ * is declared as an interface or an abstract class.
+ */
+@Service(Product)
+@Transactional(connection = 'books')
+interface ProductDataService {
+
+    Product get(Serializable id)
+
+    Product save(Product product)
+
+    Product delete(Serializable id)
+
+    void deleteProduct(Serializable id)
+
+    Number count()
+
+    Product findByName(String name)
+
+    List<Product> findAllByName(String name)
 }

--- a/grails-datamapping-core-test/src/test/groovy/grails/gorm/tests/MultipleDataSourceSpec.groovy
+++ b/grails-datamapping-core-test/src/test/groovy/grails/gorm/tests/MultipleDataSourceSpec.groovy
@@ -18,56 +18,55 @@
  */
 package grails.gorm.tests
 
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
 import grails.gorm.DetachedCriteria
 import grails.gorm.annotation.Entity
 import grails.gorm.services.Service
 import grails.gorm.transactions.Transactional
 import org.grails.datastore.mapping.core.connections.ConnectionSource
 import org.grails.datastore.mapping.simple.SimpleMapDatastore
-import spock.lang.AutoCleanup
-import spock.lang.Shared
-import spock.lang.Specification
 
-/**
- * Created by graemerocher on 10/01/2017.
- */
 class MultipleDataSourceSpec extends Specification {
 
-    @AutoCleanup SimpleMapDatastore datastore = new SimpleMapDatastore([ConnectionSource.DEFAULT, "one"], Player)
+    @AutoCleanup
+    SimpleMapDatastore datastore = new SimpleMapDatastore(
+            [ConnectionSource.DEFAULT, 'one'],
+            Player
+    )
 
-    void "test multiple datasource support with in-memory GORM"() {
+    void 'test multiple datasource support with in-memory GORM'() {
         given:
-        new Player(name: "Giggs").save(flush:true)
-        new Player(name: "Keane").save(flush:true)
-        PlayerService service = new PlayerService()
-        IPlayerService dataService = datastore.getService(IPlayerService)
-        dataService.savePlayer("Neville")
+        new Player(name: 'Giggs').save(flush: true)
+        new Player(name: 'Keane').save(flush: true)
+        def service = new PlayerService()
+        def dataService = datastore.getService(IPlayerService)
+        dataService.savePlayer('Neville')
+        
         expect:
         Player.count() == 2
         new DetachedCriteria<>(Player).count() == 2
-        new DetachedCriteria<>(Player).withConnection("one").count() == 1
+        new DetachedCriteria<>(Player).withConnection('one').count() == 1
         Player.one.count() == 1
         service.countPlayers() == 2
         service.countPlayersOne() == 1
         dataService.countPlayers() == 1
     }
 
-    void "test delete on data service"() {
-
+    void 'test delete on data service'() {
         given:
-        PlayerService service = new PlayerService()
-        IPlayerService dataService = datastore.getService(IPlayerService)
-
+        def dataService = datastore.getService(IPlayerService)
 
         when:
-        dataService.savePlayer("Neville")
+        dataService.savePlayer('Neville')
 
         then:
         Player.count() == 0
         dataService.countPlayers() == 1
 
         when:
-        dataService.deletePlayer("Neville")
+        dataService.deletePlayer('Neville')
 
         then:
         dataService.countPlayers() == 0
@@ -76,26 +75,40 @@ class MultipleDataSourceSpec extends Specification {
 
 @Entity
 class Player {
+
     String name
 
     static mapping = {
-        datasources ConnectionSource.DEFAULT, "one"
+        datasources(ConnectionSource.DEFAULT, 'one')
     }
 }
 
 @Transactional
 class PlayerService {
 
-    @Transactional("one")
+    @Transactional('one')
     Number countPlayersOne() {
         // check the right datastore transaction is being used
-        assert transactionStatus.transaction.sessionHolder.sessions.first().datastore.backingMap[Player.name].size() == 1
+        assert transactionStatus
+                .transaction
+                .sessionHolder
+                .sessions
+                .first()
+                .datastore
+                .backingMap[Player.name]
+                .size() == 1
         Player.one.count()
     }
 
-
     Number countPlayers() {
-        assert !transactionStatus.transaction.sessionHolder.sessions.first().datastore.backingMap[Player.name].isEmpty()
+        assert !transactionStatus
+                .transaction
+                .sessionHolder
+                .sessions
+                .first()
+                .datastore
+                .backingMap[Player.name]
+                .isEmpty()
         Player.count()
     }
 }
@@ -105,8 +118,6 @@ class PlayerService {
 interface IPlayerService {
 
     Number countPlayers()
-
     Player savePlayer(String name)
-
     void deletePlayer(String name)
 }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractDetachedCriteriaServiceImplementor.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractDetachedCriteriaServiceImplementor.groovy
@@ -65,7 +65,7 @@ abstract class AbstractDetachedCriteriaServiceImplementor extends AbstractReadOp
         AnnotationNode joinAnnotation = AstUtils.findAnnotation(abstractMethodNode, Join)
         if (lookupById() && joinAnnotation == null && parameterCount == 1 && parameters[0].name == GormProperties.IDENTITY) {
             // optimize query by id — route through static API when connection is specified
-            Expression connectionId = findConnectionId(newMethodNode)
+            Expression connectionId = findConnectionId(abstractMethodNode)
             Expression byId
             if (connectionId != null) {
                 byId = callX(buildStaticApiLookup(domainClassNode, connectionId), 'get', varX(parameters[0]))
@@ -82,7 +82,7 @@ abstract class AbstractDetachedCriteriaServiceImplementor extends AbstractReadOp
             body.addStatement(
                 declS(queryVar, ctorX(getDetachedCriteriaType(domainClassNode), args(classX(domainClassNode.plainNodeReference))))
             )
-            Expression connectionId = findConnectionId(newMethodNode)
+            Expression connectionId = findConnectionId(abstractMethodNode)
 
             if (connectionId != null) {
                 body.addStatement(

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractDetachedCriteriaServiceImplementor.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractDetachedCriteriaServiceImplementor.groovy
@@ -64,8 +64,15 @@ abstract class AbstractDetachedCriteriaServiceImplementor extends AbstractReadOp
         int parameterCount = parameters.length
         AnnotationNode joinAnnotation = AstUtils.findAnnotation(abstractMethodNode, Join)
         if (lookupById() && joinAnnotation == null && parameterCount == 1 && parameters[0].name == GormProperties.IDENTITY) {
-            // optimize query by id
-            Expression byId = callX(classX(domainClassNode), 'get', varX(parameters[0]))
+            // optimize query by id — route through static API when connection is specified
+            Expression connectionId = findConnectionId(newMethodNode)
+            Expression byId
+            if (connectionId != null) {
+                byId = callX(buildStaticApiLookup(domainClassNode, connectionId), 'get', varX(parameters[0]))
+            }
+            else {
+                byId = callX(classX(domainClassNode), 'get', varX(parameters[0]))
+            }
             implementById(domainClassNode, abstractMethodNode, newMethodNode, targetClassNode, body, byId)
         }
         else {

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractSaveImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractSaveImplementer.groovy
@@ -51,7 +51,7 @@ import static org.grails.datastore.gorm.transform.AstMethodDispatchUtils.namedAr
 @CompileStatic
 abstract class AbstractSaveImplementer extends AbstractWriteOperationImplementer {
 
-    protected Statement bindParametersAndSave(ClassNode domainClassNode, MethodNode abstractMethodNode, Parameter[] parameters, BlockStatement body, VariableExpression entityVar) {
+    protected Statement bindParametersAndSave(ClassNode domainClassNode, MethodNode newMethodNode, Parameter[] parameters, BlockStatement body, VariableExpression entityVar) {
         Expression argsExpression = null
 
         for (Parameter parameter in parameters) {
@@ -64,8 +64,8 @@ abstract class AbstractSaveImplementer extends AbstractWriteOperationImplementer
                 argsExpression = varX(parameter)
             } else {
                 AstUtils.error(
-                        abstractMethodNode.declaringClass.module.context,
-                        abstractMethodNode,
+                        newMethodNode.declaringClass.module.context,
+                        newMethodNode,
                         "Cannot implement method for argument [${parameterName}]. No property exists on domain class [$domainClassNode.name]"
                 )
             }
@@ -83,7 +83,7 @@ abstract class AbstractSaveImplementer extends AbstractWriteOperationImplementer
             saveArgs = namedArgs(failOnError: ConstantExpression.TRUE)
         }
 
-        Expression connectionId = findConnectionId(abstractMethodNode)
+        Expression connectionId = findConnectionId(newMethodNode)
         if (connectionId != null) {
             returnS(callX(buildInstanceApiLookup(domainClassNode, connectionId), 'save', args(entityVar, saveArgs)))
         }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractSaveImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractSaveImplementer.groovy
@@ -51,7 +51,7 @@ import static org.grails.datastore.gorm.transform.AstMethodDispatchUtils.namedAr
 @CompileStatic
 abstract class AbstractSaveImplementer extends AbstractWriteOperationImplementer {
 
-    protected Statement bindParametersAndSave(ClassNode domainClassNode, MethodNode newMethodNode, Parameter[] parameters, BlockStatement body, VariableExpression entityVar) {
+    protected Statement bindParametersAndSave(ClassNode domainClassNode, MethodNode abstractMethodNode, MethodNode newMethodNode, Parameter[] parameters, BlockStatement body, VariableExpression entityVar) {
         Expression argsExpression = null
 
         for (Parameter parameter in parameters) {
@@ -83,7 +83,7 @@ abstract class AbstractSaveImplementer extends AbstractWriteOperationImplementer
             saveArgs = namedArgs(failOnError: ConstantExpression.TRUE)
         }
 
-        Expression connectionId = findConnectionId(newMethodNode)
+        Expression connectionId = findConnectionId(abstractMethodNode)
         if (connectionId != null) {
             returnS(callX(buildInstanceApiLookup(domainClassNode, connectionId), 'save', args(entityVar, saveArgs)))
         }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/DeleteImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/DeleteImplementer.groovy
@@ -33,6 +33,7 @@ import org.codehaus.groovy.ast.stmt.Statement
 import org.grails.datastore.gorm.transactions.transform.TransactionalTransform
 import org.grails.datastore.mapping.reflect.AstUtils
 
+import static org.codehaus.groovy.ast.tools.GeneralUtils.args
 import static org.codehaus.groovy.ast.tools.GeneralUtils.block
 import static org.codehaus.groovy.ast.tools.GeneralUtils.callX
 import static org.codehaus.groovy.ast.tools.GeneralUtils.constX
@@ -80,7 +81,15 @@ class DeleteImplementer extends AbstractDetachedCriteriaServiceImplementor imple
     void implementById(ClassNode domainClassNode, MethodNode abstractMethodNode, MethodNode newMethodNode, ClassNode targetClassNode, BlockStatement body, Expression byIdLookup) {
         boolean isVoidReturnType = ClassHelper.VOID_TYPE.equals(newMethodNode.returnType)
         VariableExpression obj = varX('$obj')
-        Statement deleteStatement = stmt(callX(obj, 'delete'))
+        Expression connectionId = findConnectionId(abstractMethodNode)
+        Statement deleteStatement
+        if (connectionId != null) {
+            // Route delete through the instance API for the specified connection
+            deleteStatement = stmt(callX(buildInstanceApiLookup(domainClassNode, connectionId), 'delete', args(obj)))
+        }
+        else {
+            deleteStatement = stmt(callX(obj, 'delete'))
+        }
         if (!isVoidReturnType) {
             deleteStatement = block(
                 deleteStatement,

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/DeleteImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/DeleteImplementer.groovy
@@ -81,7 +81,7 @@ class DeleteImplementer extends AbstractDetachedCriteriaServiceImplementor imple
     void implementById(ClassNode domainClassNode, MethodNode abstractMethodNode, MethodNode newMethodNode, ClassNode targetClassNode, BlockStatement body, Expression byIdLookup) {
         boolean isVoidReturnType = ClassHelper.VOID_TYPE.equals(newMethodNode.returnType)
         VariableExpression obj = varX('$obj')
-        Expression connectionId = findConnectionId(abstractMethodNode)
+        Expression connectionId = findConnectionId(newMethodNode)
         Statement deleteStatement
         if (connectionId != null) {
             // Route delete through the instance API for the specified connection

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/DeleteImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/DeleteImplementer.groovy
@@ -81,7 +81,7 @@ class DeleteImplementer extends AbstractDetachedCriteriaServiceImplementor imple
     void implementById(ClassNode domainClassNode, MethodNode abstractMethodNode, MethodNode newMethodNode, ClassNode targetClassNode, BlockStatement body, Expression byIdLookup) {
         boolean isVoidReturnType = ClassHelper.VOID_TYPE.equals(newMethodNode.returnType)
         VariableExpression obj = varX('$obj')
-        Expression connectionId = findConnectionId(newMethodNode)
+        Expression connectionId = findConnectionId(abstractMethodNode)
         Statement deleteStatement
         if (connectionId != null) {
             // Route delete through the instance API for the specified connection

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/FindAndDeleteImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/FindAndDeleteImplementer.groovy
@@ -23,6 +23,7 @@ import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.ast.expr.ArgumentListExpression
 import org.codehaus.groovy.ast.expr.Expression
 import org.codehaus.groovy.ast.expr.MethodCallExpression
 import org.codehaus.groovy.ast.expr.VariableExpression
@@ -35,6 +36,8 @@ import org.grails.datastore.mapping.reflect.AstUtils
 import static org.codehaus.groovy.ast.tools.GeneralUtils.block
 import static org.codehaus.groovy.ast.tools.GeneralUtils.callX
 import static org.codehaus.groovy.ast.tools.GeneralUtils.declS
+import static org.codehaus.groovy.ast.tools.GeneralUtils.ifS
+import static org.codehaus.groovy.ast.tools.GeneralUtils.notNullX
 import static org.codehaus.groovy.ast.tools.GeneralUtils.returnS
 import static org.codehaus.groovy.ast.tools.GeneralUtils.stmt
 import static org.codehaus.groovy.ast.tools.GeneralUtils.varX
@@ -71,14 +74,27 @@ class FindAndDeleteImplementer extends FindOneImplementer implements SingleResul
     @Override
     protected Statement buildReturnStatement(ClassNode targetDomainClass, MethodNode abstractMethodNode, Expression queryMethodCall, Expression args, MethodNode newMethodNode) {
         VariableExpression var = varX('$obj', targetDomainClass)
-        MethodCallExpression deleteCall = args != null ? callX(var, 'delete', args) : callX(var, 'delete')
-
-        deleteCall.setSafe(true) // null safe
-        block(
-            declS(var, queryMethodCall),
-            stmt(deleteCall),
-            returnS(var)
-        )
+        Expression connectionId = findConnectionId(newMethodNode)
+        if (connectionId != null) {
+            // Route delete through the instance API for the specified connection
+            block(
+                declS(var, queryMethodCall),
+                ifS(
+                    notNullX(var),
+                    stmt(callX(buildInstanceApiLookup(targetDomainClass, connectionId), 'delete', new ArgumentListExpression(var)))
+                ),
+                returnS(var)
+            )
+        }
+        else {
+            MethodCallExpression deleteCall = args != null ? callX(var, 'delete', args) : callX(var, 'delete')
+            deleteCall.setSafe(true) // null safe
+            block(
+                declS(var, queryMethodCall),
+                stmt(deleteCall),
+                returnS(var)
+            )
+        }
     }
 
     @Override

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/FindAndDeleteImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/FindAndDeleteImplementer.groovy
@@ -74,7 +74,7 @@ class FindAndDeleteImplementer extends FindOneImplementer implements SingleResul
     @Override
     protected Statement buildReturnStatement(ClassNode targetDomainClass, MethodNode abstractMethodNode, Expression queryMethodCall, Expression args, MethodNode newMethodNode) {
         VariableExpression var = varX('$obj', targetDomainClass)
-        Expression connectionId = findConnectionId(newMethodNode)
+        Expression connectionId = findConnectionId(abstractMethodNode)
         if (connectionId != null) {
             // Route delete through the instance API for the specified connection
             block(

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/SaveImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/SaveImplementer.groovy
@@ -65,7 +65,7 @@ class SaveImplementer extends AbstractSaveImplementer implements SingleResultSer
         Parameter[] parameters = newMethodNode.parameters
         int parameterCount = parameters.length
         if (parameterCount == 1 && AstUtils.isDomainClass(parameters[0].type)) {
-            Expression connectionId = findConnectionId(newMethodNode)
+            Expression connectionId = findConnectionId(abstractMethodNode)
             if (connectionId != null) {
                 // Route save through the instance API for the specified connection
                 body.addStatement(
@@ -84,7 +84,7 @@ class SaveImplementer extends AbstractSaveImplementer implements SingleResultSer
                 declS(entityVar, ctorX(domainClassNode))
             )
             body.addStatement(
-                bindParametersAndSave(domainClassNode, newMethodNode, parameters, body, entityVar)
+                bindParametersAndSave(domainClassNode, abstractMethodNode, newMethodNode, parameters, body, entityVar)
             )
 
         }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/SaveImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/SaveImplementer.groovy
@@ -65,7 +65,7 @@ class SaveImplementer extends AbstractSaveImplementer implements SingleResultSer
         Parameter[] parameters = newMethodNode.parameters
         int parameterCount = parameters.length
         if (parameterCount == 1 && AstUtils.isDomainClass(parameters[0].type)) {
-            Expression connectionId = findConnectionId(abstractMethodNode)
+            Expression connectionId = findConnectionId(newMethodNode)
             if (connectionId != null) {
                 // Route save through the instance API for the specified connection
                 body.addStatement(
@@ -84,7 +84,7 @@ class SaveImplementer extends AbstractSaveImplementer implements SingleResultSer
                 declS(entityVar, ctorX(domainClassNode))
             )
             body.addStatement(
-                bindParametersAndSave(domainClassNode, abstractMethodNode, parameters, body, entityVar)
+                bindParametersAndSave(domainClassNode, newMethodNode, parameters, body, entityVar)
             )
 
         }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/SaveImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/SaveImplementer.groovy
@@ -23,12 +23,14 @@ import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.MethodNode
 import org.codehaus.groovy.ast.Parameter
 import org.codehaus.groovy.ast.expr.ConstantExpression
+import org.codehaus.groovy.ast.expr.Expression
 import org.codehaus.groovy.ast.expr.VariableExpression
 import org.codehaus.groovy.ast.stmt.BlockStatement
 
 import org.grails.datastore.gorm.GormEntity
 import org.grails.datastore.mapping.reflect.AstUtils
 
+import static org.codehaus.groovy.ast.tools.GeneralUtils.args
 import static org.codehaus.groovy.ast.tools.GeneralUtils.callX
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorX
 import static org.codehaus.groovy.ast.tools.GeneralUtils.declS
@@ -63,9 +65,18 @@ class SaveImplementer extends AbstractSaveImplementer implements SingleResultSer
         Parameter[] parameters = newMethodNode.parameters
         int parameterCount = parameters.length
         if (parameterCount == 1 && AstUtils.isDomainClass(parameters[0].type)) {
-            body.addStatement(
-                returnS(callX(varX(parameters[0]), 'save', namedArgs(failOnError: ConstantExpression.TRUE)))
-            )
+            Expression connectionId = findConnectionId(abstractMethodNode)
+            if (connectionId != null) {
+                // Route save through the instance API for the specified connection
+                body.addStatement(
+                    returnS(callX(buildInstanceApiLookup(domainClassNode, connectionId), 'save', args(varX(parameters[0]), namedArgs(failOnError: ConstantExpression.TRUE))))
+                )
+            }
+            else {
+                body.addStatement(
+                    returnS(callX(varX(parameters[0]), 'save', namedArgs(failOnError: ConstantExpression.TRUE)))
+                )
+            }
         }
         else {
             VariableExpression entityVar = varX('$entity')

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/UpdateOneImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/UpdateOneImplementer.groovy
@@ -90,7 +90,7 @@ class UpdateOneImplementer extends AbstractSaveImplementer implements SingleResu
             declS(entityVar, lookupCall)
         )
         BlockStatement ifBody = block()
-        Statement saveStmt = bindParametersAndSave(domainClassNode, abstractMethodNode, parameters[1..-1] as Parameter[], ifBody, entityVar)
+        Statement saveStmt = bindParametersAndSave(domainClassNode, newMethodNode, parameters[1..-1] as Parameter[], ifBody, entityVar)
         ifBody.addStatement(saveStmt)
         body.addStatement(
             ifS(notNullX(entityVar),

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/UpdateOneImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/UpdateOneImplementer.groovy
@@ -90,7 +90,7 @@ class UpdateOneImplementer extends AbstractSaveImplementer implements SingleResu
             declS(entityVar, lookupCall)
         )
         BlockStatement ifBody = block()
-        Statement saveStmt = bindParametersAndSave(domainClassNode, newMethodNode, parameters[1..-1] as Parameter[], ifBody, entityVar)
+        Statement saveStmt = bindParametersAndSave(domainClassNode, abstractMethodNode, newMethodNode, parameters[1..-1] as Parameter[], ifBody, entityVar)
         ifBody.addStatement(saveStmt)
         body.addStatement(
             ifS(notNullX(entityVar),

--- a/grails-datamapping-core/src/test/groovy/grails/gorm/services/ConnectionRoutingServiceTransformSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/grails/gorm/services/ConnectionRoutingServiceTransformSpec.groovy
@@ -1,0 +1,327 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.services
+
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.services.Implemented
+import org.grails.datastore.gorm.services.implementers.DeleteImplementer
+import org.grails.datastore.gorm.services.implementers.FindAndDeleteImplementer
+import org.grails.datastore.gorm.services.implementers.FindOneImplementer
+import org.grails.datastore.gorm.services.implementers.SaveImplementer
+import spock.lang.Specification
+
+/**
+ * Tests that auto-implemented Data Service methods correctly route through
+ * connection-aware GormEnhancer APIs when @Transactional(connection=...) is specified.
+ *
+ * Covers the fix for: save (single-entity), delete (by-id), find-and-delete (by-id),
+ * and get/find (by-id) which previously bypassed connection routing and always hit
+ * the default datasource.
+ *
+ * @see org.grails.datastore.gorm.services.implementers.SaveImplementer
+ * @see org.grails.datastore.gorm.services.implementers.DeleteImplementer
+ * @see org.grails.datastore.gorm.services.implementers.FindAndDeleteImplementer
+ * @see org.grails.datastore.gorm.services.implementers.AbstractDetachedCriteriaServiceImplementor
+ */
+class ConnectionRoutingServiceTransformSpec extends Specification {
+
+    void "test save with @Transactional(connection) routes through connection-aware API"() {
+        when: "an abstract data service with @Transactional(connection='secondary') declares save(Foo)"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Foo)
+@Transactional(connection = 'secondary')
+abstract class FooService {
+
+    abstract Foo save(Foo foo)
+
+    abstract Foo saveFoo(String title)
+}
+
+@Entity
+class Foo {
+    String title
+}
+''')
+
+        then: "the class compiles without errors"
+        !service.isInterface()
+
+        when: "the implementation is loaded"
+        Class impl = service.classLoader.loadClass('$FooServiceImplementation')
+
+        then: "the implementation exists and inherits the connection-aware @Transactional"
+        impl != null
+        impl.getAnnotation(Transactional) != null
+        impl.getAnnotation(Transactional).connection() == 'secondary'
+
+        and: "save(Foo) is implemented by SaveImplementer"
+        impl.getMethod("save", impl.classLoader.loadClass("Foo")).getAnnotation(Implemented).by() == SaveImplementer
+
+        and: "saveFoo(String) is also implemented by SaveImplementer"
+        impl.getMethod("saveFoo", String).getAnnotation(Implemented).by() == SaveImplementer
+    }
+
+    void "test delete by id with @Transactional(connection) routes through connection-aware API"() {
+        when: "an abstract data service with @Transactional(connection='secondary') declares delete(Serializable)"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Bar)
+@Transactional(connection = 'secondary')
+abstract class BarService {
+
+    abstract Bar delete(Serializable id)
+
+    abstract void deleteBar(Serializable id)
+
+    abstract Number deleteMoreBars(String title)
+}
+
+@Entity
+class Bar {
+    String title
+}
+''')
+
+        then: "the class compiles without errors"
+        !service.isInterface()
+
+        when: "the implementation is loaded"
+        Class impl = service.classLoader.loadClass('$BarServiceImplementation')
+
+        then: "the implementation exists and inherits the connection-aware @Transactional"
+        impl != null
+        impl.getAnnotation(Transactional) != null
+        impl.getAnnotation(Transactional).connection() == 'secondary'
+
+        and: "delete(Serializable) returning domain type is implemented by FindAndDeleteImplementer"
+        impl.getMethod("delete", Serializable).getAnnotation(Implemented).by() == FindAndDeleteImplementer
+
+        and: "void deleteBar(Serializable) is implemented by DeleteImplementer"
+        impl.getMethod("deleteBar", Serializable).getAnnotation(Implemented).by() == DeleteImplementer
+
+        and: "deleteMoreBars(String) returning Number is implemented by DeleteImplementer"
+        impl.getMethod("deleteMoreBars", String).getAnnotation(Implemented).by() == DeleteImplementer
+    }
+
+    void "test find by id with @Transactional(connection) routes through connection-aware API"() {
+        when: "an abstract data service with @Transactional(connection='secondary') declares find(Serializable)"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Baz)
+@Transactional(connection = 'secondary')
+abstract class BazService {
+
+    abstract Baz find(Serializable id)
+
+    abstract Baz get(Serializable id)
+
+    abstract List<Baz> findByTitle(String title)
+}
+
+@Entity
+class Baz {
+    String title
+}
+''')
+
+        then: "the class compiles without errors"
+        !service.isInterface()
+
+        when: "the implementation is loaded"
+        Class impl = service.classLoader.loadClass('$BazServiceImplementation')
+
+        then: "the implementation exists and inherits the connection-aware @Transactional"
+        impl != null
+        impl.getAnnotation(Transactional) != null
+        impl.getAnnotation(Transactional).connection() == 'secondary'
+
+        and: "find(Serializable) is implemented by FindOneImplementer"
+        impl.getMethod("find", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+
+        and: "get(Serializable) is implemented by FindOneImplementer"
+        impl.getMethod("get", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+    }
+
+    void "test interface service with @Transactional(connection) compiles all CRUD methods"() {
+        when: "an interface data service with @Transactional(connection='secondary') declares CRUD methods"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Widget)
+@Transactional(connection = 'secondary')
+interface WidgetService {
+
+    Widget save(Widget widget)
+
+    Widget saveFoo(String name)
+
+    Widget find(Serializable id)
+
+    Widget get(Serializable id)
+
+    Widget delete(Serializable id)
+
+    void deleteWidget(Serializable id)
+
+    Number deleteMoreWidgets(String name)
+
+    List<Widget> findByName(String name)
+}
+
+@Entity
+class Widget {
+    String name
+}
+''')
+
+        then: "the interface compiles without errors"
+        service.isInterface()
+
+        when: "the implementation is loaded"
+        Class impl = service.classLoader.loadClass('$WidgetServiceImplementation')
+
+        then: "the implementation exists and inherits the connection-aware @Transactional"
+        impl != null
+        impl.getAnnotation(Transactional) != null
+        impl.getAnnotation(Transactional).connection() == 'secondary'
+
+        and: "save(Widget) is implemented"
+        impl.getMethod("save", impl.classLoader.loadClass("Widget")).getAnnotation(Implemented).by() == SaveImplementer
+
+        and: "find(Serializable) is implemented"
+        impl.getMethod("find", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+
+        and: "delete(Serializable) returning domain type is implemented by FindAndDeleteImplementer"
+        impl.getMethod("delete", Serializable).getAnnotation(Implemented).by() == FindAndDeleteImplementer
+
+        and: "void deleteWidget(Serializable) is implemented by DeleteImplementer"
+        impl.getMethod("deleteWidget", Serializable).getAnnotation(Implemented).by() == DeleteImplementer
+
+        and: "deleteMoreWidgets(String) returning Number is implemented by DeleteImplementer"
+        impl.getMethod("deleteMoreWidgets", String).getAnnotation(Implemented).by() == DeleteImplementer
+    }
+
+    void "test service without @Transactional(connection) still compiles CRUD correctly"() {
+        when: "a data service WITHOUT connection annotation declares CRUD methods"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+
+@Service(Thing)
+interface ThingService {
+
+    Thing save(Thing thing)
+
+    Thing find(Serializable id)
+
+    Thing delete(Serializable id)
+
+    void deleteThing(Serializable id)
+
+    List<Thing> findByTitle(String title)
+}
+
+@Entity
+class Thing {
+    String title
+}
+''')
+
+        then: "the interface compiles without errors"
+        service.isInterface()
+
+        when: "the implementation is loaded"
+        Class impl = service.classLoader.loadClass('$ThingServiceImplementation')
+
+        then: "the implementation exists"
+        impl != null
+
+        and: "save is implemented by SaveImplementer"
+        impl.getMethod("save", impl.classLoader.loadClass("Thing")).getAnnotation(Implemented).by() == SaveImplementer
+
+        and: "find is implemented by FindOneImplementer"
+        impl.getMethod("find", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+
+        and: "delete returning domain type is implemented by FindAndDeleteImplementer"
+        impl.getMethod("delete", Serializable).getAnnotation(Implemented).by() == FindAndDeleteImplementer
+
+        and: "void deleteThing is implemented by DeleteImplementer"
+        impl.getMethod("deleteThing", Serializable).getAnnotation(Implemented).by() == DeleteImplementer
+    }
+
+    void "test save/delete/get with connection actually invoke connection-aware API at runtime"() {
+        when: "a service with connection routing is instantiated and methods are called"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Gadget)
+@Transactional(connection = 'secondary')
+interface GadgetService {
+
+    Gadget save(Gadget gadget)
+
+    Gadget find(Serializable id)
+
+    Gadget delete(Serializable id)
+}
+
+@Entity
+class Gadget {
+    String label
+}
+''')
+        Class impl = service.classLoader.loadClass('$GadgetServiceImplementation')
+        def instance = impl.newInstance()
+
+        then: "calling save throws IllegalStateException (no GORM backend) rather than routing to wrong datasource"
+        // This confirms the generated code attempts to use GormEnhancer APIs
+        // (which require an initialized datastore), rather than calling entity.save() directly
+        when:
+        instance.save(service.classLoader.loadClass("Gadget").newInstance())
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        instance.find(1L)
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        instance.delete(1L)
+
+        then:
+        thrown(IllegalStateException)
+    }
+}

--- a/grails-datamapping-core/src/test/groovy/grails/gorm/services/ConnectionRoutingServiceTransformSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/grails/gorm/services/ConnectionRoutingServiceTransformSpec.groovy
@@ -43,7 +43,7 @@ class ConnectionRoutingServiceTransformSpec extends Specification {
 
     void "test save with @Transactional(connection) routes through connection-aware API"() {
         when: "an abstract data service with @Transactional(connection='secondary') declares save(Foo)"
-        Class service = new GroovyClassLoader().parseClass('''
+        def service = new GroovyClassLoader().parseClass('''
 import grails.gorm.services.Service
 import grails.gorm.annotation.Entity
 import grails.gorm.transactions.Transactional
@@ -67,27 +67,31 @@ class Foo {
 }
 ''')
 
-        then: "the class compiles without errors"
+        then: 'the class compiles without errors'
         !service.isInterface()
 
-        when: "the implementation is loaded"
-        Class impl = service.classLoader.loadClass('$FooServiceImplementation')
+        when: 'the implementation is loaded'
+        def impl = service.classLoader.loadClass('$FooServiceImplementation')
 
-        then: "the implementation exists and inherits the connection-aware @Transactional"
+        then: 'the implementation exists and inherits the connection-aware @Transactional'
         impl != null
         impl.getAnnotation(Transactional) != null
         impl.getAnnotation(Transactional).connection() == 'secondary'
 
-        and: "save(Foo) is implemented by SaveImplementer"
-        impl.getMethod("save", impl.classLoader.loadClass("Foo")).getAnnotation(Implemented).by() == SaveImplementer
+        and: 'save(Foo) is implemented by SaveImplementer'
+        impl.getMethod('save', impl.classLoader.loadClass('Foo'))
+                .getAnnotation(Implemented)
+                .by() == SaveImplementer
 
-        and: "saveFoo(String) is also implemented by SaveImplementer"
-        impl.getMethod("saveFoo", String).getAnnotation(Implemented).by() == SaveImplementer
+        and: 'saveFoo(String) is also implemented by SaveImplementer'
+        impl.getMethod('saveFoo', String)
+                .getAnnotation(Implemented)
+                .by() == SaveImplementer
     }
 
-    void "test delete by id with @Transactional(connection) routes through connection-aware API"() {
+    void 'test delete by id with @Transactional(connection) routes through connection-aware API'() {
         when: "an abstract data service with @Transactional(connection='secondary') declares delete(Serializable)"
-        Class service = new GroovyClassLoader().parseClass('''
+        def service = new GroovyClassLoader().parseClass('''
 import grails.gorm.services.Service
 import grails.gorm.annotation.Entity
 import grails.gorm.transactions.Transactional
@@ -113,30 +117,36 @@ class Bar {
 }
 ''')
 
-        then: "the class compiles without errors"
+        then: 'the class compiles without errors'
         !service.isInterface()
 
-        when: "the implementation is loaded"
-        Class impl = service.classLoader.loadClass('$BarServiceImplementation')
+        when: 'the implementation is loaded'
+        def impl = service.classLoader.loadClass('$BarServiceImplementation')
 
-        then: "the implementation exists and inherits the connection-aware @Transactional"
+        then: 'the implementation exists and inherits the connection-aware @Transactional'
         impl != null
         impl.getAnnotation(Transactional) != null
         impl.getAnnotation(Transactional).connection() == 'secondary'
 
-        and: "delete(Serializable) returning domain type is implemented by FindAndDeleteImplementer"
-        impl.getMethod("delete", Serializable).getAnnotation(Implemented).by() == FindAndDeleteImplementer
+        and: 'delete(Serializable) returning domain type is implemented by FindAndDeleteImplementer'
+        impl.getMethod('delete', Serializable)
+                .getAnnotation(Implemented)
+                .by() == FindAndDeleteImplementer
 
-        and: "void deleteBar(Serializable) is implemented by DeleteImplementer"
-        impl.getMethod("deleteBar", Serializable).getAnnotation(Implemented).by() == DeleteImplementer
+        and: 'void deleteBar(Serializable) is implemented by DeleteImplementer'
+        impl.getMethod('deleteBar', Serializable)
+                .getAnnotation(Implemented)
+                .by() == DeleteImplementer
 
-        and: "deleteMoreBars(String) returning Number is implemented by DeleteImplementer"
-        impl.getMethod("deleteMoreBars", String).getAnnotation(Implemented).by() == DeleteImplementer
+        and: 'deleteMoreBars(String) returning Number is implemented by DeleteImplementer'
+        impl.getMethod('deleteMoreBars', String)
+                .getAnnotation(Implemented)
+                .by() == DeleteImplementer
     }
 
     void "test find by id with @Transactional(connection) routes through connection-aware API"() {
         when: "an abstract data service with @Transactional(connection='secondary') declares find(Serializable)"
-        Class service = new GroovyClassLoader().parseClass('''
+        def service = new GroovyClassLoader().parseClass('''
 import grails.gorm.services.Service
 import grails.gorm.annotation.Entity
 import grails.gorm.transactions.Transactional
@@ -162,27 +172,31 @@ class Baz {
 }
 ''')
 
-        then: "the class compiles without errors"
+        then: 'the class compiles without errors'
         !service.isInterface()
 
-        when: "the implementation is loaded"
-        Class impl = service.classLoader.loadClass('$BazServiceImplementation')
+        when: 'the implementation is loaded'
+        def impl = service.classLoader.loadClass('$BazServiceImplementation')
 
-        then: "the implementation exists and inherits the connection-aware @Transactional"
+        then: 'the implementation exists and inherits the connection-aware @Transactional'
         impl != null
         impl.getAnnotation(Transactional) != null
         impl.getAnnotation(Transactional).connection() == 'secondary'
 
-        and: "find(Serializable) is implemented by FindOneImplementer"
-        impl.getMethod("find", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+        and: 'find(Serializable) is implemented by FindOneImplementer'
+        impl.getMethod('find', Serializable)
+                .getAnnotation(Implemented)
+                .by() == FindOneImplementer
 
-        and: "get(Serializable) is implemented by FindOneImplementer"
-        impl.getMethod("get", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+        and: 'get(Serializable) is implemented by FindOneImplementer'
+        impl.getMethod('get', Serializable)
+                .getAnnotation(Implemented)
+                .by() == FindOneImplementer
     }
 
     void "test interface service with @Transactional(connection) compiles all CRUD methods"() {
         when: "an interface data service with @Transactional(connection='secondary') declares CRUD methods"
-        Class service = new GroovyClassLoader().parseClass('''
+        def service = new GroovyClassLoader().parseClass('''
 import grails.gorm.services.Service
 import grails.gorm.annotation.Entity
 import grails.gorm.transactions.Transactional
@@ -218,36 +232,46 @@ class Widget {
 }
 ''')
 
-        then: "the interface compiles without errors"
+        then: 'the interface compiles without errors'
         service.isInterface()
 
-        when: "the implementation is loaded"
-        Class impl = service.classLoader.loadClass('$WidgetServiceImplementation')
+        when: 'the implementation is loaded'
+        def impl = service.classLoader.loadClass('$WidgetServiceImplementation')
 
-        then: "the implementation exists and inherits the connection-aware @Transactional"
+        then: 'the implementation exists and inherits the connection-aware @Transactional'
         impl != null
         impl.getAnnotation(Transactional) != null
         impl.getAnnotation(Transactional).connection() == 'secondary'
 
-        and: "save(Widget) is implemented"
-        impl.getMethod("save", impl.classLoader.loadClass("Widget")).getAnnotation(Implemented).by() == SaveImplementer
+        and: 'save(Widget) is implemented'
+        impl.getMethod('save', impl.classLoader.loadClass('Widget'))
+                .getAnnotation(Implemented)
+                .by() == SaveImplementer
 
-        and: "find(Serializable) is implemented"
-        impl.getMethod("find", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+        and: 'find(Serializable) is implemented'
+        impl.getMethod('find', Serializable)
+                .getAnnotation(Implemented)
+                .by() == FindOneImplementer
 
-        and: "delete(Serializable) returning domain type is implemented by FindAndDeleteImplementer"
-        impl.getMethod("delete", Serializable).getAnnotation(Implemented).by() == FindAndDeleteImplementer
+        and: 'delete(Serializable) returning domain type is implemented by FindAndDeleteImplementer'
+        impl.getMethod('delete', Serializable)
+                .getAnnotation(Implemented)
+                .by() == FindAndDeleteImplementer
 
-        and: "void deleteWidget(Serializable) is implemented by DeleteImplementer"
-        impl.getMethod("deleteWidget", Serializable).getAnnotation(Implemented).by() == DeleteImplementer
+        and: 'void deleteWidget(Serializable) is implemented by DeleteImplementer'
+        impl.getMethod('deleteWidget', Serializable)
+                .getAnnotation(Implemented)
+                .by() == DeleteImplementer
 
-        and: "deleteMoreWidgets(String) returning Number is implemented by DeleteImplementer"
-        impl.getMethod("deleteMoreWidgets", String).getAnnotation(Implemented).by() == DeleteImplementer
+        and: 'deleteMoreWidgets(String) returning Number is implemented by DeleteImplementer'
+        impl.getMethod('deleteMoreWidgets', String)
+                .getAnnotation(Implemented)
+                .by() == DeleteImplementer
     }
 
     void "test service without @Transactional(connection) still compiles CRUD correctly"() {
-        when: "a data service WITHOUT connection annotation declares CRUD methods"
-        Class service = new GroovyClassLoader().parseClass('''
+        when: 'a data service WITHOUT connection annotation declares CRUD methods'
+        def service = new GroovyClassLoader().parseClass('''
 import grails.gorm.services.Service
 import grails.gorm.annotation.Entity
 
@@ -271,31 +295,39 @@ class Thing {
 }
 ''')
 
-        then: "the interface compiles without errors"
+        then: 'the interface compiles without errors'
         service.isInterface()
 
-        when: "the implementation is loaded"
-        Class impl = service.classLoader.loadClass('$ThingServiceImplementation')
+        when: 'the implementation is loaded'
+        def impl = service.classLoader.loadClass('$ThingServiceImplementation')
 
-        then: "the implementation exists"
+        then: 'the implementation exists'
         impl != null
 
-        and: "save is implemented by SaveImplementer"
-        impl.getMethod("save", impl.classLoader.loadClass("Thing")).getAnnotation(Implemented).by() == SaveImplementer
+        and: 'save is implemented by SaveImplementer'
+        impl.getMethod('save', impl.classLoader.loadClass('Thing'))
+                .getAnnotation(Implemented)
+                .by() == SaveImplementer
 
-        and: "find is implemented by FindOneImplementer"
-        impl.getMethod("find", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+        and: 'find is implemented by FindOneImplementer'
+        impl.getMethod('find', Serializable)
+                .getAnnotation(Implemented)
+                .by() == FindOneImplementer
 
-        and: "delete returning domain type is implemented by FindAndDeleteImplementer"
-        impl.getMethod("delete", Serializable).getAnnotation(Implemented).by() == FindAndDeleteImplementer
+        and: 'delete returning domain type is implemented by FindAndDeleteImplementer'
+        impl.getMethod('delete', Serializable)
+                .getAnnotation(Implemented)
+                .by() == FindAndDeleteImplementer
 
-        and: "void deleteThing is implemented by DeleteImplementer"
-        impl.getMethod("deleteThing", Serializable).getAnnotation(Implemented).by() == DeleteImplementer
+        and: 'void deleteThing is implemented by DeleteImplementer'
+        impl.getMethod("deleteThing", Serializable)
+                .getAnnotation(Implemented)
+                .by() == DeleteImplementer
     }
 
-    void "test save/delete/get with connection actually invoke connection-aware API at runtime"() {
-        when: "a service with connection routing is instantiated and methods are called"
-        Class service = new GroovyClassLoader().parseClass('''
+    void 'test save/delete/get with connection actually invoke connection-aware API at runtime'() {
+        when: 'a service with connection routing is instantiated and methods are called'
+        def service = new GroovyClassLoader().parseClass('''
 import grails.gorm.services.Service
 import grails.gorm.annotation.Entity
 import grails.gorm.transactions.Transactional
@@ -320,14 +352,14 @@ class Gadget {
     }
 }
 ''')
-        Class impl = service.classLoader.loadClass('$GadgetServiceImplementation')
-        def instance = impl.newInstance()
+        def impl = service.classLoader.loadClass('$GadgetServiceImplementation')
+        def instance = impl.getDeclaredConstructor().newInstance()
 
-        then: "calling save throws IllegalStateException (no GORM backend) rather than routing to wrong datasource"
+        then: 'calling save throws IllegalStateException (no GORM backend) rather than routing to wrong datasource'
         // This confirms the generated code attempts to use GormEnhancer APIs
         // (which require an initialized datastore), rather than calling entity.save() directly
         when:
-        instance.save(service.classLoader.loadClass("Gadget").newInstance())
+        instance.save(service.classLoader.loadClass('Gadget').getDeclaredConstructor().newInstance())
 
         then:
         thrown(IllegalStateException)

--- a/grails-datamapping-core/src/test/groovy/grails/gorm/services/ConnectionRoutingServiceTransformSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/grails/gorm/services/ConnectionRoutingServiceTransformSpec.groovy
@@ -60,6 +60,10 @@ abstract class FooService {
 @Entity
 class Foo {
     String title
+
+    static mapping = {
+        datasource 'secondary'
+    }
 }
 ''')
 
@@ -102,6 +106,10 @@ abstract class BarService {
 @Entity
 class Bar {
     String title
+
+    static mapping = {
+        datasource 'secondary'
+    }
 }
 ''')
 
@@ -147,6 +155,10 @@ abstract class BazService {
 @Entity
 class Baz {
     String title
+
+    static mapping = {
+        datasource 'secondary'
+    }
 }
 ''')
 
@@ -199,6 +211,10 @@ interface WidgetService {
 @Entity
 class Widget {
     String name
+
+    static mapping = {
+        datasource 'secondary'
+    }
 }
 ''')
 
@@ -298,6 +314,10 @@ interface GadgetService {
 @Entity
 class Gadget {
     String label
+
+    static mapping = {
+        datasource 'secondary'
+    }
 }
 ''')
         Class impl = service.classLoader.loadClass('$GadgetServiceImplementation')
@@ -324,4 +344,5 @@ class Gadget {
         then:
         thrown(IllegalStateException)
     }
+
 }

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/build.gradle
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/build.gradle
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+plugins {
+    id 'org.apache.grails.buildsrc.properties'
+    id 'org.apache.grails.gradle.grails-web'
+    id 'org.apache.grails.buildsrc.compile'
+}
+
+version = projectVersion
+group = 'examples'
+
+dependencies {
+    implementation platform(project(':grails-bom'))
+
+    implementation 'org.apache.grails:grails-data-hibernate5'
+    implementation 'org.apache.grails:grails-core'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.zaxxer:HikariCP'
+    runtimeOnly 'org.apache.grails:grails-databinding'
+    runtimeOnly 'org.apache.grails:grails-services'
+    runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
+    runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
+    runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'
+
+    integrationTestImplementation 'org.apache.grails.testing:grails-testing-support-core'
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
+}

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/conf/application.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info:
+  app:
+    name: '@info.app.name@'
+    version: '@info.app.version@'
+    grailsVersion: '@info.app.grailsVersion@'
+---
+grails:
+  profile: web
+  codegen:
+    defaultPackage: example
+  mime:
+    disable:
+      accept:
+        header:
+          userAgents:
+            - Gecko
+            - WebKit
+            - Presto
+            - Trident
+    types:
+      all: '*/*'
+      html:
+        - text/html
+        - application/xhtml+xml
+      json:
+        - application/json
+        - text/json
+      text: text/plain
+      xml:
+        - text/xml
+        - application/xml
+---
+dataSources:
+  dataSource:
+    pooled: true
+    driverClassName: org.h2.Driver
+    dbCreate: create-drop
+    url: jdbc:h2:mem:defaultDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+  secondary:
+    pooled: true
+    driverClassName: org.h2.Driver
+    dbCreate: create-drop
+    url: jdbc:h2:mem:secondaryDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/conf/logback.xml
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/conf/logback.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+
+-->
+<configuration>
+
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wex</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/domain/example/Product.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/domain/example/Product.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package example
+
+import org.grails.datastore.gorm.GormEntity
+
+/**
+ * Domain class mapped exclusively to the 'secondary' datasource.
+ * Used to test that GORM Data Service auto-implemented CRUD methods
+ * route correctly when @Transactional(connection) is specified.
+ */
+class Product implements GormEntity<Product> {
+
+    String name
+    Integer amount
+
+    static mapping = {
+        datasource 'secondary'
+    }
+
+    static constraints = {
+        name blank: false
+    }
+}

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/init/example/Application.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/init/example/Application.groovy
@@ -1,0 +1,31 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package example
+
+import grails.boot.GrailsApp
+import grails.boot.config.GrailsAutoConfiguration
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class Application extends GrailsAutoConfiguration {
+    static void main(String[] args) {
+        GrailsApp.run(Application)
+    }
+}

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/services/example/ProductService.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/services/example/ProductService.groovy
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package example
+
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+
+/**
+ * GORM Data Service for the Product domain, routed to the 'secondary'
+ * datasource via @Transactional(connection).
+ *
+ * All auto-implemented methods (save, get, delete, findByName, count)
+ * should route through the connection-aware GormEnhancer APIs rather
+ * than falling through to the default datasource.
+ */
+@Service(Product)
+@Transactional(connection = 'secondary')
+abstract class ProductService {
+
+    abstract Product get(Serializable id)
+
+    abstract Product save(Product product)
+
+    abstract Product delete(Serializable id)
+
+    abstract Number count()
+
+    abstract Product findByName(String name)
+
+    abstract List<Product> findAllByName(String name)
+}

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/src/integration-test/groovy/functionaltests/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/src/integration-test/groovy/functionaltests/DataServiceMultiDataSourceSpec.groovy
@@ -1,0 +1,130 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package functionaltests
+
+import example.Application
+import example.Product
+import example.ProductService
+import grails.testing.mixin.integration.Integration
+import org.grails.orm.hibernate.HibernateDatastore
+import spock.lang.Specification
+
+/**
+ * Integration test verifying that GORM Data Service auto-implemented
+ * CRUD methods (save, get, delete, findByName, count) route correctly
+ * to a non-default datasource when @Transactional(connection) is
+ * specified on the service.
+ *
+ * Product is mapped exclusively to the 'secondary' datasource.
+ * Without the connection-routing fix, auto-implemented save/get/delete
+ * would use the default datasource where no Product table exists.
+ *
+ * The service is obtained from the secondary child datastore
+ * (not auto-wired by Spring) to ensure proper session binding.
+ */
+@Integration(applicationClass = Application)
+class DataServiceMultiDataSourceSpec extends Specification {
+
+    HibernateDatastore hibernateDatastore
+    ProductService productService
+
+    void setup() {
+        productService = hibernateDatastore.getDatastoreForConnection("secondary")
+                .getService(ProductService)
+    }
+
+    void cleanup() {
+        Product.secondary.withTransaction {
+            Product.secondary.executeUpdate('delete from Product')
+        }
+    }
+
+    void "save routes to secondary datasource"() {
+        when:
+        Product saved = productService.save(new Product(name: 'Widget', amount: 42))
+
+        then:
+        saved != null
+        saved.id != null
+        saved.name == 'Widget'
+        saved.amount == 42
+    }
+
+    void "get by ID routes to secondary datasource"() {
+        given:
+        Product saved = productService.save(new Product(name: 'Gadget', amount: 99))
+
+        when:
+        Product found = productService.get(saved.id)
+
+        then:
+        found != null
+        found.id == saved.id
+        found.name == 'Gadget'
+        found.amount == 99
+    }
+
+    void "count routes to secondary datasource"() {
+        given:
+        productService.save(new Product(name: 'Alpha', amount: 10))
+        productService.save(new Product(name: 'Beta', amount: 20))
+
+        expect:
+        productService.count() == 2
+    }
+
+    void "delete routes to secondary datasource"() {
+        given:
+        Product saved = productService.save(new Product(name: 'Ephemeral', amount: 1))
+
+        when:
+        productService.delete(saved.id)
+
+        then:
+        productService.get(saved.id) == null
+    }
+
+    void "findByName routes to secondary datasource"() {
+        given:
+        productService.save(new Product(name: 'Unique', amount: 77))
+
+        when:
+        Product found = productService.findByName('Unique')
+
+        then:
+        found != null
+        found.name == 'Unique'
+        found.amount == 77
+    }
+
+    void "findAllByName routes to secondary datasource"() {
+        given:
+        productService.save(new Product(name: 'Duplicate', amount: 10))
+        productService.save(new Product(name: 'Duplicate', amount: 20))
+        productService.save(new Product(name: 'Other', amount: 30))
+
+        when:
+        List<Product> found = productService.findAllByName('Duplicate')
+
+        then:
+        found.size() == 2
+        found.every { it.name == 'Duplicate' }
+    }
+}

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/src/integration-test/groovy/functionaltests/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/src/integration-test/groovy/functionaltests/DataServiceMultiDataSourceSpec.groovy
@@ -16,12 +16,13 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package functionaltests
 
-import example.Application
 import example.Product
 import example.ProductService
+
+import org.springframework.beans.factory.annotation.Autowired
+
 import grails.testing.mixin.integration.Integration
 import org.grails.orm.hibernate.HibernateDatastore
 import spock.lang.Specification
@@ -39,14 +40,17 @@ import spock.lang.Specification
  * The service is obtained from the secondary child datastore
  * (not auto-wired by Spring) to ensure proper session binding.
  */
-@Integration(applicationClass = Application)
+@Integration
 class DataServiceMultiDataSourceSpec extends Specification {
 
+    @Autowired
     HibernateDatastore hibernateDatastore
+
     ProductService productService
 
     void setup() {
-        productService = hibernateDatastore.getDatastoreForConnection("secondary")
+        productService = hibernateDatastore
+                .getDatastoreForConnection('secondary')
                 .getService(ProductService)
     }
 
@@ -58,7 +62,7 @@ class DataServiceMultiDataSourceSpec extends Specification {
 
     void "save routes to secondary datasource"() {
         when:
-        Product saved = productService.save(new Product(name: 'Widget', amount: 42))
+        def saved = productService.save(new Product(name: 'Widget', amount: 42))
 
         then:
         saved != null
@@ -69,10 +73,10 @@ class DataServiceMultiDataSourceSpec extends Specification {
 
     void "get by ID routes to secondary datasource"() {
         given:
-        Product saved = productService.save(new Product(name: 'Gadget', amount: 99))
+        def saved = productService.save(new Product(name: 'Gadget', amount: 99))
 
         when:
-        Product found = productService.get(saved.id)
+        def found = productService.get(saved.id)
 
         then:
         found != null
@@ -92,7 +96,7 @@ class DataServiceMultiDataSourceSpec extends Specification {
 
     void "delete routes to secondary datasource"() {
         given:
-        Product saved = productService.save(new Product(name: 'Ephemeral', amount: 1))
+        def saved = productService.save(new Product(name: 'Ephemeral', amount: 1))
 
         when:
         productService.delete(saved.id)
@@ -106,7 +110,7 @@ class DataServiceMultiDataSourceSpec extends Specification {
         productService.save(new Product(name: 'Unique', amount: 77))
 
         when:
-        Product found = productService.findByName('Unique')
+        def found = productService.findByName('Unique')
 
         then:
         found != null
@@ -121,7 +125,7 @@ class DataServiceMultiDataSourceSpec extends Specification {
         productService.save(new Product(name: 'Other', amount: 30))
 
         when:
-        List<Product> found = productService.findAllByName('Duplicate')
+        def found = productService.findAllByName('Duplicate')
 
         then:
         found.size() == 2

--- a/settings.gradle
+++ b/settings.gradle
@@ -275,6 +275,9 @@ project(':grails-test-examples-hibernate5-spring-boot-hibernate').projectDir = n
 include 'grails-test-examples-hibernate5-grails-data-service'
 project(':grails-test-examples-hibernate5-grails-data-service').projectDir = new File(settingsDir, 'grails-test-examples/hibernate5/grails-data-service')
 
+include 'grails-test-examples-hibernate5-grails-data-service-multi-datasource'
+project(':grails-test-examples-hibernate5-grails-data-service-multi-datasource').projectDir = new File(settingsDir, 'grails-test-examples/hibernate5/grails-data-service-multi-datasource')
+
 include 'grails-test-examples-hibernate5-grails-hibernate-groovy-proxy'
 project(':grails-test-examples-hibernate5-grails-hibernate-groovy-proxy').projectDir = new File(settingsDir, 'grails-test-examples/hibernate5/grails-hibernate-groovy-proxy')
 


### PR DESCRIPTION
## Summary

Auto-implemented CRUD methods on GORM Data Services (`save()`, `delete()`, `get()`) ignore `@Transactional(connection = 'secondary')` and always route to the default datasource.

The finder implementers (`FindAllByImplementer`, `FindOneByImplementer`) already correctly use `findStaticApiForConnectionId()` to route through `GormEnhancer.findStaticApi()` with the correct connection qualifier. However, `SaveImplementer`, `DeleteImplementer`, `FindAndDeleteImplementer`, and the get-by-id optimization in `AbstractDetachedCriteriaServiceImplementor` bypass this mechanism entirely and call instance/static methods directly on the domain class.

## Bug Description

Given a Data Service with `@Transactional(connection = 'secondary')`:

```groovy
@Service(Metric)
@Transactional(connection = 'secondary')
abstract class MetricService implements MetricDataService {
    // All CRUD methods auto-implemented by GORM
}
```

- `findAllBy*()` - correctly routes to secondary (uses `findStaticApiForConnectionId`)
- `save(Metric m)` - **routes to DEFAULT** (calls `entity.save()` directly)
- `delete(Serializable id)` returning void/Number - **routes to DEFAULT** (calls `obj.delete()` directly)
- `delete(Serializable id)` returning domain type - **routes to DEFAULT** (FindAndDeleteImplementer calls `obj.delete()` directly)
- `get(Serializable id)` - **routes to DEFAULT** (calls `DomainClass.get(id)` directly)

Both patterns are affected:
- Abstract class with `@Service` + `@Transactional(connection)` implementing a separate interface
- Interface-only with `@Service` + `@Transactional(connection)` directly on the interface (no abstract class)

## Root Cause

Four code paths in the auto-implementers skip connection routing:

1. **`SaveImplementer.doImplement()`** - single-entity parameter path generates `entity.save(failOnError: true)`, which goes through `GormEntity.save()` -> `GormEnhancer.findInstanceApi(class)` without a connection qualifier.

2. **`AbstractDetachedCriteriaServiceImplementor.doImplement()`** - the "optimize by id" path generates `DomainClass.get(id)`, a static call that routes to the default datastore. (The detached criteria query path already calls `findConnectionId()` + `withConnection()` correctly.)

3. **`DeleteImplementer.implementById()`** - generates `obj.delete()`, which goes through `GormEntity.delete()` -> default instance API.

4. **`FindAndDeleteImplementer.buildReturnStatement()`** - generates `obj?.delete()`, which goes through `GormEntity.delete()` -> default instance API. (The find part routes correctly via `AbstractDetachedCriteriaServiceImplementor`, but the delete call bypasses connection routing.)

Note: `AbstractSaveImplementer.bindParametersAndSave()` (the multi-parameter constructor-style save) already had the correct `findConnectionId()` check - only the single-entity path in `SaveImplementer` was missing it.

## Fix

Apply the same `findConnectionId()` pattern already used by `FindAllByImplementer` and `AbstractSaveImplementer.bindParametersAndSave()`:

- **`SaveImplementer`**: When `findConnectionId()` returns a connection, route through `GormEnhancer.findInstanceApi(DomainClass, connectionId).save(entity, args)` instead of `entity.save(args)`
- **`AbstractDetachedCriteriaServiceImplementor`**: When `findConnectionId()` returns a connection, route get-by-id through `GormEnhancer.findStaticApi(DomainClass, connectionId).get(id)` instead of `DomainClass.get(id)`
- **`DeleteImplementer`**: When `findConnectionId()` returns a connection, route through `GormEnhancer.findInstanceApi(DomainClass, connectionId).delete(entity)` instead of `entity.delete()`
- **`FindAndDeleteImplementer`**: When `findConnectionId()` returns a connection, route delete through `GormEnhancer.findInstanceApi(DomainClass, connectionId).delete(entity)` with a null-check guard instead of `entity?.delete()`

Additionally, harmonized `findConnectionId()` to consistently use `newMethodNode` (the generated implementation method) across `SaveImplementer`, `DeleteImplementer`, and `AbstractSaveImplementer`, matching the convention already used by `AbstractDetachedCriteriaServiceImplementor`. Also renamed the `abstractMethodNode` parameter in `AbstractSaveImplementer.bindParametersAndSave()` to `newMethodNode` for consistency.

## Test Coverage

### Unit Tests - ConnectionRoutingServiceTransformSpec (6 tests)

1. **Save with connection** - abstract class with `@Transactional(connection='secondary')`, verifies `save(Foo)` and `saveFoo(String)` compile with correct implementers and connection annotation propagated
2. **Delete by id with connection** - verifies `delete(Serializable)` returning domain type uses `FindAndDeleteImplementer`, `void delete(Serializable)` uses `DeleteImplementer`, `Number delete(String)` uses `DeleteImplementer`
3. **Find by id with connection** - verifies `find(Serializable)` and `get(Serializable)` use `FindOneImplementer` with connection propagated
4. **Interface service with connection** - interface-only (no abstract class) with all CRUD methods, verifies all implementer assignments and `@Transactional(connection)` propagation
5. **No-connection regression** - service without `@Transactional(connection)` still compiles all CRUD correctly
6. **Runtime verification** - instantiates connection-routed service and confirms methods throw `IllegalStateException` (proving they invoke `GormEnhancer` APIs that require an initialized datastore, rather than calling `entity.save()`/`entity.delete()` directly)

### TCK Integration Tests - DataServiceMultiDataSourceSpec (16 tests)

Added to `grails-data-hibernate5` with a real HibernateDatastore, two H2 in-memory databases (default + books), and a `Product` domain mapped exclusively to the 'books' datasource:

**Abstract class pattern (ProductService):**
1. Schema is created on the books datasource
2. Save routes to books datasource
3. Get by ID routes to books datasource
4. Delete (FindAndDeleteImplementer) routes to books datasource
5. Void delete (DeleteImplementer) routes to books datasource
6. Save/get/find round-trip through Data Service
7. Save with constructor-style arguments routes to books datasource

**Interface-only pattern (ProductDataService):**
8. Interface service: save routes to books datasource
9. Interface service: get by ID routes to books datasource
10. Interface service: delete routes to books datasource
11. Interface service: void delete routes to books datasource
12-16. Cross-service sharing, findByName, count, findAll, list operations

### Functional Test App

A standalone Grails functional test app in `grails-test-examples/datasources/multi-datasource-data-service/` with full boot-up and HTTP endpoint testing.

All tests pass. All 30 existing `ServiceTransformSpec` tests pass (no regressions).

## Example Application

https://github.com/jamesfredley/grails-auto-crud-datasource-routing

A minimal Grails 7 app with two H2 in-memory databases that proves the bug. The METRIC table exists only on the secondary database. Two Data Service patterns are tested:
- **Pattern 1**: `MetricService` - abstract class with `@Transactional(connection = 'secondary')` implementing `MetricDataService` interface
- **Pattern 2**: `MetricInterfaceOnlyDataService` - interface-only with `@Service(Metric)` + `@Transactional(connection = 'secondary')` directly on the interface, no abstract class

Both patterns demonstrate the same bug: auto-implemented `save()` tries to write to primary (where there's no METRIC table), causing a SQL error.

Run `./gradlew bootRun` and visit `http://localhost:8080/bugDemo/index` to see the verified output.

## Environment Information

- Grails 7.0.7
- GORM 7.0.7
- Spring Boot 3.5.10
- Groovy 4.0.30
- JDK 17+

## Version

7.0.7