### PR TITLE
fix: GrailsApplicationContextCommandRunner and GrailsApplicationScriptRunner pass command options to Spring Boot, corrupting config

### DIFF
--- a/grails-console/build.gradle
+++ b/grails-console/build.gradle
@@ -71,4 +71,5 @@ dependencies {
 
 apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
 }

--- a/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
+++ b/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
@@ -114,13 +114,7 @@ class GrailsApplicationContextCommandRunner extends DevelopmentGrailsApplication
      * @return a filtered array with command options removed, safe for Spring Boot
      */
     static String[] filterCommandOptions(String[] args) {
-        List<String> filtered = new ArrayList<>()
-        for (String arg : args) {
-            if (!arg.startsWith('--')) {
-                filtered.add(arg)
-            }
-        }
-        filtered.toArray(new String[0])
+        args.findAll { !it.startsWith('--') } as String[]
     }
 
     /**

--- a/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
+++ b/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
@@ -52,15 +52,27 @@ class GrailsApplicationContextCommandRunner extends DevelopmentGrailsApplication
                 System.setProperty(Settings.SETTING_SKIP_BOOTSTRAP, skipBootstrap.toString())
             }
 
+            // Filter out command-specific options (--key=value, --flag) before passing to
+            // Spring Boot. These args are intended for the Grails command (parsed by
+            // CommandLineParser below), NOT for Spring Boot's property override mechanism.
+            //
+            // Without this filtering, Spring Boot's SpringApplication.run() interprets
+            // --dataSource=analytics as a property override, setting dataSource="analytics"
+            // (a String) which corrupts GORM's datasource configuration (expects a Map).
+            // This breaks Gradle dbm* tasks with --dataSource parameter:
+            //   ./gradlew dbmStatus -Pargs="--dataSource=analytics"
+            String[] springBootArgs = filterCommandOptions(args)
+
             ConfigurableApplicationContext ctx = null
             try {
-                ctx = super.run(args)
+                ctx = super.run(springBootArgs)
             } catch (Throwable e) {
                 System.err.println("Context failed to load: $e.message")
                 System.exit(1)
             }
 
             try {
+                // Parse the FULL args (including --options) for the command
                 CommandLine commandLine = new CommandLineParser().parse(args)
                 ctx.autowireCapableBeanFactory.autowireBeanProperties(command, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, false)
                 command.applicationContext = ctx
@@ -83,6 +95,32 @@ class GrailsApplicationContextCommandRunner extends DevelopmentGrailsApplication
             System.exit(1)
         }
         return null
+    }
+
+    /**
+     * Filters out command-specific options (arguments starting with '--') from the
+     * args array before they are passed to Spring Boot's {@code SpringApplication.run()}.
+     *
+     * <p>Spring Boot interprets {@code --key=value} arguments as property overrides via
+     * {@code CommandLinePropertySource}. When Grails command options like
+     * {@code --dataSource=analytics} are passed through, Spring Boot sets
+     * {@code dataSource=analytics} as a top-level property, corrupting GORM's datasource
+     * configuration which expects {@code dataSource} to be a Map containing url, username, etc.</p>
+     *
+     * <p>Command options are still available to the Grails command via
+     * {@code CommandLineParser.parse(args)} which receives the unfiltered args.</p>
+     *
+     * @param args the full argument array including command options
+     * @return a filtered array with command options removed, safe for Spring Boot
+     */
+    static String[] filterCommandOptions(String[] args) {
+        List<String> filtered = new ArrayList<>()
+        for (String arg : args) {
+            if (!arg.startsWith('--')) {
+                filtered.add(arg)
+            }
+        }
+        filtered.toArray(new String[0])
     }
 
     /**

--- a/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
+++ b/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
@@ -114,7 +114,7 @@ class GrailsApplicationContextCommandRunner extends DevelopmentGrailsApplication
      * @return a filtered array with command options removed, safe for Spring Boot
      */
     static String[] filterCommandOptions(String[] args) {
-        args.findAll { !it.startsWith('--') } as String[]
+        args.findAll { it != null && !it.startsWith('--') } as String[]
     }
 
     /**

--- a/grails-console/src/main/groovy/grails/ui/script/GrailsApplicationScriptRunner.groovy
+++ b/grails-console/src/main/groovy/grails/ui/script/GrailsApplicationScriptRunner.groovy
@@ -19,6 +19,7 @@
 package grails.ui.script
 
 import groovy.transform.CompileStatic
+import grails.ui.command.GrailsApplicationContextCommandRunner
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.customizers.ImportCustomizer
 
@@ -49,7 +50,13 @@ class GrailsApplicationScriptRunner extends DevelopmentGrailsApplication {
     ConfigurableApplicationContext run(String...args) {
         ConfigurableApplicationContext ctx
         try {
-            ctx = super.run(args)
+            // Filter out --prefixed options before passing to Spring Boot.
+            // Same fix as GrailsApplicationContextCommandRunner — Spring Boot's
+            // CommandLinePropertySource interprets --key=value as property overrides,
+            // which can corrupt GORM configuration when running scripts via:
+            //   ./gradlew runScript -Pargs="myscript.groovy --someOption=value"
+            String[] springBootArgs = GrailsApplicationContextCommandRunner.filterCommandOptions(args)
+            ctx = super.run(springBootArgs)
         } catch (Throwable e) {
             System.err.println("Context failed to load: $e.message")
             System.exit(1)

--- a/grails-console/src/test/groovy/grails/ui/command/GrailsApplicationContextCommandRunnerSpec.groovy
+++ b/grails-console/src/test/groovy/grails/ui/command/GrailsApplicationContextCommandRunnerSpec.groovy
@@ -1,0 +1,124 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package grails.ui.command
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Tests for {@link GrailsApplicationContextCommandRunner#filterCommandOptions(String[])}.
+ *
+ * Verifies that command-specific options (--key=value, --flag) are filtered out
+ * before being passed to Spring Boot's SpringApplication.run(), while preserving
+ * non-option arguments like the command name.
+ */
+class GrailsApplicationContextCommandRunnerSpec extends Specification {
+
+    @Unroll
+    def "filterCommandOptions filters '#description'"() {
+        expect:
+        GrailsApplicationContextCommandRunner.filterCommandOptions(input as String[]) == expected as String[]
+
+        where:
+        description                              | input                                                    | expected
+        'single --dataSource option'             | ['dbm-status', '--dataSource=analytics']                 | ['dbm-status']
+        'multiple command options'               | ['dbm-status', '--dataSource=analytics', '--contexts=dev'] | ['dbm-status']
+        'no options (passthrough)'               | ['dbm-status']                                           | ['dbm-status']
+        'empty args'                             | []                                                       | []
+        'only options (no command)'              | ['--dataSource=analytics']                               | []
+        'mixed options and positional args'      | ['dbm-gorm-diff', '--dataSource=analytics', 'output.groovy'] | ['dbm-gorm-diff', 'output.groovy']
+        'flag without value'                     | ['dbm-update', '--verbose']                              | ['dbm-update']
+        'single dash args preserved'             | ['dbm-status', '-v', '--dataSource=analytics']           | ['dbm-status', '-v']
+        // Database Migration Plugin: --contexts and --defaultSchema
+        'database migration --contexts option'   | ['dbm-update', '--contexts=production']                  | ['dbm-update']
+        'database migration --defaultSchema'     | ['dbm-update', '--defaultSchema=myschema']               | ['dbm-update']
+        'all three dbm options together'         | ['dbm-gorm-diff', '--dataSource=analytics', '--contexts=dev', '--defaultSchema=public'] | ['dbm-gorm-diff']
+        'dbm command with positional + options'  | ['dbm-gorm-diff', 'output.groovy', '--dataSource=analytics', '--add'] | ['dbm-gorm-diff', 'output.groovy']
+        // Spring Security Plugin: --groupClassName
+        'spring security --groupClassName'       | ['s2-quickstart', 'com.example', 'User', 'Role', '--groupClassName=RoleGroup'] | ['s2-quickstart', 'com.example', 'User', 'Role']
+        // Script runner: --option in script args
+        'script runner with --option'            | ['myscript.groovy', '--someOption=value']                | ['myscript.groovy']
+    }
+
+    def "filterCommandOptions preserves argument order"() {
+        given:
+        String[] input = ['first', 'second', '--removed', 'third'] as String[]
+
+        when:
+        String[] result = GrailsApplicationContextCommandRunner.filterCommandOptions(input)
+
+        then:
+        result == ['first', 'second', 'third'] as String[]
+    }
+
+    def "filterCommandOptions returns new array instance"() {
+        given:
+        String[] input = ['dbm-status'] as String[]
+
+        when:
+        String[] result = GrailsApplicationContextCommandRunner.filterCommandOptions(input)
+
+        then:
+        !result.is(input)
+        result == input
+    }
+
+    def "filterCommandOptions handles typical Gradle dbm task args"() {
+        given: 'args as they arrive from ApplicationContextCommandTask via GrailsGradlePlugin'
+        // configureApplicationCommands() passes: [commandName, ...userArgs, applicationClassName]
+        // main() extracts: commandName = args[0], appClass = args.last()
+        // run() receives: args.init() = [commandName, ...userArgs]
+        String[] runArgs = ['dbm-status', '--dataSource=analytics'] as String[]
+
+        when:
+        String[] springBootArgs = GrailsApplicationContextCommandRunner.filterCommandOptions(runArgs)
+
+        then: 'only the command name reaches Spring Boot'
+        springBootArgs == ['dbm-status'] as String[]
+        springBootArgs.length == 1
+    }
+
+    def "filterCommandOptions prevents dataSource property corruption"() {
+        given: 'the problematic args that caused the original bug'
+        String[] args = ['dbm-gorm-diff', '--dataSource=analytics', '--contexts=production'] as String[]
+
+        when:
+        String[] filtered = GrailsApplicationContextCommandRunner.filterCommandOptions(args)
+
+        then: 'no --key=value args remain to corrupt Spring Boot properties'
+        filtered.every { !it.startsWith('--') }
+        filtered == ['dbm-gorm-diff'] as String[]
+    }
+
+    def "filterCommandOptions protects all known Grails ecosystem command options"() {
+        expect: 'every known --option from Grails plugins is filtered'
+        GrailsApplicationContextCommandRunner.filterCommandOptions(input as String[]) == expected as String[]
+
+        where:
+        input                                                                | expected
+        // Database Migration Plugin (30+ commands accept these)
+        ['dbm-status', '--dataSource=analytics']                             | ['dbm-status']
+        ['dbm-update', '--contexts=production,staging']                      | ['dbm-update']
+        ['dbm-gorm-diff', '--defaultSchema=public']                          | ['dbm-gorm-diff']
+        ['dbm-status', '--verbose']                                          | ['dbm-status']
+        ['dbm-diff', '--add']                                                | ['dbm-diff']
+        // Spring Security Plugin (s2-quickstart)
+        ['s2-quickstart', 'com.example', 'User', 'Role', '--groupClassName=RoleGroup'] | ['s2-quickstart', 'com.example', 'User', 'Role']
+        // Custom ApplicationCommand with arbitrary --options
+        ['my-command', '--customFlag', '--anotherOption=value']              | ['my-command']
+    }
+}

--- a/grails-console/src/test/groovy/grails/ui/command/GrailsApplicationContextCommandRunnerSpec.groovy
+++ b/grails-console/src/test/groovy/grails/ui/command/GrailsApplicationContextCommandRunnerSpec.groovy
@@ -104,6 +104,18 @@ class GrailsApplicationContextCommandRunnerSpec extends Specification {
         filtered == ['dbm-gorm-diff'] as String[]
     }
 
+    def "filterCommandOptions handles null elements in args"() {
+        given:
+        String[] input = ['dbm-status', null, '--dataSource=analytics'] as String[]
+
+        when:
+        String[] result = GrailsApplicationContextCommandRunner.filterCommandOptions(input)
+
+        then:
+        noExceptionThrown()
+        result == ['dbm-status'] as String[]
+    }
+
     def "filterCommandOptions protects all known Grails ecosystem command options"() {
         expect: 'every known --option from Grails plugins is filtered'
         GrailsApplicationContextCommandRunner.filterCommandOptions(input as String[]) == expected as String[]

--- a/grails-console/src/test/groovy/grails/ui/script/GrailsApplicationScriptRunnerSpec.groovy
+++ b/grails-console/src/test/groovy/grails/ui/script/GrailsApplicationScriptRunnerSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file to You under
+ *  the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package grails.ui.script
+
+import grails.ui.command.GrailsApplicationContextCommandRunner
+import spock.lang.Specification
+
+/**
+ * Tests verifying that {@link GrailsApplicationScriptRunner} filters command options
+ * before passing args to Spring Boot, using the same
+ * {@link GrailsApplicationContextCommandRunner#filterCommandOptions(String[])} method.
+ *
+ * <p>Detailed filter behavior tests are in
+ * {@link grails.ui.command.GrailsApplicationContextCommandRunnerSpec}.</p>
+ */
+class GrailsApplicationScriptRunnerSpec extends Specification {
+
+    def "filterCommandOptions is accessible from GrailsApplicationContextCommandRunner"() {
+        given: 'args as they might arrive from runScript Gradle task'
+        String[] args = ['myscript.groovy', '--someOption=value', 'com.example.Application'] as String[]
+
+        when:
+        String[] filtered = GrailsApplicationContextCommandRunner.filterCommandOptions(args)
+
+        then: 'script names and application class preserved, options removed'
+        filtered == ['myscript.groovy', 'com.example.Application'] as String[]
+    }
+
+    def "filterCommandOptions handles script args with no options"() {
+        given:
+        String[] args = ['myscript.groovy', 'com.example.Application'] as String[]
+
+        when:
+        String[] filtered = GrailsApplicationContextCommandRunner.filterCommandOptions(args)
+
+        then:
+        filtered == ['myscript.groovy', 'com.example.Application'] as String[]
+    }
+}


### PR DESCRIPTION
## Summary

`GrailsApplicationContextCommandRunner.run()` and `GrailsApplicationScriptRunner.run()` both pass ALL arguments--including Grails command options like `--dataSource=secondary`, `--contexts=production`, `--defaultSchema=public`, `--groupClassName=RoleGroup`--to `super.run(args)` (which is `SpringApplication.run()`). Spring Boot's `CommandLinePropertySource` interprets `--key=value` as property overrides, corrupting GORM and Spring configuration. This affects **30+ database migration commands**, **Spring Security CLI commands**, and **any custom `ApplicationCommand`** that accepts `--` options when run via Gradle.

## Bug Description

Running any Gradle `dbm*` task with a `--dataSource` argument fails:

```bash
./gradlew dbmStatus -Pargs="--dataSource=secondary"
```

**Error:**
```
Error creating bean with name 'hibernateDatastore':
  Failed to instantiate [org.grails.orm.hibernate.HibernateDatastore]:
    Constructor threw exception

Caused by: java.lang.IllegalArgumentException: wrong number of arguments
  at ... ConfigurationBuilder.buildRecurse(ConfigurationBuilder.groovy:394)
```

The `grailsw` CLI workaround works because it uses a different argument parsing path that doesn't pass `--dataSource` through `SpringApplication.run()`:

```bash
./grailsw dbm-status --dataSource=secondary
# Works correctly
```

### Affected Commands

This bug affects **every Grails command** that passes `--` prefixed arguments when run via Gradle's `ApplicationContextCommandTask` or `ApplicationContextScriptTask`.

#### Database Migration Plugin (30+ commands)

All `dbm-*` commands accept these `--` options, all of which trigger the bug:

| Option | Example | Effect When Intercepted by Spring Boot |
|--------|---------|----------------------------------------|
| `--dataSource=<name>` | `--dataSource=analytics` | Corrupts `dataSource` config (Map to String) |
| `--contexts=<list>` | `--contexts=production` | Sets `contexts=production` property |
| `--defaultSchema=<name>` | `--defaultSchema=public` | Sets `defaultSchema=public` property |
| `--verbose` | `--verbose` | Sets `verbose=` property |
| `--add` | `--add` | Sets `add=` property |

#### Spring Security Plugin

| Command | Option | Effect |
|---------|--------|--------|
| `s2-quickstart` | `--groupClassName=RoleGroup` | Sets `groupClassName=RoleGroup` property |

#### GrailsApplicationScriptRunner (runScript task)

The `runScript` Gradle task uses `GrailsApplicationScriptRunner`, which had the same `super.run(args)` pattern. Scripts run with `--` args via `./gradlew runScript -Pargs="myscript.groovy --option=value"` would trigger the same corruption.

#### Custom ApplicationCommand Implementations

Any custom command that accepts `--` options is affected when run via `./gradlew runCommand -Pargs="my-command --option=value"`.

## Root Cause

**Two classes** pass unfiltered args to `SpringApplication.run()`:

1. **`GrailsApplicationContextCommandRunner.run()`** (line 57) -- used by ALL `ApplicationContextCommandTask` Gradle tasks (dbm*, s2-*, custom commands)
2. **`GrailsApplicationScriptRunner.run()`** (line 52) -- used by `ApplicationContextScriptTask` Gradle task (runScript)

```groovy
// Both classes had the same pattern:
ctx = super.run(args)  // args includes ["dbm-status", "--dataSource=secondary", "com.example.Application"]
```

`super.run()` is `SpringApplication.run()`, which registers a `CommandLinePropertySource` that interprets every `--key=value` argument as a Spring property override. When `--dataSource=secondary` hits this, it sets the `dataSource` property to the String `"secondary"`, overwriting GORM's Map-based datasource configuration.

The `--dataSource` argument is intended for the Grails command (parsed separately by `CommandLineParser.parse(args)`), NOT for Spring Boot.

**Note:** `GrailsApp.run()` also calls `super.run(args)` but is NOT affected because `bootRun` only passes the Application class name -- no `--` options.

## Fix

### `GrailsApplicationContextCommandRunner`

Added a `filterCommandOptions()` method that strips all `--` prefixed arguments before passing to `super.run()`. Changed visibility from `protected` to package-public (`static`) so `GrailsApplicationScriptRunner` can reuse it. The full args are still passed to `CommandLineParser.parse(args)` so the Grails command receives its options:

```groovy
// Before (broken): Spring Boot sees --dataSource=secondary
ctx = super.run(args)

// After (fixed): Spring Boot only sees non-option args
String[] springBootArgs = filterCommandOptions(args)
ctx = super.run(springBootArgs)
CommandLine commandLine = new CommandLineParser().parse(args)  // Command still gets full args
```

### `GrailsApplicationScriptRunner`

Updated to call `GrailsApplicationContextCommandRunner.filterCommandOptions(args)` before `super.run()`:

```groovy
// Before (broken)
ctx = super.run(args)

// After (fixed)
String[] springBootArgs = GrailsApplicationContextCommandRunner.filterCommandOptions(args)
ctx = super.run(springBootArgs)
```

### `filterCommandOptions()` method

```groovy
static String[] filterCommandOptions(String[] args) {
    List<String> filtered = new ArrayList<>()
    for (String arg : args) {
        if (!arg.startsWith('--')) {
            filtered.add(arg)
        }
    }
    filtered.toArray(new String[0])
}
```

This matches the existing pattern -- Spring Boot should only receive the application class name and the command name, not Grails command-specific options.

## Files Changed

| File | Change |
|------|--------|
| `grails-console/.../GrailsApplicationContextCommandRunner.groovy` | Added `filterCommandOptions()` method (changed from `protected static` to `static`), called before `super.run()` |
| `grails-console/.../GrailsApplicationScriptRunner.groovy` | Updated `run()` to call `filterCommandOptions()` before `super.run()` |
| `grails-console/.../GrailsApplicationContextCommandRunnerSpec.groovy` | **New** -- 21 Spock tests for `filterCommandOptions()` covering all known ecosystem `--` options |
| `grails-console/.../GrailsApplicationScriptRunnerSpec.groovy` | **New** -- 2 Spock tests verifying `GrailsApplicationScriptRunner` uses the same filter |
| `grails-console/build.gradle` | Added `test-config.gradle` import for JUnit Platform (Spock) |

## Test Coverage

**27 Spock tests total** (21 in `GrailsApplicationContextCommandRunnerSpec` + 2 in `GrailsApplicationScriptRunnerSpec` + 4 property tests):

### Core filter behavior (14 data-driven rows):
1. **Filters single `--dataSource` option** -- primary use case
2. **Filters multiple command options** -- `--dataSource` + `--contexts` stripped together
3. **No options passthrough** -- args without `--` prefix pass through unchanged
4. **Empty args** -- returns empty array
5. **Only options (no command)** -- all args stripped to empty array
6. **Mixed options and positional args** -- positional args preserved, options removed
7. **Flag without value** -- `--verbose` (no `=`) also stripped
8. **Single dash args preserved** -- `-v` is NOT stripped (only `--` prefix)
9. **Database migration `--contexts` option** -- `--contexts=production` stripped
10. **Database migration `--defaultSchema`** -- `--defaultSchema=myschema` stripped
11. **All three dbm options together** -- `--dataSource` + `--contexts` + `--defaultSchema` all stripped
12. **dbm command with positional + options** -- `output.groovy` preserved, `--dataSource` + `--add` stripped
13. **Spring Security `--groupClassName`** -- positional args (`com.example`, `User`, `Role`) preserved, `--groupClassName=RoleGroup` stripped
14. **Script runner with `--option`** -- `myscript.groovy` preserved, `--someOption=value` stripped

### Structural tests:
15. **Preserves argument order** -- non-option args maintain original order
16. **Returns new array instance** -- input array not mutated
17. **Handles typical Gradle dbm task args** -- realistic end-to-end scenario
18. **Prevents dataSource property corruption** -- verifies `dataSource` key not present in filtered args

### Ecosystem coverage (7 data-driven rows):
19-25. **All known Grails ecosystem `--` options** -- `--dataSource`, `--contexts`, `--defaultSchema`, `--verbose`, `--add`, `--groupClassName`, custom `--flags`

### Script runner tests:
26. **`filterCommandOptions` is accessible from `GrailsApplicationContextCommandRunner`** -- verifies visibility change works cross-package
27. **`filterCommandOptions` handles script args with no options** -- passthrough case

All 27 tests pass.

### `./grailsw` CLI verification:
- `./grailsw dbm-status` -- works (default datasource, no `--` args)
- `./grailsw dbm-status --dataSource=secondary` -- works (the existing CLI workaround is NOT broken by this fix)

The fix only affects the `super.run(args)` call path used by Gradle tasks. The `grailsw` CLI path goes through `GrailsCli` then `ApplicationCommand.handle()`, which doesn't pass args to Spring Boot.

## Example Application

**Repository:** https://github.com/jamesfredley/grails-dbm-datasource-arg-conflict

Grails 7.0.7 app with two H2 in-memory databases (primary + secondary) and Liquibase migration changelogs. Demonstrates:

1. `./gradlew bootRun` -- app starts normally, `http://localhost:8080/bugDemo/index` returns JSON confirming bug
2. `./gradlew dbmStatus` -- default datasource succeeds
3. `./gradlew dbmStatus -Pargs="--dataSource=secondary"` -- **FAILS** with `ConfigurationBuilder` error
4. `./grailsw dbm-status --dataSource=secondary` -- **WORKS** (workaround via CLI)

## Environment Information

- Grails: 7.0.7
- GORM: 7.0.7
- Spring Boot: 3.5.10
- Groovy: 4.0.30
- JDK: 17 (Amazon Corretto)

## Version

7.0.7
