### PR TITLE
docs: Add Data Services documentation for multi-datasource routing

### DIFF
--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/dataSourceNamespaces.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/dataSourceNamespaces.adoc
@@ -62,4 +62,4 @@ def results = c.list {
 }
 ----
 
-TIP: The namespace syntax (e.g., `ZipCode.auditing.get(42)`) uses dynamic dispatch and is not compatible with `@CompileStatic`. For statically compiled code, use `GormEnhancer.findStaticApi(ZipCode, 'auditing')` instead, which returns a `GormStaticApi` handle with the same methods routed to the specified datasource. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for examples.
+TIP: The namespace syntax (e.g., `ZipCode.auditing.get(42)`) uses dynamic dispatch and is not compatible with `@CompileStatic`. For statically compiled code, use `GormEnhancer.findStaticApi(ZipCode, 'auditing')` to obtain a `GormStaticApi` handle with the same methods routed to the specified datasource, or use a Data Service with `@Transactional(connection = 'auditing')` for automatic routing. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for the full pattern.

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/dataSourceNamespaces.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/dataSourceNamespaces.adoc
@@ -61,3 +61,5 @@ def results = c.list {
     like('code','995%')
 }
 ----
+
+TIP: The namespace syntax (e.g., `ZipCode.auditing.get(42)`) uses dynamic dispatch and is not compatible with `@CompileStatic`. For statically compiled code, use `GormEnhancer.findStaticApi(ZipCode, 'auditing')` instead, which returns a `GormStaticApi` handle with the same methods routed to the specified datasource. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for examples.

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/dataSourceNamespaces.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/dataSourceNamespaces.adoc
@@ -62,4 +62,4 @@ def results = c.list {
 }
 ----
 
-TIP: The namespace syntax (e.g., `ZipCode.auditing.get(42)`) uses dynamic dispatch and is not compatible with `@CompileStatic`. For statically compiled code, use `GormEnhancer.findStaticApi(ZipCode, 'auditing')` to obtain a `GormStaticApi` handle with the same methods routed to the specified datasource, or use a Data Service with `@Transactional(connection = 'auditing')` for automatic routing. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for the full pattern.
+TIP: The namespace syntax (e.g., `ZipCode.auditing.get(42)`) is only needed when a domain is mapped to multiple datasources and you need to target a specific one. For domains mapped to a single non-default datasource, static methods like `ZipCode.get(42)` route to the correct datasource automatically and work under `@CompileStatic`. You can also use a Data Service with `@Transactional(connection = 'auditing')` for automatic routing of auto-implemented methods. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for the full pattern.

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/index.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/index.adoc
@@ -31,6 +31,10 @@ include::mappingDomainsToDataSources.adoc[]
 
 include::dataSourceNamespaces.adoc[]
 
+=== Using Data Services with Multiple Datasources
+
+When using GORM Data Services (`@Service` annotation) with secondary datasources, you must annotate the abstract class with `@Transactional(connection = 'connectionName')` to route all auto-implemented methods to the correct datasource. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for the full pattern, including `GormEnhancer.findStaticApi()` for complex queries.
+
 [[connectionSources]]
 === The ConnectionSources API
 

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/index.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/index.adoc
@@ -33,7 +33,7 @@ include::dataSourceNamespaces.adoc[]
 
 === Using Data Services with Multiple Datasources
 
-When using GORM Data Services (`@Service` annotation) with secondary datasources, you must annotate the abstract class with `@Transactional(connection = 'connectionName')` to route all auto-implemented methods to the correct datasource. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for the full pattern, including `GormEnhancer.findStaticApi()` for complex queries.
+GORM Data Services support multi-datasource routing via `@Transactional(connection = 'connectionName')` on the abstract class. All auto-implemented methods - `get()`, `save()`, `delete()`, `findBy*()`, `countBy*()` - route to the specified datasource automatically. This works with `@CompileStatic`, injected `@Service` properties, and `MultiTenant` domain classes. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for the full pattern, including `GormEnhancer.findStaticApi()` for complex queries.
 
 [[connectionSources]]
 === The ConnectionSources API

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/index.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multipleDataSources/index.adoc
@@ -33,7 +33,7 @@ include::dataSourceNamespaces.adoc[]
 
 === Using Data Services with Multiple Datasources
 
-GORM Data Services support multi-datasource routing via `@Transactional(connection = 'connectionName')` on the abstract class. All auto-implemented methods - `get()`, `save()`, `delete()`, `findBy*()`, `countBy*()` - route to the specified datasource automatically. This works with `@CompileStatic`, injected `@Service` properties, and `MultiTenant` domain classes. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for the full pattern, including `GormEnhancer.findStaticApi()` for complex queries.
+GORM Data Services support multi-datasource routing via `@Transactional(connection = 'connectionName')` on the abstract class. All auto-implemented methods - `get()`, `save()`, `delete()`, `findBy*()`, `countBy*()` - route to the specified datasource automatically. For complex queries, domain static methods like `Book.executeQuery()` and `Book.createCriteria()` also route to the correct datasource. This works with `@CompileStatic`, injected `@Service` properties, and `MultiTenant` domain classes. See the <<dataServicesMultipleDataSources,Data Services and Multiple Datasources>> section for the full pattern.
 
 [[connectionSources]]
 === The ConnectionSources API

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/services/index.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/services/index.adoc
@@ -37,6 +37,11 @@ include::writeOperations.adoc[]
 
 include::serviceValidation.adoc[]
 
+[[dataServicesMultipleDataSources]]
+=== Data Services and Multiple Datasources
+
+include::multipleDataSources.adoc[]
+
 === RxJava Support
 
 include::rxServices.adoc[]

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
@@ -219,11 +219,11 @@ abstract class AuthorService implements AuthorDataService {
 }
 ----
 
-When the Spring context initializes the generated implementation class, it eagerly populates all `@Service`-typed properties via `datastore.getService()`. By the time any user code runs, injected Data Services are fully available.
+When the Spring context initializes the generated implementation class, it autowires all `@Service`-typed properties by type. By the time any user code runs, injected Data Services are fully available.
 
 ==== Multi-Tenancy with Multiple Datasources
 
-Domain classes that implement `GormEntity` with the `MultiTenant` trait and declare an explicit non-default datasource (e.g., `datasource 'analytics'`) route correctly through Data Services. GORM's `GormEnhancer` preserves explicit datasource qualifiers for multi-tenant entities, so Data Services using `@Transactional(connection = 'analytics')` work the same way as for non-tenant domain classes:
+Domain classes that use the `MultiTenant` trait and declare an explicit non-default datasource (e.g., `datasource 'analytics'`) route correctly through Data Services. GORM preserves explicit datasource qualifiers for multi-tenant entities, so Data Services using `@Transactional(connection = 'analytics')` work the same way as for non-tenant domain classes:
 
 [source,groovy]
 ----

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
@@ -73,7 +73,7 @@ abstract class BookService implements BookDataService {
 
 The `@Transactional(connection = 'books')` annotation on the abstract class ensures that all auto-implemented methods (`get`, `save`, `delete`, `findBy*`, `countBy*`, etc.) route to the `books` datasource. Without this annotation, queries silently route to the default datasource.
 
-IMPORTANT: The `connection` parameter is required when using Data Services with secondary datasources. The `@Service(Book)` annotation alone does not determine which datasource to use, even if the `Book` domain class declares `datasource 'books'` in its mapping block.
+NOTE: The `@Service(Book)` annotation identifies the domain class but does not determine which datasource to use. Even if `Book` declares `datasource 'books'` in its mapping block, you must specify `@Transactional(connection = 'books')` on the abstract class to route operations to the correct datasource.
 
 ==== How Connection Routing Works
 
@@ -189,3 +189,80 @@ class LibraryService {
 ----
 
 The consuming service does not need `@Transactional(connection = 'books')`. The Data Service handles datasource routing internally.
+
+Data Services can also inject other Data Services. `@CompileStatic` works on `@Service` abstract classes that declare `@Service`-typed properties:
+
+[source,groovy]
+----
+import grails.gorm.services.Service
+
+interface AuthorDataService {
+
+    Author get(Serializable id)
+
+    Author save(Author author)
+}
+----
+
+[source,groovy]
+----
+import groovy.transform.CompileStatic
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+
+@CompileStatic
+@Service(Author)
+@Transactional(connection = 'books')
+abstract class AuthorService implements AuthorDataService {
+
+    BookDataService bookDataService  // injected @Service property
+
+    Map getAuthorWithBooks(Serializable authorId) {
+        Author author = get(authorId)
+        List<Book> books = bookDataService.findAllByAuthor(author.name)
+        [author: author, books: books]
+    }
+}
+----
+
+When the Spring context initializes the generated implementation class, it eagerly populates all `@Service`-typed properties via `datastore.getService()`. By the time any user code runs, injected Data Services are fully available.
+
+==== Multi-Tenancy with Multiple Datasources
+
+Domain classes that implement `GormEntity` with the `MultiTenant` trait and declare an explicit non-default datasource (e.g., `datasource 'analytics'`) route correctly through Data Services. GORM's `GormEnhancer` preserves explicit datasource qualifiers for multi-tenant entities, so Data Services using `@Transactional(connection = 'analytics')` work the same way as for non-tenant domain classes:
+
+[source,groovy]
+----
+import grails.gorm.MultiTenant
+
+class Metric implements MultiTenant<Metric> {
+
+    String name
+    BigDecimal value
+
+    static mapping = {
+        datasource 'analytics'
+    }
+}
+----
+
+[source,groovy]
+----
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import groovy.transform.CompileStatic
+
+@CompileStatic
+@Service(Metric)
+@Transactional(connection = 'analytics')
+abstract class MetricService {
+
+    abstract Metric get(Serializable id)
+
+    abstract Metric save(Metric metric)
+
+    abstract List<Metric> list()
+}
+----
+
+The `connection` parameter on the abstract class routes all auto-implemented operations - including `save()`, `get()`, and `delete()` - to the `analytics` datasource, regardless of multi-tenancy mode (DATABASE or DISCRIMINATOR).

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
@@ -83,7 +83,7 @@ When GORM compiles a `@Service` abstract class, the `ServiceTransformation` AST 
 2. For each auto-implemented method, resolves the connection identifier via `findConnectionId()`
 3. Generates method bodies that use the appropriate connection - `GormEnhancer.findStaticApi(Book, 'books')` for CRUD operations and `DetachedCriteria.withConnection('books')` for finder queries
 
-This means auto-implemented methods like `get()`, `save()`, `delete()`, `findBy*()`, and `countBy*()` all respect the connection parameter without requiring manual implementations.
+This means auto-implemented methods like `get()`, `save()`, `delete()`, `findBy*()`, `countBy*()`, `@Where`-annotated methods, `@Query`-annotated methods, and `DetachedCriteria`-based queries all respect the connection parameter without requiring manual implementations.
 
 ==== Complex Queries with GormEnhancer
 

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
@@ -1,0 +1,191 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+When using Data Services with <<multipleDataSources,multiple datasources>>, the service must declare which connection to use via the `connection` parameter of `@Transactional`.
+
+==== Routing to a Secondary Datasource
+
+Given a domain class mapped to a secondary datasource:
+
+[source,groovy]
+----
+class Book {
+
+    String title
+    String author
+
+    static mapping = {
+        datasource 'books'
+    }
+}
+----
+
+Define an interface for your data access methods and an abstract class that declares the connection:
+
+[source,groovy]
+----
+import grails.gorm.services.Service
+
+interface BookDataService {
+
+    Book get(Serializable id)
+
+    Book save(Book book)
+
+    void delete(Serializable id)
+
+    List<Book> findAllByAuthor(String author)
+
+    Long count()
+}
+----
+
+[source,groovy]
+----
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import groovy.transform.CompileStatic
+
+@CompileStatic
+@Service(Book)
+@Transactional(connection = 'books')
+abstract class BookService implements BookDataService {
+    // All interface methods are auto-implemented by GORM
+    // and route to the 'books' datasource automatically.
+}
+----
+
+The `@Transactional(connection = 'books')` annotation on the abstract class ensures that all auto-implemented methods (`get`, `save`, `delete`, `findBy*`, `countBy*`, etc.) route to the `books` datasource. Without this annotation, queries silently route to the default datasource.
+
+IMPORTANT: The `connection` parameter is required when using Data Services with secondary datasources. The `@Service(Book)` annotation alone does not determine which datasource to use, even if the `Book` domain class declares `datasource 'books'` in its mapping block.
+
+==== How Connection Routing Works
+
+When GORM compiles a `@Service` abstract class, the `ServiceTransformation` AST transform:
+
+1. Copies the `@Transactional(connection = 'books')` annotation from the abstract class to the generated implementation class
+2. For each auto-implemented method, resolves the connection identifier via `findConnectionId()`
+3. Generates method bodies that use the appropriate connection - `GormEnhancer.findStaticApi(Book, 'books')` for CRUD operations and `DetachedCriteria.withConnection('books')` for finder queries
+
+This means auto-implemented methods like `get()`, `save()`, `delete()`, `findBy*()`, and `countBy*()` all respect the connection parameter without requiring manual implementations.
+
+==== Complex Queries with GormEnhancer
+
+Auto-implemented Data Service methods cover most query patterns, including dynamic finders with comparators, pagination, and property projections. For queries that require HQL, criteria builders, or aggregate functions, use `GormEnhancer.findStaticApi()` to obtain a statically compiled API handle for the target datasource:
+
+[source,groovy]
+----
+import groovy.transform.CompileStatic
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.gorm.GormStaticApi
+
+@CompileStatic
+@Service(Book)
+@Transactional(connection = 'books')
+abstract class BookService implements BookDataService {
+
+    // Auto-implemented methods from interface are inherited
+    // and route to 'books' datasource automatically.
+
+    private GormStaticApi<Book> getBooksApi() {
+        GormEnhancer.findStaticApi(Book, 'books')
+    }
+
+    List getTopAuthors(int limit) {
+        booksApi.executeQuery('''
+            SELECT b.author, COUNT(b) as bookCount
+            FROM Book b
+            GROUP BY b.author
+            ORDER BY bookCount DESC
+        ''', Collections.emptyMap(), [max: limit])
+    }
+
+    List<Book> searchWithCriteria(String titlePattern, String author) {
+        booksApi.createCriteria().list {
+            like('title', "%${titlePattern}%")
+            eq('author', author)
+            order('title', 'asc')
+        } as List<Book>
+    }
+}
+----
+
+The `GormStaticApi` returned by `findStaticApi()` provides these methods, all routed to the specified datasource:
+
+[cols="1,2"]
+|===
+| Method | Description
+
+| `executeQuery(String hql, Map params)`
+| HQL/JPQL queries
+
+| `executeUpdate(String hql, Map params)`
+| Bulk UPDATE/DELETE statements
+
+| `withCriteria(Closure criteria)`
+| Criteria query
+
+| `createCriteria()`
+| Criteria builder for complex queries
+
+| `where(Closure query)`
+| Where query
+
+| `withTransaction(Closure action)`
+| Manual transaction management
+
+| `count()`
+| Total record count
+
+| `get(Serializable id)`
+| Find by primary key
+
+| `list(Map params)`
+| Paginated list
+
+| `save(Object instance)`
+| Persist an instance
+|===
+
+NOTE: `GormEnhancer.findStaticApi()` is the statically compiled equivalent of the <<dataSourceNamespaces,namespace syntax>> (e.g., `Book.books.get(42)`). Unlike the namespace syntax, it works under `@CompileStatic` without requiring `@CompileDynamic` on individual methods.
+
+==== Consuming Multi-Datasource Data Services
+
+Other services inject the Data Service interface type. Spring resolves the abstract class bean automatically:
+
+[source,groovy]
+----
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class LibraryService {
+
+    BookDataService bookDataService  // injected automatically
+
+    Map getLibraryStats() {
+        Long totalBooks = bookDataService.count()
+        List<Book> recentBooks = bookDataService.findAllByAuthor('Tolkien')
+        [total: totalBooks, tolkienBooks: recentBooks.size()]
+    }
+}
+----
+
+The consuming service does not need `@Transactional(connection = 'books')`. The Data Service handles datasource routing internally.

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/services/multipleDataSources.adoc
@@ -81,21 +81,19 @@ When GORM compiles a `@Service` abstract class, the `ServiceTransformation` AST 
 
 1. Copies the `@Transactional(connection = 'books')` annotation from the abstract class to the generated implementation class
 2. For each auto-implemented method, resolves the connection identifier via `findConnectionId()`
-3. Generates method bodies that use the appropriate connection - `GormEnhancer.findStaticApi(Book, 'books')` for CRUD operations and `DetachedCriteria.withConnection('books')` for finder queries
+3. Generates method bodies that use the appropriate connection, routing CRUD operations and `DetachedCriteria`-based finder queries to the specified datasource
 
 This means auto-implemented methods like `get()`, `save()`, `delete()`, `findBy*()`, `countBy*()`, `@Where`-annotated methods, `@Query`-annotated methods, and `DetachedCriteria`-based queries all respect the connection parameter without requiring manual implementations.
 
-==== Complex Queries with GormEnhancer
+==== Complex Queries Using Domain Static Methods
 
-Auto-implemented Data Service methods cover most query patterns, including dynamic finders with comparators, pagination, and property projections. For queries that require HQL, criteria builders, or aggregate functions, use `GormEnhancer.findStaticApi()` to obtain a statically compiled API handle for the target datasource:
+Auto-implemented Data Service methods cover most query patterns, including dynamic finders with comparators, pagination, and property projections. For queries that require HQL, criteria builders, or aggregate functions, call domain static methods directly. When a domain class declares a non-default datasource in its mapping block, GORM registers its static API under that datasource. Methods like `Book.executeQuery()`, `Book.createCriteria()`, and `Book.withCriteria()` automatically route to the correct datasource:
 
 [source,groovy]
 ----
 import groovy.transform.CompileStatic
 import grails.gorm.services.Service
 import grails.gorm.transactions.Transactional
-import org.grails.datastore.gorm.GormEnhancer
-import org.grails.datastore.gorm.GormStaticApi
 
 @CompileStatic
 @Service(Book)
@@ -105,12 +103,8 @@ abstract class BookService implements BookDataService {
     // Auto-implemented methods from interface are inherited
     // and route to 'books' datasource automatically.
 
-    private GormStaticApi<Book> getBooksApi() {
-        GormEnhancer.findStaticApi(Book, 'books')
-    }
-
     List getTopAuthors(int limit) {
-        booksApi.executeQuery('''
+        Book.executeQuery('''
             SELECT b.author, COUNT(b) as bookCount
             FROM Book b
             GROUP BY b.author
@@ -119,7 +113,7 @@ abstract class BookService implements BookDataService {
     }
 
     List<Book> searchWithCriteria(String titlePattern, String author) {
-        booksApi.createCriteria().list {
+        Book.createCriteria().list {
             like('title', "%${titlePattern}%")
             eq('author', author)
             order('title', 'asc')
@@ -128,44 +122,44 @@ abstract class BookService implements BookDataService {
 }
 ----
 
-The `GormStaticApi` returned by `findStaticApi()` provides these methods, all routed to the specified datasource:
+These domain static methods all route to the datasource declared in the domain's mapping block:
 
 [cols="1,2"]
 |===
 | Method | Description
 
-| `executeQuery(String hql, Map params)`
+| `Book.executeQuery(String hql, Map params)`
 | HQL/JPQL queries
 
-| `executeUpdate(String hql, Map params)`
+| `Book.executeUpdate(String hql, Map params)`
 | Bulk UPDATE/DELETE statements
 
-| `withCriteria(Closure criteria)`
+| `Book.withCriteria(Closure criteria)`
 | Criteria query
 
-| `createCriteria()`
+| `Book.createCriteria()`
 | Criteria builder for complex queries
 
-| `where(Closure query)`
+| `Book.where(Closure query)`
 | Where query
 
-| `withTransaction(Closure action)`
+| `Book.withTransaction(Closure action)`
 | Manual transaction management
 
-| `count()`
+| `Book.withNewSession(Closure action)`
+| Obtain a new session for the domain's datasource
+
+| `Book.count()`
 | Total record count
 
-| `get(Serializable id)`
+| `Book.get(Serializable id)`
 | Find by primary key
 
-| `list(Map params)`
+| `Book.list(Map params)`
 | Paginated list
-
-| `save(Object instance)`
-| Persist an instance
 |===
 
-NOTE: `GormEnhancer.findStaticApi()` is the statically compiled equivalent of the <<dataSourceNamespaces,namespace syntax>> (e.g., `Book.books.get(42)`). Unlike the namespace syntax, it works under `@CompileStatic` without requiring `@CompileDynamic` on individual methods.
+NOTE: Domain static methods work under `@CompileStatic` and route to the correct datasource automatically. The <<dataSourceNamespaces,namespace syntax>> (e.g., `Book.books.get(42)`) is only needed when a domain is mapped to multiple datasources and you need to target a specific one.
 
 ==== Consuming Multi-Datasource Data Services
 

--- a/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
+++ b/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
@@ -459,13 +459,13 @@ abstract class AuthorService implements AuthorDataService {
 }
 ----
 
-When the Spring context initializes the generated implementation class, it eagerly populates all `@Service`-typed properties via `datastore.getService()`. By the time any user code runs, injected Data Services are fully available.
+When the Spring context initializes the generated implementation class, it autowires all `@Service`-typed properties by type. By the time any user code runs, injected Data Services are fully available.
 
 
 ===== Multi-Tenancy with Multiple Datasources
 
 
-Domain classes that implement `GormEntity` with the `MultiTenant` trait and declare an explicit non-default datasource (e.g., `datasource 'analytics'`) route correctly through Data Services. GORM's `GormEnhancer` preserves explicit datasource qualifiers for multi-tenant entities, so Data Services using `@Transactional(connection = 'analytics')` work the same way as for non-tenant domain classes:
+Domain classes that use the `MultiTenant` trait and declare an explicit non-default datasource (e.g., `datasource 'analytics'`) route correctly through Data Services. GORM preserves explicit datasource qualifiers for multi-tenant entities, so Data Services using `@Transactional(connection = 'analytics')` work the same way as for non-tenant domain classes:
 
 [source,groovy]
 ----

--- a/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
+++ b/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
@@ -317,23 +317,21 @@ When GORM compiles a `@Service` abstract class, the `ServiceTransformation` AST 
 
 1. Copies the `@Transactional(connection = 'books')` annotation from the abstract class to the generated implementation class
 2. For each auto-implemented method, resolves the connection identifier via `findConnectionId()`
-3. Generates method bodies that use the appropriate connection - `GormEnhancer.findStaticApi(Book, 'books')` for CRUD operations and `DetachedCriteria.withConnection('books')` for finder queries
+3. Generates method bodies that use the appropriate connection, routing CRUD operations and `DetachedCriteria`-based finder queries to the specified datasource
 
 This means auto-implemented methods like `get()`, `save()`, `delete()`, `findBy*()`, `countBy*()`, `@Where`-annotated methods, `@Query`-annotated methods, and `DetachedCriteria`-based queries all respect the connection parameter without requiring manual implementations.
 
 
-===== Complex Queries with GormEnhancer
+===== Complex Queries Using Domain Static Methods
 
 
-Auto-implemented Data Service methods cover most query patterns, including dynamic finders with comparators (`Between`, `Like`, `InList`, `IsNull`, etc.), pagination via a `Map` parameter, and property projections. For queries that require HQL, criteria builders, or aggregate functions, use `GormEnhancer.findStaticApi()` to obtain a statically compiled API handle for the target datasource:
+Auto-implemented Data Service methods cover most query patterns, including dynamic finders with comparators (`Between`, `Like`, `InList`, `IsNull`, etc.), pagination via a `Map` parameter, and property projections. For queries that require HQL, criteria builders, or aggregate functions, call domain static methods directly. When a domain class declares a non-default datasource in its mapping block, GORM registers its static API under that datasource. Methods like `Book.executeQuery()`, `Book.createCriteria()`, and `Book.withCriteria()` automatically route to the correct datasource:
 
 [source,groovy]
 ----
 import groovy.transform.CompileStatic
 import grails.gorm.services.Service
 import grails.gorm.transactions.Transactional
-import org.grails.datastore.gorm.GormEnhancer
-import org.grails.datastore.gorm.GormStaticApi
 
 @CompileStatic
 @Service(Book)
@@ -343,12 +341,8 @@ abstract class BookService implements BookDataService {
     // Auto-implemented methods from interface are inherited
     // and route to 'books' datasource automatically.
 
-    private GormStaticApi<Book> getBooksApi() {
-        GormEnhancer.findStaticApi(Book, 'books')
-    }
-
     List getTopAuthors(int limit) {
-        booksApi.executeQuery('''
+        Book.executeQuery('''
             SELECT b.author, COUNT(b) as bookCount
             FROM Book b
             GROUP BY b.author
@@ -357,7 +351,7 @@ abstract class BookService implements BookDataService {
     }
 
     List<Book> searchWithCriteria(String titlePattern, String author) {
-        booksApi.createCriteria().list {
+        Book.createCriteria().list {
             like('title', "%${titlePattern}%")
             eq('author', author)
             order('title', 'asc')
@@ -366,50 +360,44 @@ abstract class BookService implements BookDataService {
 }
 ----
 
-The `GormStaticApi` returned by `findStaticApi()` provides these methods, all routed to the specified datasource:
+These domain static methods all route to the datasource declared in the domain's mapping block:
 
 [cols="1,2"]
 |===
 | Method | Description
 
-| `executeQuery(String hql, Map params)`
+| `Book.executeQuery(String hql, Map params)`
 | HQL/JPQL queries
 
-| `executeUpdate(String hql, Map params)`
+| `Book.executeUpdate(String hql, Map params)`
 | Bulk UPDATE/DELETE statements
 
-| `find(String hql, Map params)`
-| Single-result HQL query
-
-| `findAll()` / `findAll(Map params)`
-| List all records with optional pagination
-
-| `withCriteria(Closure criteria)`
+| `Book.withCriteria(Closure criteria)`
 | Criteria query
 
-| `createCriteria()`
+| `Book.createCriteria()`
 | Criteria builder for complex queries
 
-| `where(Closure query)`
+| `Book.where(Closure query)`
 | Where query
 
-| `withTransaction(Closure action)`
+| `Book.withTransaction(Closure action)`
 | Manual transaction management
 
-| `count()`
+| `Book.withNewSession(Closure action)`
+| Obtain a new session for the domain's datasource
+
+| `Book.count()`
 | Total record count
 
-| `get(Serializable id)`
+| `Book.get(Serializable id)`
 | Find by primary key
 
-| `list(Map params)`
+| `Book.list(Map params)`
 | Paginated list
-
-| `save(Object instance)`
-| Persist an instance
 |===
 
-NOTE: `GormEnhancer.findStaticApi()` is the statically compiled equivalent of the namespace syntax (e.g., `Book.books.get(42)`). Unlike the namespace syntax, it works under `@CompileStatic` without requiring `@CompileDynamic` on individual methods.
+NOTE: Domain static methods work under `@CompileStatic` and route to the correct datasource automatically. The namespace syntax (e.g., `Book.books.get(42)`) is only needed when a domain is mapped to multiple datasources and you need to target a specific one.
 
 
 ===== Consuming Multi-Datasource Data Services

--- a/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
+++ b/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
@@ -319,7 +319,7 @@ When GORM compiles a `@Service` abstract class, the `ServiceTransformation` AST 
 2. For each auto-implemented method, resolves the connection identifier via `findConnectionId()`
 3. Generates method bodies that use the appropriate connection - `GormEnhancer.findStaticApi(Book, 'books')` for CRUD operations and `DetachedCriteria.withConnection('books')` for finder queries
 
-This means auto-implemented methods like `get()`, `save()`, `delete()`, `findBy*()`, and `countBy*()` all respect the connection parameter without requiring manual implementations.
+This means auto-implemented methods like `get()`, `save()`, `delete()`, `findBy*()`, `countBy*()`, `@Where`-annotated methods, `@Query`-annotated methods, and `DetachedCriteria`-based queries all respect the connection parameter without requiring manual implementations.
 
 
 ===== Complex Queries with GormEnhancer

--- a/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
+++ b/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
@@ -264,7 +264,7 @@ If you have a `Foo` domain class in `dataSource1` and a `Bar` domain class in `d
 ==== GORM Data Services and Multiple Datasources
 
 
-GORM Data Services provide a statically compiled alternative to the `static datasource` property shown above. When a `@Service` abstract class needs to route queries to a non-default datasource, use the `connection` parameter of `@Transactional`.
+GORM Data Services provide a type-safe, statically compiled approach to multi-datasource access. When a `@Service` abstract class needs to route operations to a non-default datasource, declare the target connection with `@Transactional(connection = 'name')`.
 
 
 ===== Basic Pattern
@@ -307,7 +307,7 @@ abstract class BookService implements BookDataService {
 
 The `@Transactional(connection = 'books')` annotation on the abstract class ensures that all auto-implemented methods (`get`, `save`, `delete`, `findBy*`, `countBy*`, etc.) route to the `books` datasource. Without this annotation, queries silently route to the default datasource.
 
-IMPORTANT: The `connection` parameter is required when using Data Services with secondary datasources. The `@Service(Book)` annotation alone does not determine which datasource to use, even if the `Book` domain class has `datasource 'books'` in its mapping block.
+NOTE: The `@Service(Book)` annotation identifies the domain class but does not determine which datasource to use. Even if `Book` declares `datasource 'books'` in its mapping block, you must specify `@Transactional(connection = 'books')` on the abstract class to route operations to the correct datasource.
 
 
 ===== How Connection Routing Works
@@ -435,6 +435,85 @@ class LibraryService {
 ----
 
 The consuming service does not need `@Transactional(connection = 'books')`. The Data Service handles datasource routing internally. If the consuming service coordinates writes across multiple Data Services, annotate the orchestrating method with `@Transactional` to ensure atomicity on the default datasource.
+
+Data Services can also inject other Data Services. `@CompileStatic` works on `@Service` abstract classes that declare `@Service`-typed properties:
+
+[source,groovy]
+----
+import grails.gorm.services.Service
+
+interface AuthorDataService {
+
+    Author get(Serializable id)
+
+    Author save(Author author)
+}
+----
+
+[source,groovy]
+----
+import groovy.transform.CompileStatic
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+
+@CompileStatic
+@Service(Author)
+@Transactional(connection = 'books')
+abstract class AuthorService implements AuthorDataService {
+
+    BookDataService bookDataService  // injected @Service property
+
+    Map getAuthorWithBooks(Serializable authorId) {
+        Author author = get(authorId)
+        List<Book> books = bookDataService.findAllByAuthor(author.name)
+        [author: author, books: books]
+    }
+}
+----
+
+When the Spring context initializes the generated implementation class, it eagerly populates all `@Service`-typed properties via `datastore.getService()`. By the time any user code runs, injected Data Services are fully available.
+
+
+===== Multi-Tenancy with Multiple Datasources
+
+
+Domain classes that implement `GormEntity` with the `MultiTenant` trait and declare an explicit non-default datasource (e.g., `datasource 'analytics'`) route correctly through Data Services. GORM's `GormEnhancer` preserves explicit datasource qualifiers for multi-tenant entities, so Data Services using `@Transactional(connection = 'analytics')` work the same way as for non-tenant domain classes:
+
+[source,groovy]
+----
+import grails.gorm.MultiTenant
+
+class Metric implements MultiTenant<Metric> {
+
+    String name
+    BigDecimal value
+
+    static mapping = {
+        datasource 'analytics'
+    }
+}
+----
+
+[source,groovy]
+----
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import groovy.transform.CompileStatic
+
+@CompileStatic
+@Service(Metric)
+@Transactional(connection = 'analytics')
+abstract class MetricService {
+
+    abstract Metric get(Serializable id)
+
+    abstract Metric save(Metric metric)
+
+    abstract List<Metric> list()
+}
+----
+
+The `connection` parameter on the abstract class routes all auto-implemented operations - including `save()`, `get()`, and `delete()` - to the `analytics` datasource, regardless of multi-tenancy mode (DATABASE or DISCRIMINATOR).
 
 
 ==== Transactions across multiple data sources

--- a/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
+++ b/grails-doc/src/en/guide/conf/dataSource/multipleDatasources.adoc
@@ -260,6 +260,183 @@ Note that the datasource specified in a service has no bearing on which datasour
 
 If you have a `Foo` domain class in `dataSource1` and a `Bar` domain class in `dataSource2`, if `WahooService` uses `dataSource1`, a service method that saves a new `Foo` and a new `Bar` will only be transactional for `Foo` since they share the same datasource. The transaction won't affect the `Bar` instance. If you want both to be transactional you'd need to use two services and XA datasources for two-phase commit, e.g. with the Atomikos plugin.
 
+
+==== GORM Data Services and Multiple Datasources
+
+
+GORM Data Services provide a statically compiled alternative to the `static datasource` property shown above. When a `@Service` abstract class needs to route queries to a non-default datasource, use the `connection` parameter of `@Transactional`.
+
+
+===== Basic Pattern
+
+
+Define an interface for your data access methods and an abstract class that declares the connection:
+
+[source,groovy]
+----
+import grails.gorm.services.Service
+
+interface BookDataService {
+
+    Book get(Serializable id)
+
+    Book save(Book book)
+
+    void delete(Serializable id)
+
+    List<Book> findAllByAuthor(String author)
+
+    Long count()
+}
+----
+
+[source,groovy]
+----
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import groovy.transform.CompileStatic
+
+@CompileStatic
+@Service(Book)
+@Transactional(connection = 'books')
+abstract class BookService implements BookDataService {
+    // All interface methods are auto-implemented by GORM
+    // and route to the 'books' datasource automatically.
+}
+----
+
+The `@Transactional(connection = 'books')` annotation on the abstract class ensures that all auto-implemented methods (`get`, `save`, `delete`, `findBy*`, `countBy*`, etc.) route to the `books` datasource. Without this annotation, queries silently route to the default datasource.
+
+IMPORTANT: The `connection` parameter is required when using Data Services with secondary datasources. The `@Service(Book)` annotation alone does not determine which datasource to use, even if the `Book` domain class has `datasource 'books'` in its mapping block.
+
+
+===== How Connection Routing Works
+
+
+When GORM compiles a `@Service` abstract class, the `ServiceTransformation` AST transform:
+
+1. Copies the `@Transactional(connection = 'books')` annotation from the abstract class to the generated implementation class
+2. For each auto-implemented method, resolves the connection identifier via `findConnectionId()`
+3. Generates method bodies that use the appropriate connection - `GormEnhancer.findStaticApi(Book, 'books')` for CRUD operations and `DetachedCriteria.withConnection('books')` for finder queries
+
+This means auto-implemented methods like `get()`, `save()`, `delete()`, `findBy*()`, and `countBy*()` all respect the connection parameter without requiring manual implementations.
+
+
+===== Complex Queries with GormEnhancer
+
+
+Auto-implemented Data Service methods cover most query patterns, including dynamic finders with comparators (`Between`, `Like`, `InList`, `IsNull`, etc.), pagination via a `Map` parameter, and property projections. For queries that require HQL, criteria builders, or aggregate functions, use `GormEnhancer.findStaticApi()` to obtain a statically compiled API handle for the target datasource:
+
+[source,groovy]
+----
+import groovy.transform.CompileStatic
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.gorm.GormStaticApi
+
+@CompileStatic
+@Service(Book)
+@Transactional(connection = 'books')
+abstract class BookService implements BookDataService {
+
+    // Auto-implemented methods from interface are inherited
+    // and route to 'books' datasource automatically.
+
+    private GormStaticApi<Book> getBooksApi() {
+        GormEnhancer.findStaticApi(Book, 'books')
+    }
+
+    List getTopAuthors(int limit) {
+        booksApi.executeQuery('''
+            SELECT b.author, COUNT(b) as bookCount
+            FROM Book b
+            GROUP BY b.author
+            ORDER BY bookCount DESC
+        ''', Collections.emptyMap(), [max: limit])
+    }
+
+    List<Book> searchWithCriteria(String titlePattern, String author) {
+        booksApi.createCriteria().list {
+            like('title', "%${titlePattern}%")
+            eq('author', author)
+            order('title', 'asc')
+        } as List<Book>
+    }
+}
+----
+
+The `GormStaticApi` returned by `findStaticApi()` provides these methods, all routed to the specified datasource:
+
+[cols="1,2"]
+|===
+| Method | Description
+
+| `executeQuery(String hql, Map params)`
+| HQL/JPQL queries
+
+| `executeUpdate(String hql, Map params)`
+| Bulk UPDATE/DELETE statements
+
+| `find(String hql, Map params)`
+| Single-result HQL query
+
+| `findAll()` / `findAll(Map params)`
+| List all records with optional pagination
+
+| `withCriteria(Closure criteria)`
+| Criteria query
+
+| `createCriteria()`
+| Criteria builder for complex queries
+
+| `where(Closure query)`
+| Where query
+
+| `withTransaction(Closure action)`
+| Manual transaction management
+
+| `count()`
+| Total record count
+
+| `get(Serializable id)`
+| Find by primary key
+
+| `list(Map params)`
+| Paginated list
+
+| `save(Object instance)`
+| Persist an instance
+|===
+
+NOTE: `GormEnhancer.findStaticApi()` is the statically compiled equivalent of the namespace syntax (e.g., `Book.books.get(42)`). Unlike the namespace syntax, it works under `@CompileStatic` without requiring `@CompileDynamic` on individual methods.
+
+
+===== Consuming Multi-Datasource Data Services
+
+
+Other services inject the Data Service interface type. Spring resolves the abstract class bean automatically:
+
+[source,groovy]
+----
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class LibraryService {
+
+    BookDataService bookDataService  // injected automatically
+
+    Map getLibraryStats() {
+        Long totalBooks = bookDataService.count()
+        List<Book> recentBooks = bookDataService.findAllByAuthor('Tolkien')
+        [total: totalBooks, tolkienBooks: recentBooks.size()]
+    }
+}
+----
+
+The consuming service does not need `@Transactional(connection = 'books')`. The Data Service handles datasource routing internally. If the consuming service coordinates writes across multiple Data Services, annotate the orchestrating method with `@Transactional` to ensure atomicity on the default datasource.
+
+
 ==== Transactions across multiple data sources
 
 Grails does not by default try to handle transactions that span multiple data sources.

--- a/grails-doc/src/en/guide/services/declarativeTransactions/transactionsMultiDataSource.adoc
+++ b/grails-doc/src/en/guide/services/declarativeTransactions/transactionsMultiDataSource.adoc
@@ -62,6 +62,8 @@ class BookService {
 }
 ----
 
+TIP: When using GORM Data Services (`@Service` annotation), use `@Transactional(connection = 'books')` on the abstract class instead of per-method annotations. This routes all auto-implemented methods to the correct datasource automatically. See the <<multipleDatasources,Data Services and Multiple Datasources>> section for details.
+
 [source, groovy]
 ----
 @CompileStatic

--- a/grails-doc/src/en/guide/services/declarativeTransactions/transactionsMultiDataSource.adoc
+++ b/grails-doc/src/en/guide/services/declarativeTransactions/transactionsMultiDataSource.adoc
@@ -62,7 +62,7 @@ class BookService {
 }
 ----
 
-TIP: When using GORM Data Services (`@Service` annotation), use `@Transactional(connection = 'books')` on the abstract class instead of per-method annotations. This routes all auto-implemented methods to the correct datasource automatically. See the <<multipleDatasources,Data Services and Multiple Datasources>> section for details.
+TIP: GORM Data Services offer a simpler approach. Annotate the `@Service` abstract class with `@Transactional(connection = 'books')` and all auto-implemented methods - `get()`, `save()`, `delete()`, `findBy*()`, `countBy*()` - route to the correct datasource automatically. See the <<multipleDatasources,Data Services and Multiple Datasources>> section for the full pattern.
 
 [source, groovy]
 ----


### PR DESCRIPTION
## Summary

Adds documentation for using GORM Data Services with multiple datasources - a topic completely absent from both grails-doc and the GORM Hibernate5 docs today. Covers `@Transactional(connection)` routing, `GormEnhancer.findStaticApi()` for statically compiled escape-hatch queries, the interface + abstract class pattern, `@CompileStatic` with injected `@Service` properties, and MultiTenant entity routing.

This documentation assumes the following fix PRs are merged:

- #15393 - `GormEnhancer.allQualifiers()` preserves explicit datasource qualifiers for MultiTenant entities
- #15395 - Auto-implemented Data Service CRUD methods (`save()`, `delete()`, `get()`) respect `@Transactional(connection)`
- #15396 - `@CompileStatic` on `@Service` abstract class with injected `@Service` properties compiles correctly

## Changes

### grails-doc (Grails User Guide)

**`multipleDatasources.adoc`** - New "GORM Data Services and Multiple Datasources" section with 6 subsections:

- **Basic Pattern** - Interface + abstract class with `@Transactional(connection = 'books')`, explaining that the `connection` parameter is required (the `@Service` annotation alone does not determine datasource routing)
- **How Connection Routing Works** - How `ServiceTransformation` copies the `@Transactional(connection)` annotation to the generated implementation and how `findConnectionId()` propagates it to auto-implemented methods
- **Complex Queries with GormEnhancer** - `GormEnhancer.findStaticApi(Book, 'books')` pattern for HQL, criteria, and aggregation queries that cannot be auto-implemented. Includes a reference table of all available `GormStaticApi` methods
- **Consuming Multi-Datasource Data Services** - Injecting the interface type in other services, plus `@CompileStatic` on `@Service` abstract classes that inject other `@Service`-typed properties (enabled by #15396)
- **Multi-Tenancy with Multiple Datasources** - MultiTenant entities with explicit non-default datasource declarations route correctly through Data Services in both DATABASE and DISCRIMINATOR modes (enabled by #15393)

**`transactionsMultiDataSource.adoc`** - Added a TIP cross-referencing the new Data Services section, explicitly listing all routed CRUD methods

### grails-data-hibernate5 (GORM Hibernate Docs)

**New file: `services/multipleDataSources.adoc`** - Full Data Services multi-datasource documentation mirroring the grails-doc content, including:
- Routing to a secondary datasource with `@Transactional(connection)`
- How connection routing works (ServiceTransformation AST chain)
- Complex queries with `GormEnhancer.findStaticApi()` and `GormStaticApi` method reference table
- Consuming multi-datasource Data Services with `@CompileStatic` + injected `@Service` example
- Multi-Tenancy with explicit datasource and MultiTenant trait

**`services/index.adoc`** - Added include for the new section with `[[dataServicesMultipleDataSources]]` anchor

**`multipleDataSources/index.adoc`** - Added "Using Data Services with Multiple Datasources" cross-reference section, noting support for `@CompileStatic`, injected `@Service` properties, and `MultiTenant` domain classes

**`multipleDataSources/dataSourceNamespaces.adoc`** - Added TIP noting `GormEnhancer.findStaticApi()` and Data Services as `@CompileStatic`-friendly alternatives to namespace syntax

## Why This Is Needed

Currently there is zero documentation connecting GORM Data Services to multi-datasource usage:

- **grails-doc** `multipleDatasources.adoc` only shows the old `static datasource = 'lookup'` pattern
- **GORM Hibernate5** `services/` docs cover Data Services in detail but never mention multi-datasource
- **GORM Hibernate5** `multipleDataSources/` docs cover namespace syntax but never mention Data Services
- No documentation mentions `@Transactional(connection = 'xxx')` for routing
- No documentation mentions `GormEnhancer.findStaticApi()` as a public API
- No documentation covers `@CompileStatic` on `@Service` classes with injected `@Service` properties
- No documentation covers MultiTenant entities with explicit datasource declarations

These are all essential for production multi-datasource applications using modern GORM patterns. Without this documentation, developers must read the `ServiceTransformation` source code to understand how connection routing works.

## Verified Against Source

All technical claims were verified against grails-core source:

- `ServiceTransformation.groovy` line 253: `copyAnnotations(classNode, impl)` copies `@Transactional(connection)` to generated implementation
- `TransactionalTransform.findTransactionalAnnotation()` lines 171-176: falls back to `methodNode.getDeclaringClass()` to find the connection identifier
- `SaveImplementer`, `FindOneImplementer`, `DeleteImplementer`, `CountImplementer`: all call `findConnectionId()` and use it in generated method bodies (post #15395)
- `GormEnhancer.findStaticApi(Class, String)`: returns `GormStaticApi` bound to the specified connection
- `GormEnhancer.allQualifiers()`: preserves explicit datasource qualifiers for MultiTenant entities (post #15393)
- `ServiceTransformation`: no longer sets lazy getter block on abstract class PropertyNode for `@Service`-typed properties (post #15396)

## Files Changed

| File | Change |
|------|--------|
| `grails-doc/.../multipleDatasources.adoc` | New "GORM Data Services and Multiple Datasources" section with @CompileStatic injection + MultiTenant subsections |
| `grails-doc/.../transactionsMultiDataSource.adoc` | TIP cross-reference listing all routed CRUD methods |
| `grails-data-hibernate5/.../services/multipleDataSources.adoc` | **New file** - full multi-datasource Data Services section with @CompileStatic + MultiTenant |
| `grails-data-hibernate5/.../services/index.adoc` | Include for new section |
| `grails-data-hibernate5/.../multipleDataSources/index.adoc` | Cross-reference to Data Services section |
| `grails-data-hibernate5/.../multipleDataSources/dataSourceNamespaces.adoc` | TIP about GormEnhancer and Data Services |

## Environment Information

- Grails 7.0.x branch
- GORM 7.x
- Groovy 4.0.x