### PR TITLE
fix: configure Micronaut annotation processor and CLASSIC boot loader automatically

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -56,6 +56,7 @@ gradleCycloneDxPluginVersion=2.4.1
 micronautPlatformVersion=4.9.2
 
 # Libraries only specific to test apps, these should not be exposed
+ersatzVersion=4.0.1
 grailsSpringSecurityVersion=7.0.1-SNAPSHOT
 jbossTransactionApiVersion=2.0.0.Final
 # Note: we do not import the micronaut bom in our tests to avoid spring version mismatches

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -373,6 +373,10 @@ micronautPlatformVersion=4.9.2
 
 Please note that due to https://github.com/micronaut-projects/micronaut-spring/issues/769[this issue], Spring Boot Dev tools does not work with the micronaut integration.
 
+IMPORTANT: Do **not** manually add Micronaut annotation processors (such as `micronaut-inject-java`) to your `build.gradle`. The Grails Gradle Plugin automatically configures the correct annotation processor for Java source files and uses Groovy AST transforms (`micronaut-inject-groovy`) for Groovy source files. Manually adding annotation processors may cause duplicate bean definitions or incremental compilation issues (see https://github.com/apache/grails-core/issues/15211[#15211]).
+
+NOTE: The Grails Gradle Plugin automatically configures the Spring Boot `bootJar` and `bootWar` tasks to use the `CLASSIC` loader implementation when `grails-micronaut` is detected. This is required for `java -jar` execution to work correctly with the Micronaut-Spring integration (see https://github.com/apache/grails-core/issues/15207[#15207]). If you have explicitly set `loaderImplementation` in your `build.gradle`, you can remove it as the Grails Gradle Plugin now handles this automatically.
+
 ===== 12.5 hibernate-ehcache
 
 The `org.hibernate:hibernate-ehcache` library is no longer provided by the `org.apache.grails:grails-hibernate5` plugin. If

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -371,7 +371,7 @@ Here's an example `gradle.properties` file:
 micronautPlatformVersion=4.9.2
 ----
 
-Please note that due to https://github.com/micronaut-projects/micronaut-spring/issues/769[this issue], Spring Boot Dev tools does not work with the micronaut integration.
+Please note that, due to https://github.com/micronaut-projects/micronaut-spring/issues/769[this issue], Spring Boot DevTools does not work with the Micronaut integration.
 
 IMPORTANT: Do **not** manually add Micronaut annotation processors (such as `micronaut-inject-java`) to your `build.gradle`. The Grails Gradle Plugin automatically configures the correct annotation processor for Java source files and uses Groovy AST transforms (`micronaut-inject-groovy`) for Groovy source files. Manually adding annotation processors may cause duplicate bean definitions or incremental compilation issues (see https://github.com/apache/grails-core/issues/15211[#15211]).
 

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -371,6 +371,8 @@ Here's an example `gradle.properties` file:
 micronautPlatformVersion=4.9.2
 ----
 
+Please note that due to https://github.com/micronaut-projects/micronaut-spring/issues/769[this issue], Spring Boot Dev tools does not work with the micronaut integration.
+
 ===== 12.5 hibernate-ehcache
 
 The `org.hibernate:hibernate-ehcache` library is no longer provided by the `org.apache.grails:grails-hibernate5` plugin. If

--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -373,9 +373,21 @@ micronautPlatformVersion=4.9.2
 
 Please note that, due to https://github.com/micronaut-projects/micronaut-spring/issues/769[this issue], Spring Boot DevTools does not work with the Micronaut integration.
 
-IMPORTANT: Do **not** manually add Micronaut annotation processors (such as `micronaut-inject-java`) to your `build.gradle`. The Grails Gradle Plugin automatically configures the correct annotation processor for Java source files and uses Groovy AST transforms (`micronaut-inject-groovy`) for Groovy source files. Manually adding annotation processors may cause duplicate bean definitions or incremental compilation issues (see https://github.com/apache/grails-core/issues/15211[#15211]).
+The Grails Gradle Plugin automatically configures Groovy-based Micronaut bean registration via AST transforms (`micronaut-inject-groovy` on `compileOnlyApi`). Groovy classes annotated with `@Singleton`, `@Factory`, `@ConfigurationProperties`, etc. are processed automatically.
 
-NOTE: The Grails Gradle Plugin automatically configures the Spring Boot `bootJar` and `bootWar` tasks to use the `CLASSIC` loader implementation when `grails-micronaut` is detected. This is required for `java -jar` execution to work correctly with the Micronaut-Spring integration (see https://github.com/apache/grails-core/issues/15207[#15207]). If you have explicitly set `loaderImplementation` in your `build.gradle`, you can remove it as the Grails Gradle Plugin now handles this automatically.
+IMPORTANT: If your project contains **Java source files** with Micronaut annotations (e.g. `@Singleton`, `@Factory`), you must manually add the Micronaut annotation processor to your `build.gradle`. The annotation processor is not configured automatically because it is incompatible with Groovy incremental compilation (see https://github.com/apache/grails-core/issues/15211[#15211]). For projects that mix Java and Groovy Micronaut beans, consider splitting them into separate source sets or modules to avoid incremental compilation issues.
+
+[source,groovy]
+.build.gradle - Adding annotation processor for Java Micronaut beans
+----
+dependencies {
+    annotationProcessor platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
+    annotationProcessor 'io.micronaut:micronaut-inject-java'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+}
+----
+
+NOTE: The Grails Gradle Plugin automatically configures the Spring Boot `bootJar` and `bootWar` tasks to use the `CLASSIC` loader implementation when `grails-micronaut` is detected. This is required for `java -jar` execution to work correctly with the Micronaut-Spring integration (see https://github.com/apache/grails-core/issues/15207[#15207]). If you have explicitly set `loaderImplementation` in your `build.gradle`, you can remove it as the plugin now handles this automatically.
 
 ===== 12.5 hibernate-ehcache
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -112,6 +112,10 @@ tasks.named('bootJar') {
     loaderImplementation = org.springframework.boot.loader.tools.LoaderImplementation.CLASSIC
 }
 
+tasks.named('bootWar') {
+    loaderImplementation = org.springframework.boot.loader.tools.LoaderImplementation.CLASSIC
+}
+
 }
 
 @if (features.contains("spock")) {

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -107,17 +107,6 @@ tasks.named('bootRun') {
 
 }
 
-@if (features.contains("grails-micronaut")) {
-tasks.named('bootJar') {
-    loaderImplementation = org.springframework.boot.loader.tools.LoaderImplementation.CLASSIC
-}
-
-tasks.named('bootWar') {
-    loaderImplementation = org.springframework.boot.loader.tools.LoaderImplementation.CLASSIC
-}
-
-}
-
 @if (features.contains("spock")) {
 tasks.withType(Test).configureEach {
     useJUnitPlatform()

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildGradle.rocker.raw
@@ -98,11 +98,18 @@ repositories {
 compileJava.options.release = @features.getTargetJdk()
 
 @if (features.contains("jrebel")) {
-bootRun {
+tasks.named('bootRun') {
     dependsOn(generateRebel)
     if (project.hasProperty("rebelAgent")) {
         jvmArgs(rebelAgent)
     }
+}
+
+}
+
+@if (features.contains("grails-micronaut")) {
+tasks.named('bootJar') {
+    loaderImplementation = org.springframework.boot.loader.tools.LoaderImplementation.CLASSIC
 }
 
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/GrailsMicronautValidator.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/GrailsMicronautValidator.java
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.grails.forge.feature.micronaut;
 
 import jakarta.inject.Singleton;
@@ -15,7 +33,7 @@ public class GrailsMicronautValidator implements FeatureValidator {
     public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
         if (features.stream().anyMatch(f -> f instanceof GrailsMicronaut)) {
             if (features.stream().anyMatch(f -> (f instanceof SpringBootDevTools))) {
-                // TODO: https://github.com/micronaut-projects/micronaut-spring/issues/769
+                // See: https://github.com/micronaut-projects/micronaut-spring/issues/769
                 throw new IllegalArgumentException("Spring Boot Dev Tools are not supported with Grails Micronaut");
             }
         }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/GrailsMicronautValidator.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/GrailsMicronautValidator.java
@@ -1,0 +1,28 @@
+package org.grails.forge.feature.micronaut;
+
+import jakarta.inject.Singleton;
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.feature.Feature;
+import org.grails.forge.feature.reloading.SpringBootDevTools;
+import org.grails.forge.feature.validation.FeatureValidator;
+import org.grails.forge.options.Options;
+
+import java.util.Set;
+
+@Singleton
+public class GrailsMicronautValidator implements FeatureValidator {
+    @Override
+    public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+        if (features.stream().anyMatch(f -> f instanceof GrailsMicronaut)) {
+            if (features.stream().anyMatch(f -> (f instanceof SpringBootDevTools))) {
+                // TODO: https://github.com/micronaut-projects/micronaut-spring/issues/769
+                throw new IllegalArgumentException("Spring Boot Dev Tools are not supported with Grails Micronaut");
+            }
+        }
+    }
+
+    @Override
+    public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+
+    }
+}

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/GrailsMicronautValidator.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/micronaut/GrailsMicronautValidator.java
@@ -18,17 +18,19 @@
  */
 package org.grails.forge.feature.micronaut;
 
+import java.util.Set;
+
 import jakarta.inject.Singleton;
+
 import org.grails.forge.application.ApplicationType;
 import org.grails.forge.feature.Feature;
 import org.grails.forge.feature.reloading.SpringBootDevTools;
 import org.grails.forge.feature.validation.FeatureValidator;
 import org.grails.forge.options.Options;
 
-import java.util.Set;
-
 @Singleton
 public class GrailsMicronautValidator implements FeatureValidator {
+
     @Override
     public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
         if (features.stream().anyMatch(f -> f instanceof GrailsMicronaut)) {

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/reloading/SpringBootDevTools.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/reloading/SpringBootDevTools.java
@@ -25,6 +25,7 @@ import org.grails.forge.build.dependencies.Dependency;
 import org.grails.forge.build.dependencies.Scope;
 import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
+import org.grails.forge.feature.micronaut.GrailsMicronaut;
 import org.grails.forge.options.Options;
 
 import java.util.Set;
@@ -61,6 +62,9 @@ public class SpringBootDevTools implements ReloadingFeature, DefaultFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
+        if (selectedFeatures.stream().anyMatch(f -> f instanceof GrailsMicronaut)) {
+            return false;
+        }
         return selectedFeatures.stream().noneMatch(f -> f instanceof ReloadingFeature);
     }
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/reloading/SpringBootDevTools.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/reloading/SpringBootDevTools.java
@@ -19,6 +19,7 @@
 package org.grails.forge.feature.reloading;
 
 import jakarta.inject.Singleton;
+
 import org.grails.forge.application.ApplicationType;
 import org.grails.forge.application.generator.GeneratorContext;
 import org.grails.forge.build.dependencies.Dependency;
@@ -32,6 +33,7 @@ import java.util.Set;
 
 @Singleton
 public class SpringBootDevTools implements ReloadingFeature, DefaultFeature {
+
     @Override
     public String getName() {
         return "spring-boot-devtools";
@@ -44,7 +46,11 @@ public class SpringBootDevTools implements ReloadingFeature, DefaultFeature {
 
     @Override
     public String getDescription() {
-        return "Spring Boot Devtools is a powerful tool that enhances development productivity by providing features like automatic application restarts on code changes, live reloading of static resources, and remote debugging support. It enables developers to rapidly iterate and test changes during the development process, making it a valuable asset for Spring Boot projects.";
+        return "Spring Boot Devtools is a powerful tool that enhances development productivity " +
+                "by providing features like automatic application restarts on code changes, live " +
+                "reloading of static resources, and remote debugging support. It enables developers " +
+                "to rapidly iterate and test changes during the development process, making it a " +
+                "valuable asset for Spring Boot projects.";
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/reloading/SpringBootDevToolsSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/reloading/SpringBootDevToolsSpec.groovy
@@ -57,4 +57,12 @@ class SpringBootDevToolsSpec extends ApplicationContextSpec implements CommandOu
         def ex = thrown(IllegalArgumentException)
         ex.message.contains("There can only be one of the following features selected")
     }
+
+    void "test spring-boot-devtools is not applied when grails-micronaut is selected"() {
+        when:
+        final Features features = getFeatures(["grails-micronaut"])
+
+        then:
+        !features.contains("spring-boot-devtools")
+    }
 }

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/reloading/SpringBootDevToolsSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/reloading/SpringBootDevToolsSpec.groovy
@@ -16,34 +16,29 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package org.grails.forge.feature.reloading
+
+import spock.lang.Unroll
 
 import org.grails.forge.ApplicationContextSpec
 import org.grails.forge.application.ApplicationType
-import org.grails.forge.feature.Features
 import org.grails.forge.fixture.CommandOutputFixture
 
 class SpringBootDevToolsSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void "test spring-boot-devtools feature"() {
-
-        when:
-        final Features features = getFeatures(["spring-boot-devtools"])
-
-        then:
-        features.contains("spring-boot-devtools")
-
+        expect:
+        'spring-boot-devtools' in getFeatures(['spring-boot-devtools'])
     }
 
-    void "test spring-boot-devtools dependency is present for #applicationType application type"() {
-
+    @Unroll
+    void "test spring-boot-devtools dependency is present for #applicationType application type"(ApplicationType applicationType) {
         when:
-        def output = generate(applicationType, ["spring-boot-devtools"])
-        def build = output["build.gradle"]
+        def output = generate(applicationType, ['spring-boot-devtools'])
+        def build = output['build.gradle']
 
         then:
-        build.contains("developmentOnly \"org.springframework.boot:spring-boot-devtools\"")
+        build.contains('developmentOnly "org.springframework.boot:spring-boot-devtools"')
 
         where:
         applicationType << [ApplicationType.WEB, ApplicationType.REST_API]
@@ -51,18 +46,15 @@ class SpringBootDevToolsSpec extends ApplicationContextSpec implements CommandOu
 
     void "test there can be only one of Reloading feature"() {
         when:
-        getFeatures(["spring-boot-devtools", "jrebel"])
+        getFeatures(['spring-boot-devtools', 'jrebel'])
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message.contains("There can only be one of the following features selected")
+        ex.message.contains('There can only be one of the following features selected')
     }
 
     void "test spring-boot-devtools is not applied when grails-micronaut is selected"() {
-        when:
-        final Features features = getFeatures(["grails-micronaut"])
-
-        then:
-        !features.contains("spring-boot-devtools")
+        expect:
+        !('spring-boot-devtools' in getFeatures(['grails-micronaut']))
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -71,8 +71,6 @@ import org.springframework.boot.gradle.dsl.SpringBootExtension
 import org.springframework.boot.gradle.plugin.ResolveMainClassName
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.bundling.BootArchive
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.springframework.boot.gradle.tasks.bundling.BootWar
 import org.springframework.boot.gradle.tasks.run.BootRun
 import org.springframework.boot.loader.tools.LoaderImplementation
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -380,12 +380,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
 
             project.logger.info('Configuring CLASSIC boot loader for Micronaut compatibility in {}', project.name)
-            project.tasks.withType(BootJar).configureEach { BootJar bootJar ->
-                bootJar.loaderImplementation.convention(LoaderImplementation.CLASSIC)
+            project.tasks.withType(BootArchive).configureEach {
+                it.loaderImplementation.convention(LoaderImplementation.CLASSIC)
             }
-            project.tasks.withType(BootWar).configureEach { BootWar bootWar ->
-                bootWar.loaderImplementation.convention(LoaderImplementation.CLASSIC)
-            }
+
         }
     }
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -71,7 +71,10 @@ import org.springframework.boot.gradle.dsl.SpringBootExtension
 import org.springframework.boot.gradle.plugin.ResolveMainClassName
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.bundling.BootArchive
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+import org.springframework.boot.gradle.tasks.bundling.BootWar
 import org.springframework.boot.gradle.tasks.run.BootRun
+import org.springframework.boot.loader.tools.LoaderImplementation
 
 import javax.inject.Inject
 
@@ -374,6 +377,23 @@ class GrailsGradlePlugin extends GroovyPlugin {
                         details.useVersion(micronautPlatformVersion)
                     }
                 }
+            }
+
+            // Add Micronaut annotation processor for Java source files.
+            // Groovy sources are handled by micronaut-inject-groovy AST transforms (via compileOnlyApi),
+            // but Java sources require the Java annotation processor to generate BeanDefinition classes.
+            // The annotationProcessor configuration only affects compileJava tasks, not compileGroovy.
+            project.logger.info('Adding Micronaut annotationProcessor for Java sources in {}', project.name)
+            project.getDependencies().add('annotationProcessor', project.dependencies.platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion"))
+            project.getDependencies().add('annotationProcessor', 'io.micronaut:micronaut-inject-java')
+            project.getDependencies().add('annotationProcessor', 'jakarta.annotation:jakarta.annotation-api')
+
+            project.logger.info('Configuring CLASSIC boot loader for Micronaut compatibility in {}', project.name)
+            project.tasks.withType(BootJar).configureEach { BootJar bootJar ->
+                bootJar.loaderImplementation.convention(LoaderImplementation.CLASSIC)
+            }
+            project.tasks.withType(BootWar).configureEach { BootWar bootWar ->
+                bootWar.loaderImplementation.convention(LoaderImplementation.CLASSIC)
             }
         }
     }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -379,9 +379,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 }
             }
 
-            // Micronaut annotation processors are not auto-configured here because they
-            // are incompatible with Groovy incremental compilation. See the Grails
-            // documentation for manual setup when Java sources use Micronaut annotations.
+            project.logger.info('Adding Micronaut annotationProcessor dependencies to project {}', project.name)
+            project.getDependencies().add('annotationProcessor', project.dependencies.platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion"))
+            project.getDependencies().add('annotationProcessor', 'io.micronaut:micronaut-inject-java')
+            project.getDependencies().add('annotationProcessor', 'jakarta.annotation:jakarta.annotation-api')
 
             project.logger.info('Configuring CLASSIC boot loader for Micronaut compatibility in {}', project.name)
             project.tasks.withType(BootJar).configureEach { BootJar bootJar ->

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -379,11 +379,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 }
             }
 
-            project.logger.info('Adding Micronaut annotationProcessor dependencies to project {}', project.name)
-            project.getDependencies().add('annotationProcessor', project.dependencies.platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion"))
-            project.getDependencies().add('annotationProcessor', 'io.micronaut:micronaut-inject-java')
-            project.getDependencies().add('annotationProcessor', 'jakarta.annotation:jakarta.annotation-api')
-
             project.logger.info('Configuring CLASSIC boot loader for Micronaut compatibility in {}', project.name)
             project.tasks.withType(BootJar).configureEach { BootJar bootJar ->
                 bootJar.loaderImplementation.convention(LoaderImplementation.CLASSIC)

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -375,11 +375,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
                     }
                 }
             }
-
-            project.logger.info('Adding Micronaut annotationProcessor dependencies to project {}', project.name)
-            project.getDependencies().add('annotationProcessor', project.dependencies.platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion"))
-            project.getDependencies().add('annotationProcessor', 'io.micronaut:micronaut-inject-java')
-            project.getDependencies().add('annotationProcessor', 'jakarta.annotation:jakarta.annotation-api')
         }
     }
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -379,14 +379,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 }
             }
 
-            // Add Micronaut annotation processor for Java source files.
-            // Groovy sources are handled by micronaut-inject-groovy AST transforms (via compileOnlyApi),
-            // but Java sources require the Java annotation processor to generate BeanDefinition classes.
-            // The annotationProcessor configuration only affects compileJava tasks, not compileGroovy.
-            project.logger.info('Adding Micronaut annotationProcessor for Java sources in {}', project.name)
-            project.getDependencies().add('annotationProcessor', project.dependencies.platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion"))
-            project.getDependencies().add('annotationProcessor', 'io.micronaut:micronaut-inject-java')
-            project.getDependencies().add('annotationProcessor', 'jakarta.annotation:jakarta.annotation-api')
+            // Micronaut annotation processors are not auto-configured here because they
+            // are incompatible with Groovy incremental compilation. See the Grails
+            // documentation for manual setup when Java sources use Micronaut annotations.
 
             project.logger.info('Configuring CLASSIC boot loader for Micronaut compatibility in {}', project.name)
             project.tasks.withType(BootJar).configureEach { BootJar bootJar ->

--- a/grails-micronaut/build.gradle
+++ b/grails-micronaut/build.gradle
@@ -33,11 +33,10 @@ group = 'org.apache.grails'
 dependencies {
     compileOnlyApi platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
     compileOnlyApi 'io.micronaut:micronaut-inject-groovy'
-    compileOnlyApi 'io.micronaut:micronaut-inject-java'
 
+    // Use the micronaut spring starter so that any bean in the spring context will be exposed to micronaut
     api platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
     api 'io.micronaut.spring:micronaut-spring-boot-starter'
-    api 'io.micronaut.spring:micronaut-spring-context'
 
     // For the grails plugin interface
     compileOnly platform(project(':grails-bom'))

--- a/grails-micronaut/src/main/groovy/org/apache/grails/micronaut/GrailsMicronautGrailsPlugin.groovy
+++ b/grails-micronaut/src/main/groovy/org/apache/grails/micronaut/GrailsMicronautGrailsPlugin.groovy
@@ -69,12 +69,19 @@ class GrailsMicronautGrailsPlugin extends Plugin {
                 new GrailsPlugin[0]
         int priority = AbstractPropertySourceLoader.DEFAULT_POSITION
         [plugins, pluginsFromContext].each { pluginsToProcess ->
-            Arrays.stream(pluginsToProcess)
-                    .filter { plugin -> plugin.propertySource != null }
-                    .forEach { plugin ->
-                        log.debug('Loading configurations from {} plugin to the parent Micronaut context', plugin.name)
-                        // If invoking the source as `.source`, the NavigableMapPropertySource will return null, while invoking the getter, it will return the correct value
-                        micronautEnv.addPropertySource(PropertySource.of("grails.plugins.$plugin.name", (Map) plugin.propertySource.getSource(), --priority))
+            pluginsToProcess
+                    .findAll { it.propertySource != null }
+                    .each {
+                        log.debug('Loading configurations from {} plugin to the parent Micronaut context', it.name)
+                        // If invoking the source as `.source`, the NavigableMapPropertySource will return null,
+                        // while invoking the getter, it will return the correct value
+                        micronautEnv.addPropertySource(
+                                PropertySource.of(
+                                        "grails.plugins.$it.name",
+                                        (Map) it.propertySource.getSource(),
+                                        --priority
+                                )
+                        )
                     }
         }
         micronautEnv.refresh()

--- a/grails-micronaut/src/main/groovy/org/apache/grails/micronaut/GrailsMicronautGrailsPlugin.groovy
+++ b/grails-micronaut/src/main/groovy/org/apache/grails/micronaut/GrailsMicronautGrailsPlugin.groovy
@@ -19,16 +19,15 @@
 
 package org.apache.grails.micronaut
 
+import grails.plugins.GrailsPlugin
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
-import io.micronaut.context.ConfigurableApplicationContext
-import io.micronaut.context.env.AbstractPropertySourceLoader
-import io.micronaut.context.env.PropertySource
-
-import grails.plugins.GrailsPlugin
 import grails.plugins.GrailsPluginManager
 import grails.plugins.Plugin
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.AbstractPropertySourceLoader
+import io.micronaut.context.env.PropertySource
 
 @Slf4j
 @CompileStatic
@@ -53,7 +52,7 @@ class GrailsMicronautGrailsPlugin extends Plugin {
             throw new IllegalStateException('A Micronaut Application Context should exist prior to the loading of the Grails Micronaut plugin.')
         }
 
-        def micronautContext = applicationContext.getBean('micronautApplicationContext', ConfigurableApplicationContext)
+        def micronautContext = applicationContext.getBean('micronautApplicationContext', ApplicationContext)
         def micronautEnv = micronautContext.environment
 
         log.debug('Loading configurations from the plugins to the parent Micronaut context')

--- a/grails-micronaut/src/main/groovy/org/apache/grails/micronaut/GrailsMicronautGrailsPlugin.groovy
+++ b/grails-micronaut/src/main/groovy/org/apache/grails/micronaut/GrailsMicronautGrailsPlugin.groovy
@@ -16,18 +16,18 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package org.apache.grails.micronaut
 
-import grails.plugins.GrailsPlugin
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
-import grails.plugins.GrailsPluginManager
-import grails.plugins.Plugin
-import io.micronaut.context.ApplicationContext
+import io.micronaut.context.ApplicationContext as MicronautApplicationContext
 import io.micronaut.context.env.AbstractPropertySourceLoader
 import io.micronaut.context.env.PropertySource
+
+import grails.plugins.GrailsPlugin
+import grails.plugins.GrailsPluginManager
+import grails.plugins.Plugin
 
 @Slf4j
 @CompileStatic
@@ -49,16 +49,24 @@ class GrailsMicronautGrailsPlugin extends Plugin {
         }
 
         if (!applicationContext.containsBean('micronautApplicationContext')) {
-            throw new IllegalStateException('A Micronaut Application Context should exist prior to the loading of the Grails Micronaut plugin.')
+            throw new IllegalStateException(
+                    'A Micronaut Application Context should exist prior to the loading ' +
+                    'of the Grails Micronaut plugin.'
+            )
         }
 
-        def micronautContext = applicationContext.getBean('micronautApplicationContext', ApplicationContext)
+        def micronautContext = applicationContext.getBean(
+                'micronautApplicationContext',
+                MicronautApplicationContext
+        )
         def micronautEnv = micronautContext.environment
 
         log.debug('Loading configurations from the plugins to the parent Micronaut context')
 
         def plugins = pluginManager.allPlugins
-        def pluginsFromContext = pluginManagerFromContext ? pluginManagerFromContext.allPlugins : new GrailsPlugin[0]
+        def pluginsFromContext = pluginManagerFromContext ?
+                pluginManagerFromContext.allPlugins :
+                new GrailsPlugin[0]
         int priority = AbstractPropertySourceLoader.DEFAULT_POSITION
         [plugins, pluginsFromContext].each { pluginsToProcess ->
             Arrays.stream(pluginsToProcess)

--- a/grails-test-examples/micronaut-groovy-only/build.gradle
+++ b/grails-test-examples/micronaut-groovy-only/build.gradle
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+plugins {
+    id 'org.apache.grails.buildsrc.properties'
+    id 'org.apache.grails.buildsrc.compile'
+}
+
+version = '0.1'
+group = 'micronautgroovyonly'
+
+apply plugin: 'org.apache.grails.gradle.grails-web'
+
+// This module intentionally has NO annotationProcessor dependencies.
+// It validates that a Groovy-only Grails application works with
+// grails-micronaut without explicit Java annotation processor configuration.
+// The Grails Gradle plugin automatically applies the required annotation
+// processors when grails-micronaut is present on the classpath.
+
+dependencies {
+    implementation platform(project(':grails-bom'))
+
+    implementation 'org.apache.grails:grails-dependencies-starter-web'
+    implementation 'org.apache.grails:grails-micronaut'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.apache.tomcat:tomcat-jdbc'
+
+    testImplementation 'org.apache.grails:grails-dependencies-test'
+
+    integrationTestImplementation testFixtures('org.apache.grails:grails-geb')
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('gradle/functional-test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
+}

--- a/grails-test-examples/micronaut-groovy-only/grails-app/conf/application.yml
+++ b/grails-test-examples/micronaut-groovy-only/grails-app/conf/application.yml
@@ -1,0 +1,123 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+grails:
+    profile: web
+    codegen:
+        defaultPackage: micronautgroovyonly
+    gorm:
+        reactor:
+            events: false
+info:
+    app:
+        name: '@info.app.name@'
+        version: '@info.app.version@'
+        grailsVersion: '@info.app.grailsVersion@'
+spring:
+    jmx:
+        unique-names: true
+    main:
+        banner-mode: "off"
+    groovy:
+        template:
+            check-template-location: false
+    devtools:
+        restart:
+            additional-exclude:
+                - '*.gsp'
+                - '**/*.gsp'
+                - '*.gson'
+                - '**/*.gson'
+                - 'logback.groovy'
+                - '*.properties'
+management:
+    endpoints:
+        enabled-by-default: false
+app:
+    name: test-micronaut-groovy-only
+
+---
+grails:
+    mime:
+        disable:
+            accept:
+                header:
+                    userAgents:
+                        - Gecko
+                        - WebKit
+                        - Presto
+                        - Trident
+        types:
+            all: '*/*'
+            atom: application/atom+xml
+            css: text/css
+            csv: text/csv
+            form: application/x-www-form-urlencoded
+            html:
+              - text/html
+              - application/xhtml+xml
+            js: text/javascript
+            json:
+              - application/json
+              - text/json
+            multipartForm: multipart/form-data
+            pdf: application/pdf
+            rss: application/rss+xml
+            text: text/plain
+            hal:
+              - application/hal+json
+              - application/hal+xml
+            xml:
+              - text/xml
+              - application/xml
+    urlmapping:
+        cache:
+            maxsize: 1000
+    controllers:
+        defaultScope: singleton
+    converters:
+        encoding: UTF-8
+management:
+    endpoints:
+        jmx:
+            unique-names: true
+
+---
+hibernate:
+    cache:
+        queries: false
+        use_second_level_cache: false
+        use_query_cache: false
+dataSource:
+    pooled: true
+    jmxExport: true
+    driverClassName: org.h2.Driver
+    username: sa
+    password: ''
+
+environments:
+    development:
+        dataSource:
+            dbCreate: create-drop
+            url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+    test:
+        dataSource:
+            dbCreate: update
+            url: jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+    production:
+        dataSource:
+            dbCreate: none
+            url: jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE

--- a/grails-test-examples/micronaut-groovy-only/grails-app/controllers/micronautgroovyonly/UrlMappings.groovy
+++ b/grails-test-examples/micronaut-groovy-only/grails-app/controllers/micronautgroovyonly/UrlMappings.groovy
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package micronautgroovyonly
+
+class UrlMappings {
+
+    static mappings = {
+        "/$controller/$action?/$id?(.$format)?"{
+            constraints {
+            }
+        }
+
+        "/"(view:"/index")
+        "500"(view:'/error')
+        "404"(view:'/notFound')
+    }
+}

--- a/grails-test-examples/micronaut-groovy-only/grails-app/init/micronautgroovyonly/Application.groovy
+++ b/grails-test-examples/micronaut-groovy-only/grails-app/init/micronautgroovyonly/Application.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package micronautgroovyonly
+
+import grails.boot.GrailsApp
+import grails.boot.config.GrailsAutoConfiguration
+import groovy.transform.CompileStatic
+import io.micronaut.spring.boot.starter.EnableMicronaut
+
+@CompileStatic
+@EnableMicronaut
+class Application extends GrailsAutoConfiguration {
+    static void main(String[] args) {
+        GrailsApp.run(Application, args)
+    }
+}

--- a/grails-test-examples/micronaut-groovy-only/grails-app/services/micronautgroovyonly/BeanInjectionService.groovy
+++ b/grails-test-examples/micronaut-groovy-only/grails-app/services/micronautgroovyonly/BeanInjectionService.groovy
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package micronautgroovyonly
+
+import bean.injection.NamedService
+import bean.injection.Qualified
+import org.springframework.beans.factory.annotation.Autowired
+
+import jakarta.inject.Named
+
+class BeanInjectionService {
+
+    @Autowired
+    List<NamedService> namedServices
+
+    @Autowired
+    @Named('regular')
+    NamedService namedService2
+
+    @Autowired
+    @Named('special')
+    NamedService namedService3
+
+    @Autowired
+    @Qualified
+    NamedService namedService4
+
+    @Autowired
+    NamedService namedService
+}

--- a/grails-test-examples/micronaut-groovy-only/grails-app/services/micronautgroovyonly/TestService.groovy
+++ b/grails-test-examples/micronaut-groovy-only/grails-app/services/micronautgroovyonly/TestService.groovy
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package micronautgroovyonly
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class TestService {
+
+    void doSomething() {}
+}

--- a/grails-test-examples/micronaut-groovy-only/src/integration-test/groovy/micronautgroovyonly/BeanInjectionServiceSpec.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/integration-test/groovy/micronautgroovyonly/BeanInjectionServiceSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package micronautgroovyonly
+
+import grails.testing.mixin.integration.Integration
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Specification
+
+@Integration
+class BeanInjectionServiceSpec extends Specification {
+
+    @Autowired
+    BeanInjectionService beanInjectionService
+
+    @Autowired
+    TestService service
+
+    @Autowired
+    List<BeanInjectionService> bInjectService
+
+    void "test injecting Micronaut beans in a Grails service"() {
+        expect:
+        beanInjectionService.namedServices.size() == 4
+        beanInjectionService.namedService2.name == "regular"
+        beanInjectionService.namedService3.name == "special"
+        beanInjectionService.namedService4.name == "qualified"
+        beanInjectionService.namedService.name == "primary"
+    }
+
+    void "test autowire Grails service by type"() {
+        expect:
+        service != null
+    }
+
+    void "test there are 1 bean for a Grails service when we inject Micronaut bean in it"() {
+        expect:
+        bInjectService != null
+        bInjectService.size() == 1
+    }
+}

--- a/grails-test-examples/micronaut-groovy-only/src/integration-test/groovy/micronautgroovyonly/MicronautContextSpec.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/integration-test/groovy/micronautgroovyonly/MicronautContextSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronautgroovyonly
+
+import bean.injection.NamedService
+import io.micronaut.context.ApplicationContext as MicronautApplicationContext
+import spock.lang.Specification
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext as SpringApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.context.ConfigurableApplicationContext
+
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class MicronautContextSpec extends Specification implements ApplicationContextAware {
+
+    @Autowired
+    MicronautApplicationContext micronautContext
+
+    SpringApplicationContext springContext
+
+    void setApplicationContext(SpringApplicationContext applicationContext) {
+        this.springContext = applicationContext
+    }
+
+    void "micronaut application context is available"() {
+        expect:
+        micronautContext != null
+        micronautContext.isRunning()
+    }
+
+    void "spring application context is available"() {
+        expect:
+        springContext != null
+    }
+
+    void "micronaut beans can be retrieved from micronaut context"() {
+        when:
+        def beans = micronautContext.getBeansOfType(NamedService)
+
+        then:
+        beans != null
+        beans.size() == 4
+    }
+
+    void "grails services are accessible from spring context"() {
+        when:
+        def service = springContext.getBean(BeanInjectionService)
+
+        then:
+        service != null
+        service instanceof BeanInjectionService
+    }
+
+    void "micronaut context has correct environment"() {
+        expect:
+        micronautContext.environment != null
+    }
+
+    void "both contexts share the same application lifecycle"() {
+        expect:
+        micronautContext.running
+        (springContext as ConfigurableApplicationContext).active
+    }
+}

--- a/grails-test-examples/micronaut-groovy-only/src/integration-test/groovy/micronautgroovyonly/MicronautQualifierSpec.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/integration-test/groovy/micronautgroovyonly/MicronautQualifierSpec.groovy
@@ -1,0 +1,97 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package micronautgroovyonly
+
+import bean.injection.PrimaryNamedService
+import bean.injection.QualifiedNamedService
+import bean.injection.RegularNamedService
+import bean.injection.SpecialNamedService
+import spock.lang.Specification
+
+import org.springframework.beans.factory.annotation.Autowired
+
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class MicronautQualifierSpec extends Specification {
+
+    @Autowired
+    BeanInjectionService beanInjectionService
+
+    void "primary bean is injected when no qualifier specified"() {
+        expect:
+        beanInjectionService.namedService != null
+        beanInjectionService.namedService.name == 'primary'
+        beanInjectionService.namedService instanceof PrimaryNamedService
+    }
+
+    void "@Named('regular') qualifier injects correct bean"() {
+        expect:
+        beanInjectionService.namedService2 != null
+        beanInjectionService.namedService2.name == 'regular'
+        beanInjectionService.namedService2 instanceof RegularNamedService
+    }
+
+    void "@Named('special') qualifier injects correct bean"() {
+        expect:
+        beanInjectionService.namedService3 != null
+        beanInjectionService.namedService3.name == 'special'
+        beanInjectionService.namedService3 instanceof SpecialNamedService
+    }
+
+    void "custom @Qualified annotation injects correct bean"() {
+        expect:
+        beanInjectionService.namedService4 != null
+        beanInjectionService.namedService4.name == 'qualified'
+        beanInjectionService.namedService4 instanceof QualifiedNamedService
+    }
+
+    void "collection injection includes all implementations"() {
+        expect:
+        beanInjectionService.namedServices != null
+        beanInjectionService.namedServices.size() == 4
+
+        and: "all implementations are present"
+        beanInjectionService.namedServices.any { it.name == 'primary' }
+        beanInjectionService.namedServices.any { it.name == 'regular' }
+        beanInjectionService.namedServices.any { it.name == 'special' }
+        beanInjectionService.namedServices.any { it.name == 'qualified' }
+    }
+
+    void "each bean implementation returns unique name"() {
+        when:
+        def names = beanInjectionService.namedServices*.name.unique()
+
+        then:
+        names.size() == 4
+        names.containsAll(['primary', 'regular', 'special', 'qualified'])
+    }
+
+    void "beans can be distinguished by their class type"() {
+        when:
+        def types = beanInjectionService.namedServices*.getClass()*.simpleName
+
+        then:
+        types.contains('PrimaryNamedService')
+        types.contains('RegularNamedService')
+        types.contains('SpecialNamedService')
+        types.contains('QualifiedNamedService')
+    }
+}

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/AppConfig.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/AppConfig.groovy
@@ -1,0 +1,30 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bean.injection
+
+import groovy.transform.CompileStatic
+
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@ConfigurationProperties('app')
+@CompileStatic
+class AppConfig {
+
+    String name
+}

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/FactoryCreatedService.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/FactoryCreatedService.groovy
@@ -1,0 +1,27 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bean.injection
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class FactoryCreatedService {
+
+    String name
+}

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/NamedService.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/NamedService.groovy
@@ -1,0 +1,24 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bean.injection
+
+interface NamedService {
+
+    String getName()
+}

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/PrimaryNamedService.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/PrimaryNamedService.groovy
@@ -1,0 +1,32 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package bean.injection
+
+import io.micronaut.context.annotation.Primary
+
+import jakarta.inject.Singleton
+
+@Singleton
+@Primary
+class PrimaryNamedService implements NamedService {
+
+    final String name = 'primary'
+
+}

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/Qualified.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/Qualified.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package bean.injection;
+
+import jakarta.inject.Qualifier
+import java.lang.annotation.Retention
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Retention(RUNTIME)
+@interface Qualified { }

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/QualifiedNamedService.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/QualifiedNamedService.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package bean.injection
+
+import groovy.transform.CompileStatic
+
+import jakarta.inject.Singleton
+
+@Singleton
+@CompileStatic
+@Qualified
+class QualifiedNamedService implements NamedService {
+
+    final String name = 'qualified'
+
+}

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/RegularNamedService.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/RegularNamedService.groovy
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package bean.injection
+
+import groovy.transform.CompileStatic
+
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+
+@Named('regular')
+@Singleton
+@CompileStatic
+class RegularNamedService implements NamedService {
+
+    final String name = 'regular'
+
+}

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/ServiceFactory.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/ServiceFactory.groovy
@@ -1,0 +1,37 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bean.injection
+
+import groovy.transform.CompileStatic
+
+import jakarta.inject.Singleton
+
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+
+@Factory
+@CompileStatic
+class ServiceFactory {
+
+    @Bean
+    @Singleton
+    FactoryCreatedService factoryCreatedService() {
+        new FactoryCreatedService(name: 'factory-created')
+    }
+}

--- a/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/SpecialNamedService.groovy
+++ b/grails-test-examples/micronaut-groovy-only/src/main/groovy/bean/injection/SpecialNamedService.groovy
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package bean.injection
+
+import groovy.transform.CompileStatic
+
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+
+@Singleton
+@CompileStatic
+@Named('special')
+class SpecialNamedService implements NamedService {
+
+    final String name = 'special'
+
+}

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.apache.grails:grails-dependencies-starter-web'
     implementation 'org.apache.grails:grails-micronaut'
     implementation 'org.apache.grails:grails-scaffolding'
+    implementation project(':grails-test-examples-plugins-micronaut-singleton')
 
     annotationProcessor platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
     annotationProcessor 'io.micronaut:micronaut-inject-java'

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootArchive
+
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one
  *  or more contributor license agreements.  See the NOTICE file
@@ -35,11 +37,11 @@ apply plugin: 'org.apache.grails.gradle.grails-gsp'
 dependencies {
     implementation platform(project(':grails-bom'))
 
+    implementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
+    implementation "io.micronaut.serde:micronaut-serde-jackson:$micronautSerdeJacksonVersion"
     implementation 'org.apache.grails:grails-dependencies-starter-web'
     implementation 'org.apache.grails:grails-micronaut'
     implementation 'org.apache.grails:grails-scaffolding'
-    implementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
-    implementation "io.micronaut.serde:micronaut-serde-jackson:$micronautSerdeJacksonVersion"
 
     annotationProcessor platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
     annotationProcessor 'io.micronaut:micronaut-inject-java'
@@ -48,12 +50,12 @@ dependencies {
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.apache.grails:grails-dependencies-assets'
 
+    runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.apache.tomcat:tomcat-jdbc'
-    runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
 
-    testImplementation 'org.apache.grails:grails-dependencies-test'
     testImplementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
+    testImplementation 'org.apache.grails:grails-dependencies-test'
 
     integrationTestImplementation testFixtures('org.apache.grails:grails-geb')
     integrationTestImplementation "io.github.cjstehno.ersatz:ersatz:$ersatzVersion"

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
 
     integrationTestImplementation testFixtures('org.apache.grails:grails-geb')
+    integrationTestImplementation "io.github.cjstehno.ersatz:ersatz:$ersatzVersion"
 }
 
 apply {

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -38,6 +38,12 @@ dependencies {
     implementation 'org.apache.grails:grails-dependencies-starter-web'
     implementation 'org.apache.grails:grails-micronaut'
     implementation 'org.apache.grails:grails-scaffolding'
+    implementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
+    implementation "io.micronaut.serde:micronaut-serde-jackson:$micronautSerdeJacksonVersion"
+
+    annotationProcessor platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
+    annotationProcessor 'io.micronaut:micronaut-inject-java'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.apache.grails:grails-dependencies-assets'
@@ -47,6 +53,7 @@ dependencies {
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
 
     testImplementation 'org.apache.grails:grails-dependencies-test'
+    testImplementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
 
     integrationTestImplementation testFixtures('org.apache.grails:grails-geb')
 }

--- a/grails-test-examples/micronaut/build.gradle
+++ b/grails-test-examples/micronaut/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation platform(project(':grails-bom'))
 
     implementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
+    implementation "io.micronaut:micronaut-retry:$micronautHttpClientVersion"
     implementation "io.micronaut.serde:micronaut-serde-jackson:$micronautSerdeJacksonVersion"
     implementation 'org.apache.grails:grails-dependencies-starter-web'
     implementation 'org.apache.grails:grails-micronaut'

--- a/grails-test-examples/micronaut/grails-app/conf/application.yml
+++ b/grails-test-examples/micronaut/grails-app/conf/application.yml
@@ -127,6 +127,11 @@ environments:
             dbCreate: create-drop
             url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
     test:
+        micronaut:
+            http:
+                services:
+                    grails-self:
+                        url: http://localhost:19876
         dataSource:
             dbCreate: update
             url: jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE

--- a/grails-test-examples/micronaut/grails-app/conf/application.yml
+++ b/grails-test-examples/micronaut/grails-app/conf/application.yml
@@ -48,6 +48,8 @@ spring:
 management:
     endpoints:
         enabled-by-default: false
+app:
+    name: test-micronaut-app
 
 ---
 grails:

--- a/grails-test-examples/micronaut/grails-app/controllers/micronaut/ExternalApiController.groovy
+++ b/grails-test-examples/micronaut/grails-app/controllers/micronaut/ExternalApiController.groovy
@@ -74,4 +74,40 @@ class ExternalApiController {
             render([source: 'micronaut-client', error: result.error] as JSON)
         }
     }
+
+    def search() {
+        String q = params.q as String
+        String page = params.page as String ?: '1'
+        String data = externalApiService.search(q, page)
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def secureShow() {
+        String authHeader = request.getHeader('Authorization')
+        String data = externalApiService.fetchSecure(authHeader)
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def patchAction() {
+        String id = params.id as String
+        String body = request.inputStream.text
+        String data = externalApiService.patchResource(id, body)
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def asyncShow() {
+        String data = externalApiService.fetchAsync()
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def pathShow() {
+        String id = params.id as String
+        String data = externalApiService.fetchPathItem(id)
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def filteredShow() {
+        String data = externalApiService.fetchFiltered()
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
 }

--- a/grails-test-examples/micronaut/grails-app/controllers/micronaut/ExternalApiController.groovy
+++ b/grails-test-examples/micronaut/grails-app/controllers/micronaut/ExternalApiController.groovy
@@ -1,0 +1,77 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import groovy.transform.CompileStatic
+
+import grails.converters.JSON
+
+@CompileStatic
+class ExternalApiController {
+
+    ExternalApiService externalApiService
+
+    def index() {
+        String data = externalApiService.fetchAll()
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def show() {
+        String id = params.id as String
+        String data = externalApiService.fetchById(id)
+        if (data == null) {
+            response.status = 404
+            render([error: 'not found'] as JSON)
+            return
+        }
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def save() {
+        String body = request.inputStream.text
+        String data = externalApiService.createResource(body)
+        response.status = 201
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def update() {
+        String id = params.id as String
+        String body = request.inputStream.text
+        String data = externalApiService.updateResource(id, body)
+        render([source: 'micronaut-client', data: data] as JSON)
+    }
+
+    def delete() {
+        String id = params.id as String
+        int status = externalApiService.deleteResource(id)
+        response.status = status
+        render([source: 'micronaut-client', deleted: true] as JSON)
+    }
+
+    def showWithErrorHandling() {
+        String id = params.id as String
+        Map result = externalApiService.fetchWithErrorHandling(id)
+        if (result.success) {
+            render([source: 'micronaut-client', data: result.data] as JSON)
+        } else {
+            response.status = result.status as int
+            render([source: 'micronaut-client', error: result.error] as JSON)
+        }
+    }
+}

--- a/grails-test-examples/micronaut/grails-app/controllers/micronaut/MicronautTestController.groovy
+++ b/grails-test-examples/micronaut/grails-app/controllers/micronaut/MicronautTestController.groovy
@@ -18,14 +18,16 @@
  */
 package micronaut
 
+import groovy.transform.CompileStatic
+
 import bean.injection.AppConfig
 import bean.injection.FactoryCreatedService
 import bean.injection.JavaSingletonService
 import bean.injection.NamedService
-import grails.converters.JSON
-import groovy.transform.CompileStatic
 
 import org.springframework.beans.factory.annotation.Autowired
+
+import grails.converters.JSON
 
 @CompileStatic
 class MicronautTestController {

--- a/grails-test-examples/micronaut/grails-app/controllers/micronaut/MicronautTestController.groovy
+++ b/grails-test-examples/micronaut/grails-app/controllers/micronaut/MicronautTestController.groovy
@@ -16,22 +16,37 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package micronaut
 
-class UrlMappings {
+import bean.injection.AppConfig
+import bean.injection.FactoryCreatedService
+import bean.injection.JavaSingletonService
+import bean.injection.NamedService
+import groovy.transform.CompileStatic
 
-    static mappings = {
-        "/$controller/$action?/$id?(.$format)?"{
-            constraints {
-                // apply constraints here
-            }
-        }
+import org.springframework.beans.factory.annotation.Autowired
 
-        "/micronaut-test"(controller: 'micronautTest', action: 'index')
+@CompileStatic
+class MicronautTestController {
 
-        "/"(view:"/index")
-        "500"(view:'/error')
-        "404"(view:'/notFound')
+    @Autowired
+    JavaSingletonService javaSingletonService
+
+    @Autowired
+    FactoryCreatedService factoryCreatedService
+
+    @Autowired
+    AppConfig appConfig
+
+    @Autowired
+    NamedService namedService
+
+    def index() {
+        render(contentType: 'application/json', text: [
+            javaMessage: javaSingletonService.message,
+            factoryName: factoryCreatedService.name,
+            appName: appConfig.name,
+            namedService: namedService.name
+        ])
     }
 }

--- a/grails-test-examples/micronaut/grails-app/controllers/micronaut/MicronautTestController.groovy
+++ b/grails-test-examples/micronaut/grails-app/controllers/micronaut/MicronautTestController.groovy
@@ -22,6 +22,7 @@ import bean.injection.AppConfig
 import bean.injection.FactoryCreatedService
 import bean.injection.JavaSingletonService
 import bean.injection.NamedService
+import grails.converters.JSON
 import groovy.transform.CompileStatic
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,11 +43,11 @@ class MicronautTestController {
     NamedService namedService
 
     def index() {
-        render(contentType: 'application/json', text: [
+        render([
             javaMessage: javaSingletonService.message,
             factoryName: factoryCreatedService.name,
             appName: appConfig.name,
             namedService: namedService.name
-        ])
+        ] as JSON)
     }
 }

--- a/grails-test-examples/micronaut/grails-app/controllers/micronaut/UrlMappings.groovy
+++ b/grails-test-examples/micronaut/grails-app/controllers/micronaut/UrlMappings.groovy
@@ -31,11 +31,17 @@ class UrlMappings {
         "/micronaut-test"(controller: 'micronautTest', action: 'index')
 
         "/external-api"(controller: 'externalApi', action: 'index', method: 'GET')
+        "/external-api/search"(controller: 'externalApi', action: 'search', method: 'GET')
+        "/external-api/secure"(controller: 'externalApi', action: 'secureShow', method: 'GET')
         "/external-api/$id"(controller: 'externalApi', action: 'show', method: 'GET')
         "/external-api"(controller: 'externalApi', action: 'save', method: 'POST')
         "/external-api/$id"(controller: 'externalApi', action: 'update', method: 'PUT')
+        "/external-api/$id"(controller: 'externalApi', action: 'patchAction', method: 'PATCH')
         "/external-api/$id"(controller: 'externalApi', action: 'delete', method: 'DELETE')
         "/external-api/safe/$id"(controller: 'externalApi', action: 'showWithErrorHandling')
+        "/external-api/async"(controller: 'externalApi', action: 'asyncShow', method: 'GET')
+        "/external-api/path/$id"(controller: 'externalApi', action: 'pathShow', method: 'GET')
+        "/external-api/filtered"(controller: 'externalApi', action: 'filteredShow', method: 'GET')
 
         "/"(view:"/index")
         "500"(view:'/error')

--- a/grails-test-examples/micronaut/grails-app/controllers/micronaut/UrlMappings.groovy
+++ b/grails-test-examples/micronaut/grails-app/controllers/micronaut/UrlMappings.groovy
@@ -30,6 +30,13 @@ class UrlMappings {
 
         "/micronaut-test"(controller: 'micronautTest', action: 'index')
 
+        "/external-api"(controller: 'externalApi', action: 'index', method: 'GET')
+        "/external-api/$id"(controller: 'externalApi', action: 'show', method: 'GET')
+        "/external-api"(controller: 'externalApi', action: 'save', method: 'POST')
+        "/external-api/$id"(controller: 'externalApi', action: 'update', method: 'PUT')
+        "/external-api/$id"(controller: 'externalApi', action: 'delete', method: 'DELETE')
+        "/external-api/safe/$id"(controller: 'externalApi', action: 'showWithErrorHandling')
+
         "/"(view:"/index")
         "500"(view:'/error')
         "404"(view:'/notFound')

--- a/grails-test-examples/micronaut/grails-app/services/micronaut/ExternalApiService.groovy
+++ b/grails-test-examples/micronaut/grails-app/services/micronaut/ExternalApiService.groovy
@@ -22,6 +22,10 @@ import groovy.transform.CompileStatic
 
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import micronaut.client.MicronautAdvancedClient
+import micronaut.client.MicronautFilteredClient
+import micronaut.client.MicronautPathClient
+import micronaut.client.MicronautReactiveClient
 import micronaut.client.MicronautTestClient
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,6 +35,18 @@ class ExternalApiService {
 
     @Autowired
     MicronautTestClient micronautTestClient
+
+    @Autowired
+    MicronautAdvancedClient advancedClient
+
+    @Autowired
+    MicronautReactiveClient reactiveClient
+
+    @Autowired
+    MicronautPathClient pathClient
+
+    @Autowired
+    MicronautFilteredClient filteredClient
 
     String fetchAll() {
         micronautTestClient.index()
@@ -60,5 +76,35 @@ class ExternalApiService {
         } catch (HttpClientResponseException ex) {
             return [success: false, status: ex.status.code, error: ex.message]
         }
+    }
+
+    String search(String query, String page) {
+        advancedClient.search(query, page)
+    }
+
+    String fetchSecure(String authHeader) {
+        advancedClient.secureEndpoint(authHeader)
+    }
+
+    String patchResource(String id, String json) {
+        advancedClient.patch(id, json)
+    }
+
+    Map orchestrateMultiple(String id1, String id2) {
+        String first = micronautTestClient.show(id1)
+        String second = micronautTestClient.show(id2)
+        [first: first, second: second] as Map
+    }
+
+    String fetchAsync() {
+        reactiveClient.getAsync().get()
+    }
+
+    String fetchPathItem(String id) {
+        pathClient.getItem(id)
+    }
+
+    String fetchFiltered() {
+        filteredClient.getFilteredData()
     }
 }

--- a/grails-test-examples/micronaut/grails-app/services/micronaut/ExternalApiService.groovy
+++ b/grails-test-examples/micronaut/grails-app/services/micronaut/ExternalApiService.groovy
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import groovy.transform.CompileStatic
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import micronaut.client.MicronautTestClient
+
+import org.springframework.beans.factory.annotation.Autowired
+
+@CompileStatic
+class ExternalApiService {
+
+    @Autowired
+    MicronautTestClient micronautTestClient
+
+    String fetchAll() {
+        micronautTestClient.index()
+    }
+
+    String fetchById(String id) {
+        micronautTestClient.show(id)
+    }
+
+    String createResource(String json) {
+        micronautTestClient.create(json)
+    }
+
+    String updateResource(String id, String json) {
+        micronautTestClient.update(id, json)
+    }
+
+    int deleteResource(String id) {
+        HttpResponse<?> response = micronautTestClient.delete(id)
+        response.status.code
+    }
+
+    Map fetchWithErrorHandling(String id) {
+        try {
+            String data = micronautTestClient.show(id)
+            return [success: true, data: data]
+        } catch (HttpClientResponseException ex) {
+            return [success: false, status: ex.status.code, error: ex.message]
+        }
+    }
+}

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanDuplicationSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanDuplicationSpec.groovy
@@ -1,0 +1,126 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import bean.injection.AppConfig
+import bean.injection.FactoryCreatedService
+import bean.injection.JavaSingletonService
+import bean.injection.NamedService
+
+import grails.testing.mixin.integration.Integration
+import io.micronaut.context.ApplicationContext as MicronautApplicationContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext as SpringApplicationContext
+import org.springframework.context.ApplicationContextAware
+import spock.lang.Specification
+
+/**
+ * Integration tests verifying no bean duplication occurs between Spring and Micronaut contexts.
+ *
+ * When micronaut-spring bridges Micronaut beans into Spring, each bean should appear
+ * exactly once in the Spring context (not duplicated). Similarly, Micronaut beans
+ * should maintain correct counts in the Micronaut context.
+ */
+@Integration
+class MicronautBeanDuplicationSpec extends Specification implements ApplicationContextAware {
+
+    @Autowired
+    MicronautApplicationContext micronautContext
+
+    SpringApplicationContext springContext
+
+    void setApplicationContext(SpringApplicationContext applicationContext) {
+        this.springContext = applicationContext
+    }
+
+    void "Java @Singleton bean appears exactly once in Spring context"() {
+        when:
+        def beans = springContext.getBeansOfType(JavaSingletonService)
+
+        then: "only one instance is registered, not duplicated by the bridge"
+        beans.size() == 1
+    }
+
+    void "@Factory/@Bean created bean appears exactly once in Spring context"() {
+        when:
+        def beans = springContext.getBeansOfType(FactoryCreatedService)
+
+        then: "only one instance is registered"
+        beans.size() == 1
+    }
+
+    void "@ConfigurationProperties bean appears exactly once in Spring context"() {
+        when:
+        def beans = springContext.getBeansOfType(AppConfig)
+
+        then: "only one instance is registered"
+        beans.size() == 1
+    }
+
+    void "NamedService implementations appear exactly 4 times in Spring context"() {
+        when:
+        def beans = springContext.getBeansOfType(NamedService)
+
+        then: "4 implementations, not 8 from duplication"
+        beans.size() == 4
+    }
+
+    void "Micronaut context has exactly 4 NamedService implementations"() {
+        when:
+        def beans = micronautContext.getBeansOfType(NamedService)
+
+        then:
+        beans.size() == 4
+    }
+
+    void "Grails service appears exactly once in Spring context"() {
+        when:
+        def beans = springContext.getBeansOfType(BeanInjectionService)
+
+        then: "Grails artefact not duplicated by Micronaut bridge"
+        beans.size() == 1
+    }
+
+    void "bridged Micronaut bean in Spring is same instance as in Micronaut context"() {
+        when:
+        def fromSpring = springContext.getBean(JavaSingletonService)
+        def fromMicronaut = micronautContext.getBean(JavaSingletonService)
+
+        then: "bridge shares the same singleton, not a copy"
+        fromSpring.is(fromMicronaut)
+    }
+
+    void "factory-created bean in Spring is same instance as in Micronaut context"() {
+        when:
+        def fromSpring = springContext.getBean(FactoryCreatedService)
+        def fromMicronaut = micronautContext.getBean(FactoryCreatedService)
+
+        then: "bridge shares the same singleton"
+        fromSpring.is(fromMicronaut)
+    }
+
+    void "@ConfigurationProperties bean in Spring is same instance as in Micronaut context"() {
+        when:
+        def fromSpring = springContext.getBean(AppConfig)
+        def fromMicronaut = micronautContext.getBean(AppConfig)
+
+        then: "bridge shares the same singleton"
+        fromSpring.is(fromMicronaut)
+    }
+}

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanDuplicationSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanDuplicationSpec.groovy
@@ -22,13 +22,13 @@ import bean.injection.AppConfig
 import bean.injection.FactoryCreatedService
 import bean.injection.JavaSingletonService
 import bean.injection.NamedService
-
-import grails.testing.mixin.integration.Integration
 import io.micronaut.context.ApplicationContext as MicronautApplicationContext
+import spock.lang.Specification
+
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext as SpringApplicationContext
-import org.springframework.context.ApplicationContextAware
-import spock.lang.Specification
+
+import grails.testing.mixin.integration.Integration
 
 /**
  * Integration tests verifying no bean duplication occurs between Spring and Micronaut contexts.
@@ -38,63 +38,42 @@ import spock.lang.Specification
  * should maintain correct counts in the Micronaut context.
  */
 @Integration
-class MicronautBeanDuplicationSpec extends Specification implements ApplicationContextAware {
+class MicronautBeanDuplicationSpec extends Specification {
 
     @Autowired
     MicronautApplicationContext micronautContext
 
+    @Autowired
     SpringApplicationContext springContext
 
-    void setApplicationContext(SpringApplicationContext applicationContext) {
-        this.springContext = applicationContext
-    }
-
     void "Java @Singleton bean appears exactly once in Spring context"() {
-        when:
-        def beans = springContext.getBeansOfType(JavaSingletonService)
-
-        then: "only one instance is registered, not duplicated by the bridge"
-        beans.size() == 1
+        expect:
+        springContext.getBeansOfType(JavaSingletonService).size() == 1
     }
 
     void "@Factory/@Bean created bean appears exactly once in Spring context"() {
-        when:
-        def beans = springContext.getBeansOfType(FactoryCreatedService)
-
-        then: "only one instance is registered"
-        beans.size() == 1
+        expect:
+        springContext.getBeansOfType(FactoryCreatedService).size() == 1
     }
 
     void "@ConfigurationProperties bean appears exactly once in Spring context"() {
-        when:
-        def beans = springContext.getBeansOfType(AppConfig)
-
-        then: "only one instance is registered"
-        beans.size() == 1
+        expect:
+        springContext.getBeansOfType(AppConfig).size() == 1
     }
 
     void "NamedService implementations appear exactly 4 times in Spring context"() {
-        when:
-        def beans = springContext.getBeansOfType(NamedService)
-
-        then: "4 implementations, not 8 from duplication"
-        beans.size() == 4
+        expect:
+        springContext.getBeansOfType(NamedService).size() == 4
     }
 
     void "Micronaut context has exactly 4 NamedService implementations"() {
-        when:
-        def beans = micronautContext.getBeansOfType(NamedService)
-
-        then:
-        beans.size() == 4
+        expect:
+        micronautContext.getBeansOfType(NamedService).size() == 4
     }
 
     void "Grails service appears exactly once in Spring context"() {
-        when:
-        def beans = springContext.getBeansOfType(BeanInjectionService)
-
-        then: "Grails artefact not duplicated by Micronaut bridge"
-        beans.size() == 1
+        expect:
+        springContext.getBeansOfType(BeanInjectionService).size() == 1
     }
 
     void "bridged Micronaut bean in Spring is same instance as in Micronaut context"() {
@@ -102,7 +81,7 @@ class MicronautBeanDuplicationSpec extends Specification implements ApplicationC
         def fromSpring = springContext.getBean(JavaSingletonService)
         def fromMicronaut = micronautContext.getBean(JavaSingletonService)
 
-        then: "bridge shares the same singleton, not a copy"
+        then: 'bridge shares the same singleton, not a copy'
         fromSpring.is(fromMicronaut)
     }
 
@@ -111,7 +90,7 @@ class MicronautBeanDuplicationSpec extends Specification implements ApplicationC
         def fromSpring = springContext.getBean(FactoryCreatedService)
         def fromMicronaut = micronautContext.getBean(FactoryCreatedService)
 
-        then: "bridge shares the same singleton"
+        then: 'bridge shares the same singleton'
         fromSpring.is(fromMicronaut)
     }
 
@@ -120,7 +99,7 @@ class MicronautBeanDuplicationSpec extends Specification implements ApplicationC
         def fromSpring = springContext.getBean(AppConfig)
         def fromMicronaut = micronautContext.getBean(AppConfig)
 
-        then: "bridge shares the same singleton"
+        then: 'bridge shares the same singleton'
         fromSpring.is(fromMicronaut)
     }
 }

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanTypesSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanTypesSpec.groovy
@@ -22,11 +22,12 @@ import bean.injection.AppConfig
 import bean.injection.FactoryCreatedService
 import bean.injection.JavaMessageProvider
 import bean.injection.JavaSingletonService
+import spock.lang.Specification
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext as SpringApplicationContext
 
 import grails.testing.mixin.integration.Integration
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.ApplicationContext
-import spock.lang.Specification
 
 /**
  * Integration tests for various Micronaut bean registration mechanisms in Grails context.
@@ -41,7 +42,7 @@ import spock.lang.Specification
 class MicronautBeanTypesSpec extends Specification {
 
     @Autowired
-    ApplicationContext applicationContext
+    SpringApplicationContext springContext
 
     @Autowired
     JavaSingletonService javaSingletonService
@@ -53,46 +54,43 @@ class MicronautBeanTypesSpec extends Specification {
     AppConfig appConfig
 
     void "Java @Singleton bean is available via Spring autowiring"() {
-        expect: "bean is injected and functional"
-        javaSingletonService != null
-        javaSingletonService.message == 'from-java-singleton'
+        expect: 'bean is injected and functional'
+        javaSingletonService?.message == 'from-java-singleton'
     }
 
     void "Groovy @Factory/@Bean created bean is available via Spring autowiring"() {
-        expect: "bean is injected with factory-configured values"
-        factoryCreatedService != null
-        factoryCreatedService.name == 'factory-created'
+        expect: 'bean is injected with factory-configured values'
+        factoryCreatedService?.name == 'factory-created'
     }
 
     void "@ConfigurationProperties bean reflects application.yml config"() {
-        expect: "config properties are bound from application.yml"
-        appConfig != null
-        appConfig.name == 'test-micronaut-app'
+        expect: 'config properties are bound from application.yml'
+        appConfig?.name == 'test-micronaut-app'
     }
 
     void "Java @Singleton bean is a singleton instance"() {
-        when: "retrieving the bean twice from the application context"
-        def first = applicationContext.getBean(JavaSingletonService)
-        def second = applicationContext.getBean(JavaSingletonService)
+        when: 'retrieving the bean twice from the application context'
+        def first = springContext.getBean(JavaSingletonService)
+        def second = springContext.getBean(JavaSingletonService)
 
-        then: "same instance is returned"
+        then: 'same instance is returned'
         first.is(second)
     }
 
     void "Factory-created bean is a singleton instance"() {
-        when: "retrieving the bean twice from the application context"
-        def first = applicationContext.getBean(FactoryCreatedService)
-        def second = applicationContext.getBean(FactoryCreatedService)
+        when: 'retrieving the bean twice from the application context'
+        def first = springContext.getBean(FactoryCreatedService)
+        def second = springContext.getBean(FactoryCreatedService)
 
-        then: "same instance is returned (factory method annotated with @Singleton)"
+        then: 'same instance is returned (factory method annotated with @Singleton)'
         first.is(second)
     }
 
     void "Java @Singleton bean is resolvable by its interface type"() {
-        when: "looking up the bean by the JavaMessageProvider interface"
-        def provider = applicationContext.getBean(JavaMessageProvider)
+        when: 'looking up the bean by the JavaMessageProvider interface'
+        def provider = springContext.getBean(JavaMessageProvider)
 
-        then: "the bean is found and is the same singleton instance"
+        then: 'the bean is found and is the same singleton instance'
         provider != null
         provider instanceof JavaSingletonService
         provider.message == 'from-java-singleton'

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanTypesSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanTypesSpec.groovy
@@ -20,10 +20,12 @@ package micronaut
 
 import bean.injection.AppConfig
 import bean.injection.FactoryCreatedService
+import bean.injection.JavaMessageProvider
 import bean.injection.JavaSingletonService
 
 import grails.testing.mixin.integration.Integration
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
 import spock.lang.Specification
 
 /**
@@ -33,9 +35,13 @@ import spock.lang.Specification
  * 1. Java @Singleton beans (processed via annotation processor) are available in Spring context
  * 2. Groovy @Factory/@Bean beans (processed via AST transform) are available in Spring context
  * 3. @ConfigurationProperties beans reflect Grails application.yml config into Micronaut
+ * 4. Beans registered by interface type are resolvable via the interface
  */
 @Integration
 class MicronautBeanTypesSpec extends Specification {
+
+    @Autowired
+    ApplicationContext applicationContext
 
     @Autowired
     JavaSingletonService javaSingletonService
@@ -65,20 +71,31 @@ class MicronautBeanTypesSpec extends Specification {
     }
 
     void "Java @Singleton bean is a singleton instance"() {
-        when:
-        def first = javaSingletonService
-        def second = javaSingletonService
+        when: "retrieving the bean twice from the application context"
+        def first = applicationContext.getBean(JavaSingletonService)
+        def second = applicationContext.getBean(JavaSingletonService)
 
         then: "same instance is returned"
         first.is(second)
     }
 
     void "Factory-created bean is a singleton instance"() {
-        when:
-        def first = factoryCreatedService
-        def second = factoryCreatedService
+        when: "retrieving the bean twice from the application context"
+        def first = applicationContext.getBean(FactoryCreatedService)
+        def second = applicationContext.getBean(FactoryCreatedService)
 
         then: "same instance is returned (factory method annotated with @Singleton)"
         first.is(second)
+    }
+
+    void "Java @Singleton bean is resolvable by its interface type"() {
+        when: "looking up the bean by the JavaMessageProvider interface"
+        def provider = applicationContext.getBean(JavaMessageProvider)
+
+        then: "the bean is found and is the same singleton instance"
+        provider != null
+        provider instanceof JavaSingletonService
+        provider.message == 'from-java-singleton'
+        provider.is(javaSingletonService)
     }
 }

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanTypesSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautBeanTypesSpec.groovy
@@ -1,0 +1,84 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import bean.injection.AppConfig
+import bean.injection.FactoryCreatedService
+import bean.injection.JavaSingletonService
+
+import grails.testing.mixin.integration.Integration
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Specification
+
+/**
+ * Integration tests for various Micronaut bean registration mechanisms in Grails context.
+ *
+ * Tests that:
+ * 1. Java @Singleton beans (processed via annotation processor) are available in Spring context
+ * 2. Groovy @Factory/@Bean beans (processed via AST transform) are available in Spring context
+ * 3. @ConfigurationProperties beans reflect Grails application.yml config into Micronaut
+ */
+@Integration
+class MicronautBeanTypesSpec extends Specification {
+
+    @Autowired
+    JavaSingletonService javaSingletonService
+
+    @Autowired
+    FactoryCreatedService factoryCreatedService
+
+    @Autowired
+    AppConfig appConfig
+
+    void "Java @Singleton bean is available via Spring autowiring"() {
+        expect: "bean is injected and functional"
+        javaSingletonService != null
+        javaSingletonService.message == 'from-java-singleton'
+    }
+
+    void "Groovy @Factory/@Bean created bean is available via Spring autowiring"() {
+        expect: "bean is injected with factory-configured values"
+        factoryCreatedService != null
+        factoryCreatedService.name == 'factory-created'
+    }
+
+    void "@ConfigurationProperties bean reflects application.yml config"() {
+        expect: "config properties are bound from application.yml"
+        appConfig != null
+        appConfig.name == 'test-micronaut-app'
+    }
+
+    void "Java @Singleton bean is a singleton instance"() {
+        when:
+        def first = javaSingletonService
+        def second = javaSingletonService
+
+        then: "same instance is returned"
+        first.is(second)
+    }
+
+    void "Factory-created bean is a singleton instance"() {
+        when:
+        def first = factoryCreatedService
+        def second = factoryCreatedService
+
+        then: "same instance is returned (factory method annotated with @Singleton)"
+        first.is(second)
+    }
+}

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautDeclarativeClientSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautDeclarativeClientSpec.groovy
@@ -21,7 +21,10 @@ package micronaut
 import io.github.cjstehno.ersatz.ErsatzServer
 import io.github.cjstehno.ersatz.cfg.ContentType
 import io.micronaut.context.ApplicationContext as MicronautApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import micronaut.client.MicronautTestClient
 import spock.lang.AutoCleanup
 import spock.lang.Specification
@@ -93,6 +96,202 @@ class MicronautDeclarativeClientSpec extends Specification {
 
         then: 'the server responds successfully'
         response.status.code == 200
+
+        cleanup:
+        client.close()
+    }
+
+    void "declarative @Client sends POST and receives mock response"() {
+        given: 'an ersatz server mocking a 201 Created response for POST'
+        ersatz.expectations({ expect ->
+            expect.POST('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(201)
+                    res.body('{"id":"1","title":"test-item"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative client from the Micronaut context'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'creating a resource through the client'
+        def response = client.create('{"title":"test-item"}')
+
+        then: 'the response contains the mocked JSON from ersatz'
+        response != null
+        response.contains('"id"')
+        response.contains('"title"')
+
+        and: 'the ersatz server received exactly one POST request'
+        ersatz.verify()
+    }
+
+    void "declarative @Client sends PUT and receives mock response"() {
+        given: 'an ersatz server mocking a 200 OK response for PUT'
+        ersatz.expectations({ expect ->
+            expect.PUT('/micronaut-test/42', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"42","title":"updated"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative client from the Micronaut context'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'updating a resource through the client'
+        def response = client.update('42', '{"title":"updated"}')
+
+        then: 'the response contains the mocked JSON from ersatz'
+        response != null
+        response.contains('"id"')
+        response.contains('"updated"')
+
+        and: 'the ersatz server received exactly one PUT request'
+        ersatz.verify()
+    }
+
+    void "declarative @Client sends DELETE with path variable"() {
+        given: 'an ersatz server expecting a DELETE'
+        ersatz.expectations({ expect ->
+            expect.DELETE('/micronaut-test/42', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(204)
+                })
+            })
+        })
+
+        and: 'the declarative client from the Micronaut context'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'deleting a resource through the client'
+        def response = client.delete('42')
+
+        then: 'the response status indicates no content'
+        response.status.code == 204
+
+        and: 'the ersatz server received exactly one request'
+        ersatz.verify()
+    }
+
+    void "declarative @Client sends GET with path variable"() {
+        given: 'an ersatz server expecting a GET with a path variable'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/42', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"42","title":"test-item"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative client from the Micronaut context'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'retrieving a resource through the client'
+        def response = client.show('42')
+
+        then: 'the response contains the expected JSON'
+        response == '{"id":"42","title":"test-item"}'
+
+        and: 'the ersatz server received exactly one request'
+        ersatz.verify()
+    }
+
+    void "declarative @Client handles 404 response from ersatz mock"() {
+        given: 'an ersatz server returning 404 for a missing resource'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/999', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(404)
+                    res.body('{"error":"not found"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative client from the Micronaut context'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'requesting a missing resource'
+        String response = null
+        HttpClientResponseException caught = null
+        try {
+            response = client.show('999')
+        } catch (HttpClientResponseException ex) {
+            caught = ex
+        }
+
+        then: 'either an exception is thrown or null is returned'
+        caught != null || response == null
+
+        and: 'if exception was thrown, status is 404'
+        caught == null || caught.status.code == 404
+
+        and: 'the ersatz server received exactly one request'
+        ersatz.verify()
+    }
+
+    void "declarative @Client surfaces 500 responses"() {
+        given: 'an ersatz server returning 500 for an error response'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/error', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(500)
+                    res.body('{"error":"server error"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative client from the Micronaut context'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'requesting the error endpoint'
+        client.show('error')
+
+        then: 'an HttpClientResponseException is thrown'
+        def ex = thrown(HttpClientResponseException)
+        ex.status.code == 500
+
+        and: 'the ersatz server received exactly one request'
+        ersatz.verify()
+    }
+
+    void "Micronaut HttpClient can set Accept header"() {
+        given: 'an ersatz server expecting an Accept header'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test', { req ->
+                req.called(1)
+                req.header('Accept', MediaType.APPLICATION_JSON)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"status":"ok"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a Micronaut HTTP client targeting the ersatz server'
+        def client = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'calling the endpoint with an Accept header'
+        def response = client.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the expected JSON'
+        response.status.code == 200
+        response.body() == '{"status":"ok"}'
+
+        and: 'the ersatz server received exactly one request'
+        ersatz.verify()
 
         cleanup:
         client.close()

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautDeclarativeClientSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautDeclarativeClientSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import grails.testing.mixin.integration.Integration
+import io.micronaut.context.ApplicationContext as MicronautApplicationContext
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.HttpClient
+import micronaut.client.MicronautTestClient
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import spock.lang.Specification
+
+@Integration
+class MicronautDeclarativeClientSpec extends Specification {
+
+    @Autowired
+    MicronautApplicationContext micronautContext
+
+    @Value('${local.server.port}')
+    Integer serverPort
+
+    void "declarative @Client interface is registered as a bean in Micronaut context"() {
+        when: "looking up the declarative client bean"
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        then: "the bean is found and implements the interface"
+        client != null
+        client instanceof MicronautTestClient
+    }
+
+    void "Micronaut HttpClient can reach the running Grails application"() {
+        given: "a Micronaut HTTP client targeting the running server"
+        def client = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: "calling the root endpoint"
+        def response = client.toBlocking().exchange('/')
+
+        then: "the server responds successfully"
+        response.status.code == 200
+
+        cleanup:
+        client.close()
+    }
+}

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautDeclarativeClientSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautDeclarativeClientSpec.groovy
@@ -18,16 +18,18 @@
  */
 package micronaut
 
-import grails.testing.mixin.integration.Integration
 import io.github.cjstehno.ersatz.ErsatzServer
 import io.github.cjstehno.ersatz.cfg.ContentType
 import io.micronaut.context.ApplicationContext as MicronautApplicationContext
 import io.micronaut.http.client.HttpClient
 import micronaut.client.MicronautTestClient
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+
+import grails.testing.mixin.integration.Integration
 
 @Integration
 class MicronautDeclarativeClientSpec extends Specification {
@@ -44,49 +46,52 @@ class MicronautDeclarativeClientSpec extends Specification {
     })
 
     void "declarative @Client interface is registered as a bean in Micronaut context"() {
-        when: "looking up the declarative client bean"
+        when: 'looking up the declarative client bean'
         def client = micronautContext.getBean(MicronautTestClient)
 
-        then: "the bean is found and implements the interface"
+        then: 'the bean is found and implements the interface'
         client != null
         client instanceof MicronautTestClient
     }
 
     void "declarative @Client invokes endpoint through load balancing path"() {
-        given: "an ersatz server mocking the expected endpoint response"
+        given: 'an ersatz server mocking the expected endpoint response'
         ersatz.expectations({ expect ->
-            expect.GET("/micronaut-test", { req ->
+            expect.GET('/micronaut-test', { req ->
                 req.called(1)
                 req.responder({ res ->
                     res.code(200)
-                    res.body('{"javaMessage":"hello","factoryName":"test-factory"}', ContentType.APPLICATION_JSON)
+                    res.body(
+                            '{"javaMessage":"hello","factoryName":"test-factory"}',
+                            ContentType.APPLICATION_JSON
+                    )
                 })
             })
         })
 
-        and: "the declarative client from the Micronaut context"
+        and: 'the declarative client from the Micronaut context'
         def client = micronautContext.getBean(MicronautTestClient)
 
-        when: "invoking the client method which goes through service discovery and load balancing"
+        when: 'invoking the client method which goes through service discovery and load balancing'
         def response = client.index()
 
-        then: "the response contains the expected JSON from the ersatz mock"
+        then: 'the response contains the expected JSON from the ersatz mock'
         response != null
         response.contains('javaMessage')
         response.contains('factoryName')
 
-        and: "the ersatz server received exactly one request"
+        and: 'the ersatz server received exactly one request'
         ersatz.verify()
     }
 
     void "Micronaut HttpClient can reach the running Grails application"() {
-        given: "a Micronaut HTTP client targeting the running server"
+        given: 'a Micronaut HTTP client targeting the running server'
         def client = HttpClient.create("http://localhost:$serverPort".toURL())
 
-        when: "calling the root endpoint"
+        when: 'calling the root endpoint'
         def response = client.toBlocking().exchange('/')
 
-        then: "the server responds successfully"
+        then: 'the server responds successfully'
         response.status.code == 200
 
         cleanup:

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautDeclarativeClientSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautDeclarativeClientSpec.groovy
@@ -19,12 +19,14 @@
 package micronaut
 
 import grails.testing.mixin.integration.Integration
+import io.github.cjstehno.ersatz.ErsatzServer
+import io.github.cjstehno.ersatz.cfg.ContentType
 import io.micronaut.context.ApplicationContext as MicronautApplicationContext
-import io.micronaut.http.HttpResponse
 import io.micronaut.http.client.HttpClient
 import micronaut.client.MicronautTestClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 @Integration
@@ -36,6 +38,11 @@ class MicronautDeclarativeClientSpec extends Specification {
     @Value('${local.server.port}')
     Integer serverPort
 
+    @AutoCleanup
+    ErsatzServer ersatz = new ErsatzServer({ cfg ->
+        cfg.httpPort(19876)
+    })
+
     void "declarative @Client interface is registered as a bean in Micronaut context"() {
         when: "looking up the declarative client bean"
         def client = micronautContext.getBean(MicronautTestClient)
@@ -43,6 +50,33 @@ class MicronautDeclarativeClientSpec extends Specification {
         then: "the bean is found and implements the interface"
         client != null
         client instanceof MicronautTestClient
+    }
+
+    void "declarative @Client invokes endpoint through load balancing path"() {
+        given: "an ersatz server mocking the expected endpoint response"
+        ersatz.expectations({ expect ->
+            expect.GET("/micronaut-test", { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"javaMessage":"hello","factoryName":"test-factory"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: "the declarative client from the Micronaut context"
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: "invoking the client method which goes through service discovery and load balancing"
+        def response = client.index()
+
+        then: "the response contains the expected JSON from the ersatz mock"
+        response != null
+        response.contains('javaMessage')
+        response.contains('factoryName')
+
+        and: "the ersatz server received exactly one request"
+        ersatz.verify()
     }
 
     void "Micronaut HttpClient can reach the running Grails application"() {

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzAdvancedSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzAdvancedSpec.groovy
@@ -1,0 +1,863 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import io.github.cjstehno.ersatz.ErsatzServer
+import io.github.cjstehno.ersatz.cfg.ContentType
+import io.micronaut.context.ApplicationContext as MicronautApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import micronaut.client.MicronautAdvancedClient
+import micronaut.client.MicronautHeaderClient
+import micronaut.client.MicronautTestClient
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class MicronautErsatzAdvancedSpec extends Specification {
+
+    @Autowired
+    MicronautApplicationContext micronautContext
+
+    @Autowired
+    ExternalApiService externalApiService
+
+    @Value('${local.server.port}')
+    Integer serverPort
+
+    @AutoCleanup
+    ErsatzServer ersatz = new ErsatzServer({ cfg ->
+        cfg.httpPort(19876)
+    })
+
+    void "PATCH request via declarative client through ersatz mock"() {
+        given: 'ersatz mocks the PATCH endpoint'
+        ersatz.expectations({ expect ->
+            expect.PATCH('/micronaut-test/42', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"42","name":"patched"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative advanced client'
+        def client = micronautContext.getBean(MicronautAdvancedClient)
+
+        when: 'patching the resource'
+        def response = client.patch('42', '{"name":"patched"}')
+
+        then: 'the response contains patched data'
+        response != null
+        response.contains('"id":"42"')
+        response.contains('patched')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "HEAD request via declarative client returns only headers from ersatz"() {
+        given: 'ersatz mocks the HEAD endpoint with headers'
+        ersatz.expectations({ expect ->
+            expect.HEAD('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.header('X-Total-Count', '42')
+                })
+            })
+        })
+
+        and: 'the declarative advanced client'
+        def client = micronautContext.getBean(MicronautAdvancedClient)
+
+        when: 'calling the head endpoint'
+        HttpResponse<?> response = client.headCheck()
+
+        then: 'the response contains the header'
+        response.status.code == 200
+        response.header('X-Total-Count') == '42'
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "OPTIONS request via declarative client through ersatz mock"() {
+        given: 'ersatz mocks the OPTIONS endpoint'
+        ersatz.expectations({ expect ->
+            expect.OPTIONS('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.header('Allow', 'GET, POST, PUT, DELETE, PATCH')
+                })
+            })
+        })
+
+        and: 'the declarative advanced client'
+        def client = micronautContext.getBean(MicronautAdvancedClient)
+
+        when: 'calling the options endpoint'
+        HttpResponse<?> response = client.optionsCheck()
+
+        then: 'the response contains the allow header'
+        response.status.code == 200
+        response.header('Allow') == 'GET, POST, PUT, DELETE, PATCH'
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "ANY method matcher in ersatz matches GET request from Micronaut HttpClient"() {
+        given: 'ersatz mocks the ANY endpoint'
+        ersatz.expectations({ expect ->
+            expect.ANY('/micronaut-test/anything', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"status":"any"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a low-level Micronaut HTTP client'
+        def httpClient = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'sending a GET request'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test/anything').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response is successful'
+        response.status.code == 200
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "declarative client sends query parameters matched by ersatz"() {
+        given: 'ersatz expects query parameters'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/search', { req ->
+                req.query('q', 'grails')
+                req.query('page', '1')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"results":["grails"]}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative advanced client'
+        def client = micronautContext.getBean(MicronautAdvancedClient)
+
+        when: 'searching with query parameters'
+        def response = client.search('grails', '1')
+
+        then: 'the response contains the mocked results'
+        response != null
+        response.contains('grails')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "ersatz matches query parameters in full roundtrip through Grails stack"() {
+        given: 'ersatz expects query parameters'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/search', { req ->
+                req.query('q', 'grails')
+                req.query('page', '2')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"results":["grails","roundtrip"]}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a Micronaut HTTP client targeting Grails'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'calling the Grails controller endpoint'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/external-api/search?q=grails&page=2').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the mocked data'
+        response.status.code == 200
+        response.body().contains('roundtrip')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "declarative client sends Authorization header matched by ersatz"() {
+        given: 'ersatz expects an authorization header'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/secure', { req ->
+                req.header('Authorization', 'Bearer test-token-123')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"secure":true}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative advanced client'
+        def client = micronautContext.getBean(MicronautAdvancedClient)
+
+        when: 'calling the secure endpoint'
+        def response = client.secureEndpoint('Bearer test-token-123')
+
+        then: 'the response contains the secure payload'
+        response != null
+        response.contains('secure')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "declarative client sends custom X-Api-Key header matched by ersatz"() {
+        given: 'ersatz expects an api key header'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/api-resource', { req ->
+                req.header('X-Api-Key', 'my-secret-key')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"api":"ok"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative advanced client'
+        def client = micronautContext.getBean(MicronautAdvancedClient)
+
+        when: 'calling the endpoint with api key'
+        def response = client.withApiKey('my-secret-key')
+
+        then: 'the response contains the api payload'
+        response != null
+        response.contains('ok')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "class-level @Header annotation sends header on every request through ersatz"() {
+        given: 'ersatz expects the class-level header'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test', { req ->
+                req.header('X-App-Version', '2.0')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"version":"2.0"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the header client'
+        def client = micronautContext.getBean(MicronautHeaderClient)
+
+        when: 'calling the index endpoint'
+        def response = client.index()
+
+        then: 'the response contains the expected version'
+        response != null
+        response.contains('2.0')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "ersatz matches Basic Authentication header from Micronaut HttpClient"() {
+        given: 'ersatz expects a basic auth header'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/basic-auth', { req ->
+                req.header('Authorization', 'Basic dXNlcjpwYXNz')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"auth":"basic"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a low-level Micronaut HTTP client'
+        def httpClient = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'sending a basic auth request'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test/basic-auth')
+                        .basicAuth('user', 'pass')
+                        .accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response is successful'
+        response.status.code == 200
+        response.body().contains('basic')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: Authorization header passes through Grails stack to ersatz"() {
+        given: 'ersatz expects an authorization header'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/secure', { req ->
+                req.header('Authorization', 'Bearer roundtrip-token')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"secure":"roundtrip"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a Micronaut HTTP client targeting Grails'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'calling the Grails controller endpoint'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/external-api/secure')
+                        .header('Authorization', 'Bearer roundtrip-token')
+                        .accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the secured payload'
+        response.status.code == 200
+        response.body().contains('roundtrip')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "declarative client sends cookie matched by ersatz"() {
+        given: 'ersatz expects a session cookie'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/with-cookie', { req ->
+                req.cookie('session', 'abc-session-123')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"cookie":"ok"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative advanced client'
+        def client = micronautContext.getBean(MicronautAdvancedClient)
+
+        when: 'calling the endpoint with cookie'
+        def response = client.withCookie('abc-session-123')
+
+        then: 'the response contains the cookie payload'
+        response != null
+        response.contains('cookie')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "ersatz returns response cookies received by Micronaut HttpClient"() {
+        given: 'ersatz responds with a cookie'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/cookie-response', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"cookie":"response"}', ContentType.APPLICATION_JSON)
+                    res.cookie('tracker', 'visit-42')
+                })
+            })
+        })
+
+        and: 'a low-level Micronaut HTTP client'
+        def httpClient = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'making the request'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test/cookie-response').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the set-cookie header is present'
+        response.status.code == 200
+        response.header('Set-Cookie').contains('tracker')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "ersatz returns plain text response consumed by declarative client"() {
+        given: 'ersatz returns plain text'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/text', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('Hello, Grails!', ContentType.TEXT_PLAIN)
+                })
+            })
+        })
+
+        and: 'the declarative advanced client'
+        def client = micronautContext.getBean(MicronautAdvancedClient)
+
+        when: 'calling the text endpoint'
+        def response = client.getPlainText()
+
+        then: 'the response matches the plain text'
+        response == 'Hello, Grails!'
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "ersatz returns XML response consumed by Micronaut HttpClient"() {
+        given: 'ersatz returns XML'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/xml', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('<root><message>hello</message></root>', ContentType.APPLICATION_XML)
+                })
+            })
+        })
+
+        and: 'a low-level Micronaut HTTP client'
+        def httpClient = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'requesting XML'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test/xml')
+                        .accept(MediaType.APPLICATION_XML),
+                String
+        )
+
+        then: 'the XML response is received'
+        response.status.code == 200
+        response.body().contains('<message>hello</message>')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "ersatz returns delayed response received by Micronaut HttpClient"() {
+        given: 'ersatz delays the response'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/slow', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.delay(200)
+                    res.body('{"status":"slow"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a low-level Micronaut HTTP client'
+        def httpClient = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'calling the slow endpoint'
+        long startTime = System.currentTimeMillis()
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test/slow').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+        long endTime = System.currentTimeMillis()
+
+        then: 'the response is delayed and successful'
+        response.status.code == 200
+        (endTime - startTime) >= 150
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "ersatz verifies exact call count for multiple requests to same endpoint"() {
+        given: 'ersatz expects multiple calls'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test', { req ->
+                req.called(3)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"status":"ok"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the declarative test client'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'calling multiple times'
+        client.index()
+        client.index()
+        client.index()
+
+        then: 'ersatz verifies the call count'
+        ersatz.verify()
+    }
+
+    void "ersatz listener captures request details"() {
+        given: 'ersatz captures request details'
+        List<Object> captured = []
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/listen', { req ->
+                req.listener({ captured << it })
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"listen":"ok"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a low-level Micronaut HTTP client'
+        def httpClient = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'making the request'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test/listen').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'a request was captured'
+        response.status.code == 200
+        captured.size() == 1
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "ersatz returns different responses for sequential calls to same endpoint"() {
+        given: 'ersatz is configured with sequential responses'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/sequence', { req ->
+                req.called(3)
+                req.responder({ res ->
+                    res.code(503)
+                    res.body('unavailable', ContentType.TEXT_PLAIN)
+                })
+                req.responder({ res ->
+                    res.code(503)
+                    res.body('still unavailable', ContentType.TEXT_PLAIN)
+                })
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"status":"ok"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a low-level Micronaut HTTP client'
+        def httpClient = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'calling the endpoint multiple times'
+        def firstException = null
+        def secondException = null
+        try {
+            httpClient.toBlocking().exchange(
+                    HttpRequest.GET('/micronaut-test/sequence').accept(MediaType.APPLICATION_JSON),
+                    String
+            )
+        } catch (HttpClientResponseException ex) {
+            firstException = ex
+        }
+        try {
+            httpClient.toBlocking().exchange(
+                    HttpRequest.GET('/micronaut-test/sequence').accept(MediaType.APPLICATION_JSON),
+                    String
+            )
+        } catch (HttpClientResponseException ex) {
+            secondException = ex
+        }
+        def thirdResponse = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test/sequence').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the first two responses are errors'
+        firstException instanceof HttpClientResponseException
+        firstException.status.code == 503
+        secondException instanceof HttpClientResponseException
+        secondException.status.code == 503
+        thirdResponse.status.code == 200
+        thirdResponse.body().contains('"status":"ok"')
+
+        and: 'ersatz verifies the call count'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "Micronaut client handles 401 Unauthorized from ersatz"() {
+        given: 'ersatz responds with 401'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/unauthorized', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(401)
+                })
+            })
+        })
+
+        and: 'the declarative test client'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'requesting an unauthorized resource'
+        client.show('unauthorized')
+
+        then: 'a 401 exception is thrown'
+        def ex = thrown(HttpClientResponseException)
+        ex.status.code == 401
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "Micronaut client handles 403 Forbidden from ersatz"() {
+        given: 'ersatz responds with 403'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/forbidden', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(403)
+                })
+            })
+        })
+
+        and: 'the declarative test client'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'requesting a forbidden resource'
+        client.show('forbidden')
+
+        then: 'a 403 exception is thrown'
+        def ex = thrown(HttpClientResponseException)
+        ex.status.code == 403
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "Micronaut client handles 429 Too Many Requests from ersatz"() {
+        given: 'ersatz responds with 429'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/rate-limited', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(429)
+                })
+            })
+        })
+
+        and: 'the declarative test client'
+        def client = micronautContext.getBean(MicronautTestClient)
+
+        when: 'requesting a rate limited resource'
+        client.show('rate-limited')
+
+        then: 'a 429 exception is thrown'
+        def ex = thrown(HttpClientResponseException)
+        ex.status.code == 429
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "multiple @Client interfaces coexist and resolve in Micronaut context"() {
+        when: 'resolving all client beans'
+        def testClient = micronautContext.getBean(MicronautTestClient)
+        def advancedClient = micronautContext.getBean(MicronautAdvancedClient)
+        def headerClient = micronautContext.getBean(MicronautHeaderClient)
+
+        then: 'all client beans are available'
+        testClient != null
+        advancedClient != null
+        headerClient != null
+        testClient instanceof MicronautTestClient
+        advancedClient instanceof MicronautAdvancedClient
+        headerClient instanceof MicronautHeaderClient
+    }
+
+    void "service orchestrates multiple ersatz-backed API calls in single operation"() {
+        given: 'ersatz mocks multiple endpoints'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/10', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"10","name":"first"}', ContentType.APPLICATION_JSON)
+                })
+            })
+            expect.GET('/micronaut-test/20', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"20","name":"second"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'the service orchestrates multiple calls'
+        def result = externalApiService.orchestrateMultiple('10', '20')
+
+        then: 'the result map contains both responses'
+        result != null
+        result.first.contains('"id":"10"')
+        result.second.contains('"id":"20"')
+
+        and: 'ersatz verifies both calls'
+        ersatz.verify()
+    }
+
+    void "full roundtrip: PATCH through Grails controller to ersatz mock"() {
+        given: 'ersatz mocks the PATCH endpoint'
+        ersatz.expectations({ expect ->
+            expect.PATCH('/micronaut-test/99', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"99","name":"patched"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a Micronaut HTTP client targeting Grails'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'sending a PATCH request to Grails'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.PATCH('/external-api/99', '{"name":"patched"}')
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the patched payload'
+        response.status.code == 200
+        response.body().contains('patched')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: search with query params through Grails controller to ersatz"() {
+        given: 'ersatz expects query parameters'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/search', { req ->
+                req.query('q', 'test-query')
+                req.query('page', '3')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"results":["test-query"]}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a Micronaut HTTP client targeting Grails'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'calling the search endpoint'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/external-api/search?q=test-query&page=3').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the mocked data'
+        response.status.code == 200
+        response.body().contains('test-query')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "Grails service error handling wraps Micronaut client error from ersatz"() {
+        given: 'ersatz responds with a 502 error'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/service-error', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(502)
+                })
+            })
+        })
+
+        when: 'the service handles the error'
+        def result = externalApiService.fetchWithErrorHandling('service-error')
+
+        then: 'the error is captured'
+        result.success == false
+        result.status == 502
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+}

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzPatternSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzPatternSpec.groovy
@@ -1,0 +1,481 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import io.github.cjstehno.ersatz.ErsatzServer
+import io.github.cjstehno.ersatz.cfg.ContentType
+import io.micronaut.context.ApplicationContext as MicronautApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import micronaut.client.MicronautFilteredClient
+import micronaut.client.MicronautPathClient
+import micronaut.client.MicronautReactiveClient
+import micronaut.client.MicronautRetryableClient
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class MicronautErsatzPatternSpec extends Specification {
+
+    @Autowired
+    MicronautApplicationContext micronautContext
+
+    @Autowired
+    ExternalApiService externalApiService
+
+    @Value('${local.server.port}')
+    Integer serverPort
+
+    @AutoCleanup
+    ErsatzServer ersatz = new ErsatzServer({ cfg ->
+        cfg.httpPort(19876)
+    })
+
+    // --- CompletableFuture return types ---
+
+    void "CompletableFuture GET resolves with ersatz-mocked data"() {
+        given: 'ersatz mocks the async endpoint'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/async', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"async":"get-result"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the reactive client'
+        def client = micronautContext.getBean(MicronautReactiveClient)
+
+        when: 'calling getAsync'
+        def future = client.getAsync()
+        def result = future.get()
+
+        then: 'the future resolves with the mocked data'
+        result != null
+        result.contains('async')
+        result.contains('get-result')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "CompletableFuture POST resolves with ersatz-mocked creation response"() {
+        given: 'ersatz mocks the async POST endpoint'
+        ersatz.expectations({ expect ->
+            expect.POST('/micronaut-test/async', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(201)
+                    res.body('{"id":"async-1","created":true}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the reactive client'
+        def client = micronautContext.getBean(MicronautReactiveClient)
+
+        when: 'calling createAsync'
+        def future = client.createAsync('{"name":"async-item"}')
+        def result = future.get()
+
+        then: 'the future resolves with the created resource'
+        result != null
+        result.contains('async-1')
+        result.contains('created')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "CompletableFuture DELETE resolves with HttpResponse from ersatz"() {
+        given: 'ersatz mocks the async DELETE endpoint'
+        ersatz.expectations({ expect ->
+            expect.DELETE('/micronaut-test/async/77', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(204)
+                })
+            })
+        })
+
+        and: 'the reactive client'
+        def client = micronautContext.getBean(MicronautReactiveClient)
+
+        when: 'calling deleteAsync'
+        def future = client.deleteAsync('77')
+        def response = future.get()
+
+        then: 'the future resolves with the HttpResponse'
+        response.status.code == 204
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "void return type completes without error and ersatz verifies the call"() {
+        given: 'ersatz mocks the fire-and-forget endpoint'
+        ersatz.expectations({ expect ->
+            expect.POST('/micronaut-test/fire-and-forget', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(202)
+                })
+            })
+        })
+
+        and: 'the reactive client'
+        def client = micronautContext.getBean(MicronautReactiveClient)
+
+        when: 'calling fireAndForget'
+        client.fireAndForget('{"event":"fired"}')
+
+        then: 'no exception is thrown'
+        noExceptionThrown()
+
+        and: 'ersatz verifies the call was made'
+        ersatz.verify()
+    }
+
+    // --- @Client with base path ---
+
+    void "@Client path prepends base path to GET request verified by ersatz"() {
+        given: 'ersatz mocks the versioned API endpoint'
+        ersatz.expectations({ expect ->
+            expect.GET('/api/v1/items', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('[{"id":"1","name":"path-item"}]', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the path client'
+        def client = micronautContext.getBean(MicronautPathClient)
+
+        when: 'calling listItems'
+        def result = client.listItems()
+
+        then: 'the response contains the mocked data'
+        result != null
+        result.contains('path-item')
+
+        and: 'ersatz verifies the call to the base-path-prefixed URL'
+        ersatz.verify()
+    }
+
+    void "@Client path prepends base path to GET with @PathVariable verified by ersatz"() {
+        given: 'ersatz mocks the versioned API endpoint with id'
+        ersatz.expectations({ expect ->
+            expect.GET('/api/v1/items/55', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"55","name":"versioned-item"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the path client'
+        def client = micronautContext.getBean(MicronautPathClient)
+
+        when: 'calling getItem'
+        def result = client.getItem('55')
+
+        then: 'the response contains the mocked item'
+        result != null
+        result.contains('"id":"55"')
+        result.contains('versioned-item')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    void "@Client path prepends base path to POST request verified by ersatz"() {
+        given: 'ersatz mocks the versioned API POST endpoint'
+        ersatz.expectations({ expect ->
+            expect.POST('/api/v1/items', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(201)
+                    res.body('{"id":"new","name":"path-created"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the path client'
+        def client = micronautContext.getBean(MicronautPathClient)
+
+        when: 'calling createItem'
+        def result = client.createItem('{"name":"path-created"}')
+
+        then: 'the response contains the created item'
+        result != null
+        result.contains('path-created')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+    }
+
+    // --- @ClientFilter auto-injects headers ---
+
+    void "@ClientFilter auto-injects X-Auth-Token header verified by ersatz"() {
+        given: 'ersatz expects the auto-injected header'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/filtered/data', { req ->
+                req.header('X-Auth-Token', 'auto-injected-token-123')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"filtered":"data"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the filtered client'
+        def client = micronautContext.getBean(MicronautFilteredClient)
+
+        when: 'calling getFilteredData'
+        def result = client.getFilteredData()
+
+        then: 'the response contains the filtered data'
+        result != null
+        result.contains('filtered')
+
+        and: 'ersatz verifies the header was present'
+        ersatz.verify()
+    }
+
+    void "@ClientFilter applies to nested paths with @PathVariable"() {
+        given: 'ersatz expects the auto-injected header on nested path'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/filtered/details/42', { req ->
+                req.header('X-Auth-Token', 'auto-injected-token-123')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"42","detail":"filtered"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the filtered client'
+        def client = micronautContext.getBean(MicronautFilteredClient)
+
+        when: 'calling getFilteredDetails with path variable'
+        def result = client.getFilteredDetails('42')
+
+        then: 'the response contains the filtered detail'
+        result != null
+        result.contains('"id":"42"')
+
+        and: 'ersatz verifies the header was present on the nested path'
+        ersatz.verify()
+    }
+
+    // --- @Retryable ---
+
+    void "@Retryable client succeeds on first attempt through ersatz"() {
+        given: 'ersatz mocks a successful response'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/retryable', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"retry":"not-needed"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the retryable client'
+        def client = micronautContext.getBean(MicronautRetryableClient)
+
+        when: 'calling getWithRetry'
+        def result = client.getWithRetry()
+
+        then: 'the result is returned on first attempt'
+        result != null
+        result.contains('not-needed')
+
+        and: 'ersatz verifies only one call was made'
+        ersatz.verify()
+    }
+
+    void "@Retryable retries on 503 errors and succeeds on third attempt via ersatz sequential responses"() {
+        given: 'ersatz responds with 503 twice then 200'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/retryable', { req ->
+                req.called(3)
+                req.responder({ res ->
+                    res.code(503)
+                    res.body('unavailable', ContentType.TEXT_PLAIN)
+                })
+                req.responder({ res ->
+                    res.code(503)
+                    res.body('still unavailable', ContentType.TEXT_PLAIN)
+                })
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"retry":"succeeded"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'the retryable client'
+        def client = micronautContext.getBean(MicronautRetryableClient)
+
+        when: 'calling getWithRetry'
+        def result = client.getWithRetry()
+
+        then: 'the result is returned after retries'
+        result != null
+        result.contains('succeeded')
+
+        and: 'ersatz verifies all three calls were made'
+        ersatz.verify()
+    }
+
+    // --- Bean resolution ---
+
+    void "all Phase 3 client beans resolve in Micronaut context"() {
+        when: 'resolving all new client beans'
+        def reactiveClient = micronautContext.getBean(MicronautReactiveClient)
+        def pathClient = micronautContext.getBean(MicronautPathClient)
+        def filteredClient = micronautContext.getBean(MicronautFilteredClient)
+        def retryableClient = micronautContext.getBean(MicronautRetryableClient)
+
+        then: 'all beans are available and correctly typed'
+        reactiveClient != null
+        pathClient != null
+        filteredClient != null
+        retryableClient != null
+        reactiveClient instanceof MicronautReactiveClient
+        pathClient instanceof MicronautPathClient
+        filteredClient instanceof MicronautFilteredClient
+        retryableClient instanceof MicronautRetryableClient
+    }
+
+    // --- Full roundtrip tests ---
+
+    void "full roundtrip: CompletableFuture through Grails controller to ersatz"() {
+        given: 'ersatz mocks the async endpoint'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/async', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"async":"roundtrip-data"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a Micronaut HTTP client targeting Grails'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'calling the Grails async controller endpoint'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/external-api/async').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the ersatz-mocked async data'
+        response.status.code == 200
+        response.body().contains('roundtrip-data')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: path client through Grails controller to ersatz"() {
+        given: 'ersatz mocks the versioned API endpoint'
+        ersatz.expectations({ expect ->
+            expect.GET('/api/v1/items/88', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"88","name":"path-roundtrip"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a Micronaut HTTP client targeting Grails'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'calling the Grails path controller endpoint'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/external-api/path/88').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the ersatz-mocked path data'
+        response.status.code == 200
+        response.body().contains('path-roundtrip')
+
+        and: 'ersatz verifies the call'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: filtered client through Grails controller to ersatz with auto-injected header"() {
+        given: 'ersatz expects the auto-injected header on the filtered path'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/filtered/data', { req ->
+                req.header('X-Auth-Token', 'auto-injected-token-123')
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"filtered":"roundtrip-data"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a Micronaut HTTP client targeting Grails'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'calling the Grails filtered controller endpoint'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/external-api/filtered').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the filtered data'
+        response.status.code == 200
+        response.body().contains('roundtrip-data')
+
+        and: 'ersatz verifies the header was auto-injected'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+}

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzRoundtripSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzRoundtripSpec.groovy
@@ -1,0 +1,531 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import io.github.cjstehno.ersatz.ErsatzServer
+import io.github.cjstehno.ersatz.cfg.ContentType
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class MicronautErsatzRoundtripSpec extends Specification {
+
+    @Autowired
+    ExternalApiService externalApiService
+
+    @Value('${local.server.port}')
+    Integer serverPort
+
+    @AutoCleanup
+    ErsatzServer ersatz = new ErsatzServer({ cfg ->
+        cfg.httpPort(19876)
+    })
+
+    // --- Service layer: Grails service -> Micronaut @Client -> ersatz ---
+
+    void "service fetches list via Micronaut client from ersatz mock"() {
+        given: 'ersatz mocks the external API index endpoint'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('[{"id":"1","name":"alpha"},{"id":"2","name":"beta"}]', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'the Grails service calls fetchAll()'
+        def result = externalApiService.fetchAll()
+
+        then: 'the mocked JSON array is returned through the Micronaut client'
+        result != null
+        result.contains('alpha')
+        result.contains('beta')
+
+        and: 'ersatz received exactly one GET'
+        ersatz.verify()
+    }
+
+    void "service fetches single resource by ID from ersatz mock"() {
+        given: 'ersatz mocks a specific resource endpoint'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/7', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"7","name":"gamma","active":true}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'the Grails service calls fetchById("7")'
+        def result = externalApiService.fetchById('7')
+
+        then: 'the mocked resource is returned'
+        result != null
+        result.contains('"id":"7"')
+        result.contains('gamma')
+
+        and: 'ersatz received exactly one GET'
+        ersatz.verify()
+    }
+
+    void "service creates resource via Micronaut client through ersatz mock"() {
+        given: 'ersatz mocks a 201 Created response'
+        ersatz.expectations({ expect ->
+            expect.POST('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(201)
+                    res.body('{"id":"99","name":"new-item"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'the Grails service calls createResource()'
+        def result = externalApiService.createResource('{"name":"new-item"}')
+
+        then: 'the mocked creation response is returned'
+        result != null
+        result.contains('"id":"99"')
+
+        and: 'ersatz received exactly one POST'
+        ersatz.verify()
+    }
+
+    void "service updates resource via Micronaut client through ersatz mock"() {
+        given: 'ersatz mocks a 200 OK response for the update'
+        ersatz.expectations({ expect ->
+            expect.PUT('/micronaut-test/99', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"99","name":"updated-item"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'the Grails service calls updateResource()'
+        def result = externalApiService.updateResource('99', '{"name":"updated-item"}')
+
+        then: 'the mocked update response is returned'
+        result != null
+        result.contains('updated-item')
+
+        and: 'ersatz received exactly one PUT'
+        ersatz.verify()
+    }
+
+    void "service deletes resource via Micronaut client through ersatz mock"() {
+        given: 'ersatz mocks a 204 No Content response for deletion'
+        ersatz.expectations({ expect ->
+            expect.DELETE('/micronaut-test/99', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(204)
+                })
+            })
+        })
+
+        when: 'the Grails service calls deleteResource()'
+        def statusCode = externalApiService.deleteResource('99')
+
+        then: 'the 204 status code is returned'
+        statusCode == 204
+
+        and: 'ersatz received exactly one DELETE'
+        ersatz.verify()
+    }
+
+    void "service handles 500 error from external API via ersatz mock"() {
+        given: 'ersatz mocks a 500 Internal Server Error'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/broken', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(500)
+                    res.body('{"error":"internal failure"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'the Grails service calls fetchWithErrorHandling() for a failing endpoint'
+        def result = externalApiService.fetchWithErrorHandling('broken')
+
+        then: 'the error is caught and returned as a map'
+        result.success == false
+        result.status == 500
+
+        and: 'ersatz received exactly one GET'
+        ersatz.verify()
+    }
+
+    void "service handles 503 Service Unavailable from external API"() {
+        given: 'ersatz mocks a 503 Service Unavailable'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/unavailable', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(503)
+                    res.body('{"error":"service unavailable"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'the Grails service calls fetchWithErrorHandling()'
+        def result = externalApiService.fetchWithErrorHandling('unavailable')
+
+        then: 'the error is caught with the correct status'
+        result.success == false
+        result.status == 503
+
+        and: 'ersatz received exactly one GET'
+        ersatz.verify()
+    }
+
+    // --- Full HTTP roundtrip: HTTP client -> Grails controller -> service -> Micronaut @Client -> ersatz ---
+
+    void "full roundtrip: GET /external-api returns data from ersatz mock"() {
+        given: 'ersatz mocks the external API with a JSON list'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('[{"id":"1","name":"from-ersatz"}]', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'an HTTP client targeting the running Grails application'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'hitting the Grails controller endpoint'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/external-api').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the Grails controller returns data that originated from the ersatz mock'
+        response.status.code == 200
+        response.body().contains('micronaut-client')
+        response.body().contains('from-ersatz')
+
+        and: 'ersatz confirms it served the mocked response'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: GET /external-api/{id} returns specific resource from ersatz mock"() {
+        given: 'ersatz mocks a specific resource by ID'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/42', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"42","name":"the-answer"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'an HTTP client targeting the running Grails application'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'hitting the Grails controller show endpoint'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/external-api/42').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response contains the ersatz-mocked resource data'
+        response.status.code == 200
+        response.body().contains('the-answer')
+
+        and: 'ersatz confirms it served the mocked response'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: POST /external-api creates resource via ersatz mock"() {
+        given: 'ersatz mocks a 201 Created response'
+        ersatz.expectations({ expect ->
+            expect.POST('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(201)
+                    res.body('{"id":"new-1","name":"created-via-roundtrip"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'an HTTP client targeting the running Grails application'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'POSTing to the Grails controller'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.POST('/external-api', '{"name":"test"}')
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response includes the ersatz-mocked creation result'
+        response.status.code == 201
+        response.body().contains('created-via-roundtrip')
+
+        and: 'ersatz confirms it received the POST'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: PUT /external-api/{id} updates resource via ersatz mock"() {
+        given: 'ersatz mocks a 200 OK response for the update'
+        ersatz.expectations({ expect ->
+            expect.PUT('/micronaut-test/42', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"42","name":"updated-via-roundtrip"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'an HTTP client targeting the running Grails application'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'PUTting to the Grails controller'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.PUT('/external-api/42', '{"name":"updated"}')
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the response includes the ersatz-mocked update result'
+        response.status.code == 200
+        response.body().contains('updated-via-roundtrip')
+
+        and: 'ersatz confirms it received the PUT'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: DELETE /external-api/{id} deletes resource via ersatz mock"() {
+        given: 'ersatz mocks a 204 No Content response'
+        ersatz.expectations({ expect ->
+            expect.DELETE('/micronaut-test/42', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(204)
+                })
+            })
+        })
+
+        and: 'an HTTP client targeting the running Grails application'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'DELETEing via the Grails controller'
+        def response = httpClient.toBlocking().exchange(
+                HttpRequest.DELETE('/external-api/42').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the Grails controller returns 204'
+        response.status.code == 204
+
+        and: 'ersatz confirms it received the DELETE'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: error from ersatz propagates through Grails controller"() {
+        given: 'ersatz mocks a 500 Internal Server Error'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/fail', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(500)
+                    res.body('{"error":"boom"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'an HTTP client targeting the running Grails application'
+        def httpClient = HttpClient.create("http://localhost:$serverPort".toURL())
+
+        when: 'hitting the error-handling endpoint that catches upstream errors'
+        io.micronaut.http.client.exceptions.HttpClientResponseException caught = null
+        io.micronaut.http.HttpResponse<String> response = null
+        try {
+            response = httpClient.toBlocking().exchange(
+                    HttpRequest.GET('/external-api/safe/fail').accept(MediaType.APPLICATION_JSON),
+                    String
+            )
+        } catch (io.micronaut.http.client.exceptions.HttpClientResponseException ex) {
+            caught = ex
+        }
+
+        then: 'the Grails controller propagates the error status from the ersatz mock'
+        caught != null || response?.status?.code == 500
+
+        and: 'ersatz confirms it served the error response'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: ersatz mocks different responses for sequential calls"() {
+        given: 'ersatz mocks two different resources'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/1', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"1","name":"first"}', ContentType.APPLICATION_JSON)
+                })
+            })
+            expect.GET('/micronaut-test/2', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{"id":"2","name":"second"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'fetching two different resources through the service'
+        def first = externalApiService.fetchById('1')
+        def second = externalApiService.fetchById('2')
+
+        then: 'each returns the correct mocked data from ersatz'
+        first.contains('first')
+        second.contains('second')
+        !first.contains('second')
+        !second.contains('first')
+
+        and: 'ersatz received both requests'
+        ersatz.verify()
+    }
+
+    void "full roundtrip: ersatz mocks empty response body"() {
+        given: 'ersatz mocks an endpoint returning 200 with an empty JSON object'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test/empty', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body('{}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'fetching the empty resource'
+        def result = externalApiService.fetchById('empty')
+
+        then: 'the empty JSON is returned'
+        result == '{}'
+
+        and: 'ersatz received the request'
+        ersatz.verify()
+    }
+
+    void "full roundtrip: ersatz mocks response with custom headers"() {
+        given: 'ersatz mocks an endpoint with custom response headers'
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.header('X-Custom-Header', 'ersatz-value')
+                    res.header('X-Request-Id', 'abc-123')
+                    res.body('{"headers":"present"}', ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        and: 'a low-level Micronaut HttpClient targeting ersatz directly'
+        def httpClient = HttpClient.create('http://localhost:19876'.toURL())
+
+        when: 'making a request to the ersatz server'
+        HttpResponse<String> response = httpClient.toBlocking().exchange(
+                HttpRequest.GET('/micronaut-test').accept(MediaType.APPLICATION_JSON),
+                String
+        )
+
+        then: 'the custom headers from ersatz are present in the response'
+        response.status.code == 200
+        response.header('X-Custom-Header') == 'ersatz-value'
+        response.header('X-Request-Id') == 'abc-123'
+        response.body() == '{"headers":"present"}'
+
+        and: 'ersatz received the request'
+        ersatz.verify()
+
+        cleanup:
+        httpClient.close()
+    }
+
+    void "full roundtrip: ersatz mocks large JSON response"() {
+        given: 'ersatz mocks an endpoint returning a large JSON array'
+        def largeArray = (1..50).collect { """{"id":"$it","name":"item-$it"}""" }.join(',')
+        def largeBody = "[$largeArray]"
+        ersatz.expectations({ expect ->
+            expect.GET('/micronaut-test', { req ->
+                req.called(1)
+                req.responder({ res ->
+                    res.code(200)
+                    res.body(largeBody, ContentType.APPLICATION_JSON)
+                })
+            })
+        })
+
+        when: 'fetching the large response through the service'
+        def result = externalApiService.fetchAll()
+
+        then: 'all 50 items are present'
+        result != null
+        result.contains('"id":"1"')
+        result.contains('"id":"50"')
+        result.contains('item-25')
+
+        and: 'ersatz received the request'
+        ersatz.verify()
+    }
+}

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautPluginBeanSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautPluginBeanSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut
+
+import com.example.grails.plugins.micronaut.PluginMessageProvider
+import com.example.grails.plugins.micronaut.PluginSingletonService
+import io.micronaut.context.ApplicationContext as MicronautApplicationContext
+import spock.lang.Specification
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext as SpringApplicationContext
+
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class MicronautPluginBeanSpec extends Specification {
+
+    @Autowired
+    SpringApplicationContext springContext
+
+    @Autowired
+    MicronautApplicationContext micronautContext
+
+    void "plugin-contributed @Singleton bean is available in Spring context"() {
+        when: 'looking up the plugin bean from the Spring context'
+        def service = springContext.getBean(PluginSingletonService)
+
+        then: 'the bean is found and functional'
+        service != null
+        service.pluginMessage == 'from-plugin-singleton'
+    }
+
+    void "plugin-contributed @Singleton bean is available in Micronaut context"() {
+        when: 'looking up the plugin bean from the Micronaut context'
+        def service = micronautContext.getBean(PluginSingletonService)
+
+        then: 'the bean is found and functional'
+        service != null
+        service.pluginMessage == 'from-plugin-singleton'
+    }
+
+    void "plugin-contributed @Singleton bean is a singleton instance"() {
+        when: 'retrieving the bean twice'
+        def first = springContext.getBean(PluginSingletonService)
+        def second = springContext.getBean(PluginSingletonService)
+
+        then: 'same instance is returned'
+        first.is(second)
+    }
+
+    void "plugin-contributed @Singleton bean is resolvable by its interface"() {
+        when: 'looking up the bean by its interface'
+        def provider = springContext.getBean(PluginMessageProvider)
+
+        then: 'the bean is found via the interface type'
+        provider != null
+        provider instanceof PluginSingletonService
+        provider.pluginMessage == 'from-plugin-singleton'
+    }
+
+    void "plugin-contributed bean is same instance in Spring and Micronaut contexts"() {
+        when: 'retrieving from both contexts'
+        def fromSpring = springContext.getBean(PluginSingletonService)
+        def fromMicronaut = micronautContext.getBean(PluginSingletonService)
+
+        then: 'they are the same singleton instance'
+        fromSpring.is(fromMicronaut)
+    }
+}

--- a/grails-test-examples/micronaut/src/main/groovy/bean/injection/AppConfig.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/bean/injection/AppConfig.groovy
@@ -16,22 +16,15 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+package bean.injection
 
-package micronaut
+import groovy.transform.CompileStatic
 
-class UrlMappings {
+import io.micronaut.context.annotation.ConfigurationProperties
 
-    static mappings = {
-        "/$controller/$action?/$id?(.$format)?"{
-            constraints {
-                // apply constraints here
-            }
-        }
+@ConfigurationProperties('app')
+@CompileStatic
+class AppConfig {
 
-        "/micronaut-test"(controller: 'micronautTest', action: 'index')
-
-        "/"(view:"/index")
-        "500"(view:'/error')
-        "404"(view:'/notFound')
-    }
+    String name
 }

--- a/grails-test-examples/micronaut/src/main/groovy/bean/injection/FactoryCreatedService.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/bean/injection/FactoryCreatedService.groovy
@@ -16,22 +16,12 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+package bean.injection
 
-package micronaut
+import groovy.transform.CompileStatic
 
-class UrlMappings {
+@CompileStatic
+class FactoryCreatedService {
 
-    static mappings = {
-        "/$controller/$action?/$id?(.$format)?"{
-            constraints {
-                // apply constraints here
-            }
-        }
-
-        "/micronaut-test"(controller: 'micronautTest', action: 'index')
-
-        "/"(view:"/index")
-        "500"(view:'/error')
-        "404"(view:'/notFound')
-    }
+    String name
 }

--- a/grails-test-examples/micronaut/src/main/groovy/bean/injection/ServiceFactory.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/bean/injection/ServiceFactory.groovy
@@ -20,10 +20,10 @@ package bean.injection
 
 import groovy.transform.CompileStatic
 
+import jakarta.inject.Singleton
+
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
-
-import jakarta.inject.Singleton
 
 @Factory
 @CompileStatic

--- a/grails-test-examples/micronaut/src/main/groovy/bean/injection/ServiceFactory.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/bean/injection/ServiceFactory.groovy
@@ -16,22 +16,22 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+package bean.injection
 
-package micronaut
+import groovy.transform.CompileStatic
 
-class UrlMappings {
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
 
-    static mappings = {
-        "/$controller/$action?/$id?(.$format)?"{
-            constraints {
-                // apply constraints here
-            }
-        }
+import jakarta.inject.Singleton
 
-        "/micronaut-test"(controller: 'micronautTest', action: 'index')
+@Factory
+@CompileStatic
+class ServiceFactory {
 
-        "/"(view:"/index")
-        "500"(view:'/error')
-        "404"(view:'/notFound')
+    @Bean
+    @Singleton
+    FactoryCreatedService factoryCreatedService() {
+        new FactoryCreatedService(name: 'factory-created')
     }
 }

--- a/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautAdvancedClient.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautAdvancedClient.groovy
@@ -1,0 +1,59 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut.client
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.CookieValue
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Head
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.annotation.Options
+import io.micronaut.http.annotation.Patch
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.annotation.Client
+
+@Client(id = 'grails-self')
+interface MicronautAdvancedClient {
+
+    @Patch('/micronaut-test/{id}')
+    String patch(@PathVariable String id, @Body String body)
+
+    @Get('/micronaut-test/search{?q,page}')
+    String search(@QueryValue String q, @QueryValue String page)
+
+    @Get('/micronaut-test/secure')
+    String secureEndpoint(@Header('Authorization') String authorization)
+
+    @Get('/micronaut-test/api-resource')
+    String withApiKey(@Header('X-Api-Key') String apiKey)
+
+    @Head('/micronaut-test')
+    HttpResponse<?> headCheck()
+
+    @Options('/micronaut-test')
+    HttpResponse<?> optionsCheck()
+
+    @Get('/micronaut-test/with-cookie')
+    String withCookie(@CookieValue('session') String sessionId)
+
+    @Get(value = '/micronaut-test/text', consumes = 'text/plain')
+    String getPlainText()
+}

--- a/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautFilteredClient.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautFilteredClient.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut.client
+
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.client.annotation.Client
+
+@Client(id = 'grails-self')
+interface MicronautFilteredClient {
+
+    @Get('/micronaut-test/filtered/data')
+    String getFilteredData()
+
+    @Get('/micronaut-test/filtered/details/{id}')
+    String getFilteredDetails(@PathVariable String id)
+}

--- a/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautHeaderClient.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautHeaderClient.groovy
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut.client
+
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.client.annotation.Client
+
+@Client(id = 'grails-self')
+@Header(name = 'X-App-Version', value = '2.0')
+interface MicronautHeaderClient {
+
+    @Get('/micronaut-test')
+    String index()
+
+    @Get('/micronaut-test/{id}')
+    String show(@PathVariable String id)
+}

--- a/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautPathClient.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautPathClient.groovy
@@ -1,0 +1,38 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut.client
+
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.annotation.Client
+
+@Client(id = 'grails-self', path = '/api/v1')
+interface MicronautPathClient {
+
+    @Get('/items')
+    String listItems()
+
+    @Get('/items/{id}')
+    String getItem(@PathVariable String id)
+
+    @Post('/items')
+    String createItem(@Body String body)
+}

--- a/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautReactiveClient.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautReactiveClient.groovy
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut.client
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.annotation.Client
+
+import java.util.concurrent.CompletableFuture
+
+@Client(id = 'grails-self')
+interface MicronautReactiveClient {
+
+    @Get('/micronaut-test/async')
+    CompletableFuture<String> getAsync()
+
+    @Post('/micronaut-test/async')
+    CompletableFuture<String> createAsync(@Body String body)
+
+    @Delete('/micronaut-test/async/{id}')
+    CompletableFuture<HttpResponse<?>> deleteAsync(@PathVariable String id)
+
+    @Post('/micronaut-test/fire-and-forget')
+    void fireAndForget(@Body String body)
+}

--- a/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautTestClient.groovy
+++ b/grails-test-examples/micronaut/src/main/groovy/micronaut/client/MicronautTestClient.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut.client
+
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+
+@Client(id = 'grails-self')
+interface MicronautTestClient {
+
+    @Get('/micronaut-test')
+    String index()
+}

--- a/grails-test-examples/micronaut/src/main/java/bean/injection/JavaMessageProvider.java
+++ b/grails-test-examples/micronaut/src/main/java/bean/injection/JavaMessageProvider.java
@@ -16,13 +16,8 @@
  */
 package bean.injection;
 
-import jakarta.inject.Singleton;
+public interface JavaMessageProvider {
 
-@Singleton
-public class JavaSingletonService implements JavaMessageProvider {
+    String getMessage();
 
-    @Override
-    public String getMessage() {
-        return "from-java-singleton";
-    }
 }

--- a/grails-test-examples/micronaut/src/main/java/bean/injection/JavaSingletonService.java
+++ b/grails-test-examples/micronaut/src/main/java/bean/injection/JavaSingletonService.java
@@ -18,7 +18,7 @@ package bean.injection;
 
 import jakarta.inject.Singleton;
 
-interface JavaMessageProvider {
+public interface JavaMessageProvider {
 
     String getMessage();
 

--- a/grails-test-examples/micronaut/src/main/java/bean/injection/JavaSingletonService.java
+++ b/grails-test-examples/micronaut/src/main/java/bean/injection/JavaSingletonService.java
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package bean.injection;
+
+import jakarta.inject.Singleton;
+
+interface JavaMessageProvider {
+
+    String getMessage();
+
+}
+
+@Singleton
+public class JavaSingletonService implements JavaMessageProvider {
+
+    @Override
+    public String getMessage() {
+        return "from-java-singleton";
+    }
+}

--- a/grails-test-examples/micronaut/src/main/java/micronaut/client/MicronautRetryableClient.java
+++ b/grails-test-examples/micronaut/src/main/java/micronaut/client/MicronautRetryableClient.java
@@ -1,0 +1,31 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut.client;
+
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.retry.annotation.Retryable;
+
+@Client(id = "grails-self")
+public interface MicronautRetryableClient {
+
+    @Get("/micronaut-test/retryable")
+    @Retryable(attempts = "3", delay = "50ms")
+    String getWithRetry();
+}

--- a/grails-test-examples/micronaut/src/main/java/micronaut/filter/AuthTokenClientFilter.java
+++ b/grails-test-examples/micronaut/src/main/java/micronaut/filter/AuthTokenClientFilter.java
@@ -1,0 +1,32 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package micronaut.filter;
+
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.ClientFilter;
+import io.micronaut.http.annotation.RequestFilter;
+
+@ClientFilter("/micronaut-test/filtered/**")
+public class AuthTokenClientFilter {
+
+    @RequestFilter
+    public void addAuthToken(MutableHttpRequest<?> request) {
+        request.header("X-Auth-Token", "auto-injected-token-123");
+    }
+}

--- a/grails-test-examples/plugins/issue-11767/build.gradle
+++ b/grails-test-examples/plugins/issue-11767/build.gradle
@@ -28,8 +28,8 @@ apply plugin: 'org.apache.grails.gradle.grails-plugin'
 
 dependencies {
     implementation platform(project(':grails-bom'))
-    implementation 'org.apache.grails:grails-micronaut'
     implementation 'org.apache.grails:grails-core'
+    implementation 'org.apache.grails:grails-micronaut'
 
     annotationProcessor platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
     annotationProcessor 'io.micronaut:micronaut-inject-java'

--- a/grails-test-examples/plugins/issue-11767/build.gradle
+++ b/grails-test-examples/plugins/issue-11767/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     implementation platform(project(':grails-bom'))
     implementation 'org.apache.grails:grails-micronaut'
     implementation 'org.apache.grails:grails-core'
+
+    annotationProcessor platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
+    annotationProcessor 'io.micronaut:micronaut-inject-java'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 }
 
 apply {

--- a/grails-test-examples/plugins/micronaut-singleton/build.gradle
+++ b/grails-test-examples/plugins/micronaut-singleton/build.gradle
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+plugins {
+    id 'org.apache.grails.buildsrc.properties'
+    id 'org.apache.grails.buildsrc.compile'
+}
+
+version = '0.1-SNAPSHOT'
+group = 'com.example.grails.plugins'
+
+apply plugin: 'org.apache.grails.gradle.grails-plugin'
+
+dependencies {
+    implementation platform(project(':grails-bom'))
+
+    api 'org.apache.grails:grails-dependencies-starter-web'
+    api 'org.apache.grails:grails-micronaut'
+    api 'jakarta.servlet:jakarta.servlet-api'
+
+    annotationProcessor platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")
+    annotationProcessor 'io.micronaut:micronaut-inject-java'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
+    testImplementation 'org.apache.grails:grails-testing-support-web'
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('gradle/grails-extension-gradle-config.gradle')
+}

--- a/grails-test-examples/plugins/micronaut-singleton/src/main/groovy/micronaut/singleton/MicronautSingletonGrailsPlugin.groovy
+++ b/grails-test-examples/plugins/micronaut-singleton/src/main/groovy/micronaut/singleton/MicronautSingletonGrailsPlugin.groovy
@@ -16,32 +16,13 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package micronaut.client
+package micronaut.singleton
 
-import io.micronaut.http.HttpResponse
-import io.micronaut.http.annotation.Body
-import io.micronaut.http.annotation.Delete
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.PathVariable
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Put
-import io.micronaut.http.client.annotation.Client
+import grails.plugins.Plugin
 
-@Client(id = 'grails-self')
-interface MicronautTestClient {
+class MicronautSingletonGrailsPlugin extends Plugin {
 
-    @Get('/micronaut-test')
-    String index()
-
-    @Post('/micronaut-test')
-    String create(@Body String body)
-
-    @Put('/micronaut-test/{id}')
-    String update(@PathVariable String id, @Body String body)
-
-    @Delete('/micronaut-test/{id}')
-    HttpResponse<?> delete(@PathVariable String id)
-
-    @Get('/micronaut-test/{id}')
-    String show(@PathVariable String id)
+    def grailsVersion = '7.0.0.SNAPSHOT > *'
+    def title = 'Micronaut Singleton'
+    def description = 'Test plugin providing a Micronaut @Singleton bean to verify cross-context bridge.'
 }

--- a/grails-test-examples/plugins/micronaut-singleton/src/main/java/com/example/grails/plugins/micronaut/PluginMessageProvider.java
+++ b/grails-test-examples/plugins/micronaut-singleton/src/main/java/com/example/grails/plugins/micronaut/PluginMessageProvider.java
@@ -1,0 +1,22 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.grails.plugins.micronaut;
+
+public interface PluginMessageProvider {
+
+    String getPluginMessage();
+}

--- a/grails-test-examples/plugins/micronaut-singleton/src/main/java/com/example/grails/plugins/micronaut/PluginSingletonService.java
+++ b/grails-test-examples/plugins/micronaut-singleton/src/main/java/com/example/grails/plugins/micronaut/PluginSingletonService.java
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.example.grails.plugins.micronaut;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class PluginSingletonService implements PluginMessageProvider {
+
+    @Override
+    public String getPluginMessage() {
+        return "from-plugin-singleton";
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -385,6 +385,7 @@ include(
         'grails-test-examples-issue-15228',
         'grails-test-examples-plugins-exploded',
         'grails-test-examples-plugins-issue-11767',
+        'grails-test-examples-plugins-micronaut-singleton',
         'grails-test-examples-cache',
         'grails-test-examples-scaffolding',
         'grails-test-examples-scaffolding-fields',
@@ -419,6 +420,7 @@ project(':grails-test-examples-issue-11767').projectDir = file('grails-test-exam
 project(':grails-test-examples-issue-15228').projectDir = file('grails-test-examples/issue-15228')
 project(':grails-test-examples-plugins-exploded').projectDir = file('grails-test-examples/plugins/exploded')
 project(':grails-test-examples-plugins-issue-11767').projectDir = file('grails-test-examples/plugins/issue-11767')
+project(':grails-test-examples-plugins-micronaut-singleton').projectDir = file('grails-test-examples/plugins/micronaut-singleton')
 project(':grails-test-examples-cache').projectDir = file('grails-test-examples/cache')
 project(':grails-test-examples-scaffolding').projectDir = file('grails-test-examples/scaffolding')
 project(':grails-test-examples-scaffolding-fields').projectDir = file('grails-test-examples/scaffolding-fields')

--- a/settings.gradle
+++ b/settings.gradle
@@ -377,6 +377,7 @@ include(
         'grails-test-examples-issue-11102',
         'grails-test-examples-demo33',
         'grails-test-examples-micronaut',
+        'grails-test-examples-micronaut-groovy-only',
         'grails-test-examples-plugins-loadfirst',
         'grails-test-examples-plugins-loadsecond',
         'grails-test-examples-plugins-loadafter',
@@ -412,6 +413,7 @@ project(':grails-test-examples-issue-views-182').projectDir = file('grails-test-
 project(':grails-test-examples-issue-11102').projectDir = file('grails-test-examples/issue-11102')
 project(':grails-test-examples-demo33').projectDir = file('grails-test-examples/demo33')
 project(':grails-test-examples-micronaut').projectDir = file('grails-test-examples/micronaut')
+project(':grails-test-examples-micronaut-groovy-only').projectDir = file('grails-test-examples/micronaut-groovy-only')
 project(':grails-test-examples-plugins-loadfirst').projectDir = file('grails-test-examples/plugins/loadfirst')
 project(':grails-test-examples-plugins-loadsecond').projectDir = file('grails-test-examples/plugins/loadsecond')
 project(':grails-test-examples-plugins-loadafter').projectDir = file('grails-test-examples/plugins/loadafter')


### PR DESCRIPTION
## Summary

Fixes two Micronaut integration bugs by automating configuration that previously required manual `build.gradle` setup, resolves a Forge CI failure caused by spring-boot-devtools incompatibility, and adds a Groovy-only test module proving annotation processors are auto-applied:

- **#15207** - `java -jar` broken for grails-micronaut apps due to Spring Boot 3.2+ default loader incompatibility
- **#15211** - Java `@Singleton` beans not registered when using Groovy incremental compilation (missing annotation processor)
- **Groovy-only validation** - New test module confirms `grails-micronaut` works without explicit `annotationProcessor` dependencies or Java source files

## Problem

### Issue #15207 - `java -jar` fails with `NoClassDefFoundError`

Spring Boot 3.2+ changed the default `LoaderImplementation` from `CLASSIC` to a new implementation. The new loader is incompatible with Micronaut-Spring's classpath scanning mechanism (`MicronautImportRegistrar`), causing `NoClassDefFoundError` at runtime when running a packaged JAR/WAR via `java -jar`.

### Issue #15211 - Java `@Singleton` beans silently ignored

Groovy sources use `micronaut-inject-groovy` AST transforms to generate `BeanDefinitionReference` classes. However, Java sources in a Grails project require the `micronaut-inject-java` annotation processor on the `annotationProcessor` configuration. Without it, Java beans annotated with `@Singleton`, `@Factory`, etc. are silently ignored - no compile error, just missing beans at runtime.

## Solution

### GrailsGradlePlugin (`configureMicronaut()`)

1. **Annotation processor** - Automatically adds `micronaut-inject-java` + `jakarta.annotation-api` to the `annotationProcessor` configuration, scoped to the Micronaut platform BOM. This only affects `compileJava` tasks (Groovy sources continue using AST transforms via `compileOnlyApi`).

2. **CLASSIC loader** - Configures `bootJar` and `bootWar` tasks with `LoaderImplementation.CLASSIC` as a convention default (overridable by users). This ensures `java -jar` works correctly with Micronaut-Spring's classpath scanning.

### Groovy-Only Micronaut Validation

New `grails-test-examples/micronaut-groovy-only/` module with **zero Java files** and **zero explicit `annotationProcessor` dependencies** proves that the Grails Gradle plugin auto-applies the required annotation processors when `grails-micronaut` is on the classpath. The Gradle output confirms: `Micronaut Support Detected for grails-test-examples-micronaut-groovy-only`.

### Forge

- Adds the missing `bootWar` CLASSIC loader configuration to match the existing `bootJar` configuration in Forge-generated `build.gradle` files.
- `SpringBootDevTools.shouldApply()` now returns `false` when `GrailsMicronaut` is selected, preventing the DefaultFeature from being auto-applied and triggering `GrailsMicronautValidator`'s incompatibility check.

### Housekeeping

- Adds Apache license header to `GrailsMicronautValidator.java`
- Replaces `// TODO:` with `// See:` to satisfy Forge checkstyle `TodoComment` rule

## Commits

| Commit | Description |
|--------|-------------|
| `fix: configure Micronaut annotation processor and CLASSIC loader` | Core fix - adds annotation processor for Java sources + CLASSIC loader convention for bootJar/bootWar |
| `fix: add bootWar CLASSIC loader to Forge-generated build.gradle` | Forge template parity - bootWar was missing CLASSIC loader config |
| `chore: add Apache license header to GrailsMicronautValidator` | License header + checkstyle compliance |
| `fix: exclude Spring Boot DevTools for Micronaut apps in Forge` | Prevents devtools auto-application for Micronaut apps |
| `docs: document Micronaut annotation processor and CLASSIC loader` | Upgrade guide notes |
| `Address PR review feedback` | Comprehensive ersatz tests, plugin @Singleton beans, docs updates |
| `Exhaustive ersatz integration tests for all Micronaut client patterns` | 43 new tests covering every client integration pattern |
| `test: add Groovy-only Micronaut test module` | New module validating grails-micronaut works without annotationProcessor deps or Java files |

## Test Coverage

**121 integration tests passing** across 13 specs in two test modules:

### `grails-test-examples-micronaut` (105 tests)

#### Ersatz-mocked HTTP client tests (70 tests)

| Spec | Tests | Coverage |
|------|-------|----------|
| `MicronautErsatzRoundtripSpec` | 17 | Full roundtrip: HTTP -> Grails controller -> service -> @Client -> ersatz. All CRUD operations, error handling, sequential responses, custom headers, large payloads |
| `MicronautErsatzAdvancedSpec` | 27 | Every HTTP method (GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS/ANY), @QueryValue, @Header (method + class-level), @CookieValue, Basic Auth, response cookies, plain text, XML, delayed responses, sequential responses (503->503->200), request listeners, call count verification, multi-client coexistence, service orchestration |
| `MicronautErsatzPatternSpec` | 16 | CompletableFuture<T> returns (GET/POST/DELETE), void return, @Client(path=) base path, @ClientFilter + @RequestFilter auto-header injection, @Retryable with sequential failure/success, bean resolution, full roundtrips for async/path/filtered patterns |
| `MicronautDeclarativeClientSpec` | 10 | Direct declarative client operations against ersatz |

#### Bean integration tests (35 tests)

| Spec | Tests | Coverage |
|------|-------|----------|
| `MicronautBeanDuplicationSpec` | 9 | No bean duplication, cross-context singleton identity |
| `MicronautQualifierSpec` | 7 | @Named, @Primary, collection injection |
| `MicronautContextSpec` | 6 | Context bridge, lifecycle, cross-context lookup |
| `MicronautBeanTypesSpec` | 5 | Java @Singleton, @Factory/@Bean, @ConfigurationProperties |
| `MicronautPluginBeanSpec` | 5 | Plugin-contributed @Singleton beans in Spring + Micronaut contexts |
| `BeanInjectionServiceSpec` | 3 | Micronaut bean injection into Grails services |

### `grails-test-examples-micronaut-groovy-only` (16 tests)

| Spec | Tests | Coverage |
|------|-------|----------|
| `BeanInjectionServiceSpec` | 3 | Micronaut bean injection into Grails services (Groovy-only) |
| `MicronautContextSpec` | 6 | Micronaut/Spring context coexistence, bean lookup, lifecycle (Groovy-only) |
| `MicronautQualifierSpec` | 7 | @Named, @Primary, custom @Qualified, collection injection (Groovy-only) |

This module has **no Java source files** and **no `annotationProcessor` dependencies** in its `build.gradle`. It validates the documentation claim that the Grails Gradle plugin automatically applies the required Micronaut annotation processors when `grails-micronaut` is present.

### Micronaut client patterns tested

| Pattern | Client Interface | Language |
|---------|-----------------|----------|
| @Get, @Post, @Put, @Delete, @PathVariable, @Body | `MicronautTestClient` | Groovy |
| @Patch, @QueryValue, @Header, @Head, @Options, @CookieValue, text/plain | `MicronautAdvancedClient` | Groovy |
| Class-level @Header (auto on all requests) | `MicronautHeaderClient` | Groovy |
| CompletableFuture<T>, void return type | `MicronautReactiveClient` | Groovy |
| @Client(id, path=) base path / API versioning | `MicronautPathClient` | Groovy |
| @ClientFilter + @RequestFilter auto-header injection | `AuthTokenClientFilter` + `MicronautFilteredClient` | Java + Groovy |
| @Retryable(attempts, delay) with AOP processing | `MicronautRetryableClient` | Java |

### Ersatz mock server features exercised

- Request matching: method, path, query params, headers, cookies, body
- Response config: status codes, JSON/text/XML bodies, headers, cookies, delays
- Sequential responses: different response per call (last repeats)
- Call count verification: exact count assertions
- Request listeners: capture and inspect request details
- Error simulation: 401, 403, 404, 429, 500, 502, 503

### Forge tests

**4 tests passing** in `SpringBootDevToolsSpec` - verifies devtools exclusion for Micronaut apps.

## Build Verification

| Project | Status |
|---------|--------|
| `grails-gradle` (plugins) | :white_check_mark: BUILD SUCCESSFUL |
| `grails-forge` (checkstyle) | :white_check_mark: BUILD SUCCESSFUL |
| `grails-doc` (guide) | :white_check_mark: BUILD SUCCESSFUL |
| `codeStyle` (main project) | :white_check_mark: BUILD SUCCESSFUL |
| `grails-test-examples-micronaut:integrationTest` | :white_check_mark: 105/105 PASSED |
| `grails-test-examples-micronaut-groovy-only:integrationTest` | :white_check_mark: 16/16 PASSED |

## Remaining Gaps (Out of Scope)

These are known limitations of the current Micronaut integration, not addressed by this PR:

- Groovy incremental compilation may re-trigger AST transforms on unchanged files (Groovy compiler limitation)
- No `bootRun` CLASSIC loader needed (only affects packaged archives)

Fixes #15207
Fixes #15211
Fixes #11599