### PR TITLE
docs: add comment explaining jakarta.servlet-api implementation scope in CLI

### DIFF
--- a/grails-shell-cli/build.gradle
+++ b/grails-shell-cli/build.gradle
@@ -61,6 +61,12 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-loader-tools'
     compileOnly 'org.springframework:spring-web'
     api 'org.springframework.boot:spring-boot-cli'
+    // Must be 'implementation' (not 'compileOnly') so the servlet API is included in the shadow JAR.
+    // grails-web-common registers HttpServletRequestExtension as a Groovy extension module, which is
+    // auto-discovered when GroovyScriptCommandFactory compiles custom scripts in src/main/scripts/.
+    // Without jakarta.servlet.ServletRequest on the runtime classpath, all grailsw commands fail with
+    // NoClassDefFoundError when custom scripts exist. The servlet API is also required by CLI commands
+    // such as create-controller, generate-all, and scaffolding that parse and generate web-layer code.
     implementation 'jakarta.servlet:jakarta.servlet-api'
     compileOnly "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
 


### PR DESCRIPTION
## Summary

- Add inline comment to `grails-shell-cli/build.gradle` explaining why `jakarta.servlet-api` uses `implementation` scope instead of `compileOnly`

## Context

Follow-up to #15392. The dependency scope change was reviewed with a question about the rationale (why not exclude the extension instead). This comment documents the answer directly in the build file so future contributors understand the constraint without needing to trace PR history.