### PR TITLE
test(ci): add indy matrix to functional test CI jobs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -136,11 +136,12 @@ jobs:
           -PonlyCoreTests
           -PskipCodeStyle
   buildForge:
-    name: "Build Grails Forge"
+    name: "Build Grails Forge (Java ${{ matrix.java }}, indy=${{ matrix.indy }})"
     strategy:
       fail-fast: false
       matrix:
         java: [ 17, 21 ]
+        indy: [ false, true ]
     runs-on: ubuntu-24.04
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
@@ -163,6 +164,7 @@ jobs:
           ./gradlew build
           --continue
           --stacktrace
+          -PgrailsIndy=${{ matrix.indy }}
           -PskipCodeStyle
           -PskipTests
       - name: "🔨 Build project with tests"
@@ -173,6 +175,7 @@ jobs:
           --continue
           --rerun-tasks
           --stacktrace
+          -PgrailsIndy=${{ matrix.indy }}
           -PskipCodeStyle
       - name: "✅ Verify combined CLI"
         run: |
@@ -183,7 +186,7 @@ jobs:
           ./tmp1/cli/bin/grails --version
           ./tmp1/cli/bin/grails-forge-cli --version
       - name: "📤 Upload CLI Zip to Workflow Summary Page"
-        if: ${{ matrix.java == '17' }}
+        if: ${{ matrix.java == '17' && matrix.indy == false }}
         uses: actions/upload-artifact@v6
         with:
           name: 'apache-grails-SNAPSHOT-bin.zip'
@@ -191,12 +194,13 @@ jobs:
           path: grails-forge/tmp1/cli/**/*
           if-no-files-found: 'error'
   functional:
-    name: "Functional Tests"
+    name: "Functional Tests (Java ${{ matrix.java }}, indy=${{ matrix.indy }})"
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     strategy:
       fail-fast: false
       matrix:
         java: [ 17, 21, 25 ]
+        indy: [ false, true ]
     runs-on: ubuntu-24.04
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
@@ -219,19 +223,21 @@ jobs:
           --rerun-tasks
           --stacktrace
           -PgebAtCheckWaiting
+          -PgrailsIndy=${{ matrix.indy }}
           -PonlyFunctionalTests
           -PskipCodeStyle
           -PskipHibernate5Tests
           -PskipMongodbTests
   mongodbFunctional:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
-    name: "Mongodb Functional Tests"
+    name: "Mongodb Functional Tests (Java ${{ matrix.java }}, MongoDB ${{ matrix.mongodb-version }}, indy=${{ matrix.indy }})"
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         java: [ 17, 25 ]
         mongodb-version: [ '7.0', '8.0' ] # test with supported versions https://www.mongodb.com/legal/support-policy/lifecycles
+        indy: [ false, true ]
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
         run: curl -s https://api.ipify.org
@@ -254,17 +260,19 @@ jobs:
           --continue
           --rerun-tasks
           --stacktrace
+          -PgrailsIndy=${{ matrix.indy }}
           -PonlyMongodbTests
           -PmongodbContainerVersion=${{ matrix.mongodb-version }}
           -PskipCodeStyle
   hibernate5Functional:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
-    name: "Hibernate5 Functional Tests"
+    name: "Hibernate5 Functional Tests (Java ${{ matrix.java }}, indy=${{ matrix.indy }})"
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         java: [ 17, 25 ]
+        indy: [ false, true ]
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
         run: curl -s https://api.ipify.org
@@ -287,6 +295,7 @@ jobs:
           --continue
           --rerun-tasks
           --stacktrace
+          -PgrailsIndy=${{ matrix.indy }}
           -PonlyHibernate5Tests
           -PskipCodeStyle
   publishGradle:

--- a/gradle/grails-extension-gradle-config.gradle
+++ b/gradle/grails-extension-gradle-config.gradle
@@ -31,4 +31,11 @@ grails {
     // this means you MUST publish locally via ./gradlew :grails-bom:publishMavenPublicationToLocalBomRepository
     // this causes unexpected version mismatches in the various plugin projects
     springDependencyManagement = false
+
+    // Allow CI to toggle Groovy invokedynamic (indy) via -PgrailsIndy=true
+    // This enables testing functional tests with both indy enabled and disabled.
+    // See: https://github.com/apache/grails-core/issues/15321
+    if (project.hasProperty('grailsIndy')) {
+        indy = Boolean.parseBoolean(project.property('grailsIndy') as String)
+    }
 }


### PR DESCRIPTION
## Summary

- Add `indy: [false, true]` matrix dimension to all functional test CI jobs to ensure Groovy invokedynamic is tested both enabled and disabled
- Add `-PgrailsIndy` property toggle to `grails-extension-gradle-config.gradle` so all 45 test example projects respect the CI matrix setting
- Include indy status in job names for clear CI dashboard visibility

## Context

PR #15375 moved indy configuration from generated `build.gradle` files to the Grails Gradle Plugin (`GrailsExtension.indy`, default: `false`). After that merge, CI was only testing with the default `indy=false`, leaving `indy=true` completely untested. If a user sets `grails { indy = true }`, we had zero CI coverage for that code path.

## Changes

### `gradle/grails-extension-gradle-config.gradle`
- Added conditional `indy` property toggle inside the `grails { }` block
- When `-PgrailsIndy=true` is passed, sets `grails { indy = true }` on all test example projects
- All 45 test example build files apply this config, so no per-project changes needed

### `.github/workflows/gradle.yml`
- **Functional Tests**: 3 Java versions x 2 indy = 6 jobs (was 3)
- **Hibernate5 Functional Tests**: 2 Java versions x 2 indy = 4 jobs (was 2)
- **MongoDB Functional Tests**: 2 Java versions x 2 MongoDB versions x 2 indy = 8 jobs (was 4)
- **Build Grails Forge**: 2 Java versions x 2 indy = 4 jobs (was 2)
- Job names now include `indy=true/false` for dashboard clarity

## Note on Forge Tests

The forge `test-core` tests use Gradle TestKit, which creates an isolated build environment. The generated apps resolve the Grails Gradle plugin from Maven repositories rather than the local composite build, so the `-PgrailsIndy` property is passed to the forge build itself. Full end-to-end indy coverage for forge-generated apps would require additional work to inject `grails { indy = true }` into the Rocker template or TestKit configuration.

Relates to #15321, follow-up to #15375