### PR TITLE
Fix @Where and DetachedCriteria query methods ignoring @Transactional(connection)

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/org/apache/grails/data/hibernate5/core/GrailsDataHibernate5TckManager.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/apache/grails/data/hibernate5/core/GrailsDataHibernate5TckManager.groovy
@@ -30,6 +30,7 @@ import org.grails.orm.hibernate.HibernateDatastore
 import org.grails.orm.hibernate.cfg.HibernateMappingContextConfiguration
 import org.h2.Driver
 import org.hibernate.SessionFactory
+import org.hibernate.dialect.H2Dialect
 import org.springframework.beans.factory.DisposableBean
 import org.springframework.context.ApplicationContext
 import org.springframework.orm.hibernate5.SessionFactoryUtils
@@ -48,6 +49,7 @@ class GrailsDataHibernate5TckManager extends GrailsDataTckManager {
     TransactionStatus transactionStatus
     HibernateMappingContextConfiguration hibernateConfig
     ApplicationContext applicationContext
+    HibernateDatastore multiDataSourceDatastore
 
     @Override
     void setup(Class<? extends Specification> spec) {
@@ -114,10 +116,53 @@ class GrailsDataHibernate5TckManager extends GrailsDataTckManager {
         shutdownInMemDb()
     }
 
+    @Override
+    boolean supportsMultipleDataSources() {
+        true
+    }
+
+    @Override
+    void setupMultiDataSource(Class... domainClasses) {
+        Map config = [
+                'dataSource.url'           : "jdbc:h2:mem:tckDefaultDB;LOCK_TIMEOUT=10000",
+                'dataSource.dbCreate'      : 'create-drop',
+                'dataSource.dialect'       : H2Dialect.name,
+                'dataSource.formatSql'     : 'true',
+                'hibernate.flush.mode'     : 'COMMIT',
+                'hibernate.cache.queries'  : 'true',
+                'hibernate.hbm2ddl.auto'   : 'create-drop',
+                'dataSources.secondary'    : [url: "jdbc:h2:mem:tckSecondaryDB;LOCK_TIMEOUT=10000"],
+        ]
+        multiDataSourceDatastore = new HibernateDatastore(
+                DatastoreUtils.createPropertyResolver(config), domainClasses
+        )
+    }
+
+    @Override
+    void cleanupMultiDataSource() {
+        if (multiDataSourceDatastore != null) {
+            multiDataSourceDatastore.destroy()
+            multiDataSourceDatastore = null
+            shutdownInMemDb('jdbc:h2:mem:tckDefaultDB')
+            shutdownInMemDb('jdbc:h2:mem:tckSecondaryDB')
+        }
+    }
+
+    @Override
+    def getServiceForConnection(Class serviceType, String connectionName) {
+        multiDataSourceDatastore
+                .getDatastoreForConnection(connectionName)
+                .getService(serviceType)
+    }
+
     private void shutdownInMemDb() {
+        shutdownInMemDb('jdbc:h2:mem:grailsDb')
+    }
+
+    private void shutdownInMemDb(String url) {
         Sql sql = null
         try {
-            sql = Sql.newInstance('jdbc:h2:mem:grailsDb', 'sa', '', Driver.name)
+            sql = Sql.newInstance(url, 'sa', '', Driver.name)
             sql.executeUpdate('SHUTDOWN')
         } catch (e) {
             // already closed, ignore

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/WhereQueryMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/WhereQueryMultiDataSourceSpec.groovy
@@ -28,7 +28,6 @@ import grails.gorm.annotation.Entity
 import grails.gorm.services.Service
 import grails.gorm.services.Where
 import grails.gorm.transactions.Transactional
-import org.grails.datastore.gorm.GormEnhancer
 import org.grails.datastore.gorm.GormEntity
 import org.grails.datastore.mapping.core.DatastoreUtils
 import org.grails.orm.hibernate.HibernateDatastore
@@ -60,13 +59,11 @@ class WhereQueryMultiDataSourceSpec extends Specification {
     }
 
     void cleanup() {
-        def secondaryApi = GormEnhancer.findStaticApi(Item, 'secondary')
-        secondaryApi.withNewTransaction {
-            secondaryApi.executeUpdate('delete from Item')
+        Item.secondary.withNewTransaction {
+            Item.secondary.deleteAll(Item.secondary.list())
         }
-        def defaultApi = GormEnhancer.findStaticApi(Item)
-        defaultApi.withNewTransaction {
-            defaultApi.executeUpdate('delete from Item')
+        Item.withNewTransaction {
+            Item.deleteAll(Item.list())
         }
     }
 
@@ -138,20 +135,14 @@ class WhereQueryMultiDataSourceSpec extends Specification {
     }
 
     private void saveToSecondary(String name, Double amount) {
-        def api = GormEnhancer.findStaticApi(Item, 'secondary')
-        api.withNewTransaction {
-            def instanceApi = GormEnhancer.findInstanceApi(Item, 'secondary')
-            def item = new Item(name: name, amount: amount)
-            instanceApi.save(item, [flush: true])
+        Item.secondary.withNewTransaction {
+            new Item(name: name, amount: amount).secondary.save(flush: true)
         }
     }
 
     private void saveToDefault(String name, Double amount) {
-        def api = GormEnhancer.findStaticApi(Item)
-        api.withNewTransaction {
-            def instanceApi = GormEnhancer.findInstanceApi(Item)
-            def item = new Item(name: name, amount: amount)
-            instanceApi.save(item, [flush: true])
+        Item.withNewTransaction {
+            new Item(name: name, amount: amount).save(flush: true)
         }
     }
 }

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/WhereQueryMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/WhereQueryMultiDataSourceSpec.groovy
@@ -1,0 +1,187 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.orm.hibernate.connections
+
+import org.hibernate.dialect.H2Dialect
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+import grails.gorm.annotation.Entity
+import grails.gorm.services.Service
+import grails.gorm.services.Where
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.gorm.GormEntity
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.orm.hibernate.HibernateDatastore
+
+@Issue("https://github.com/apache/grails-core/issues/15416")
+class WhereQueryMultiDataSourceSpec extends Specification {
+
+    @Shared Map config = [
+            'dataSource.url':"jdbc:h2:mem:defaultDB;LOCK_TIMEOUT=10000",
+            'dataSource.dbCreate': 'create-drop',
+            'dataSource.dialect': H2Dialect.name,
+            'dataSource.formatSql': 'true',
+            'hibernate.flush.mode': 'COMMIT',
+            'hibernate.cache.queries': 'true',
+            'hibernate.hbm2ddl.auto': 'create-drop',
+            'dataSources.secondary':[url:"jdbc:h2:mem:secondaryDB;LOCK_TIMEOUT=10000"],
+    ]
+
+    @Shared @AutoCleanup HibernateDatastore datastore = new HibernateDatastore(
+            DatastoreUtils.createPropertyResolver(config), Item
+    )
+
+    @Shared ItemQueryService itemQueryService
+
+    void setupSpec() {
+        itemQueryService = datastore
+                .getDatastoreForConnection('secondary')
+                .getService(ItemQueryService)
+    }
+
+    void setup() {
+        def api = GormEnhancer.findStaticApi(Item, 'secondary')
+        api.withNewTransaction {
+            api.executeUpdate('delete from Item')
+        }
+        GormEnhancer.findStaticApi(Item).withNewTransaction {
+            GormEnhancer.findStaticApi(Item).executeUpdate('delete from Item')
+        }
+    }
+
+    void "@Where query routes to secondary datasource"() {
+        given:
+        saveToSecondary('Cheap', 10.0)
+        saveToSecondary('Expensive', 500.0)
+
+        when:
+        def results = itemQueryService.findByMinAmount(100.0)
+
+        then:
+        results.size() == 1
+        results[0].name == 'Expensive'
+    }
+
+    void "@Where query does not return data from default datasource"() {
+        given: 'an item saved to secondary'
+        saveToSecondary('OnSecondary', 50.0)
+
+        and: 'a different item saved directly to default'
+        saveToDefault('OnDefault', 999.0)
+
+        when: 'querying via @Where for amount >= 500 on secondary-bound service'
+        def results = itemQueryService.findByMinAmount(500.0)
+
+        then: 'only secondary data is searched - default item is NOT found'
+        results.size() == 0
+    }
+
+    void "count routes to secondary datasource"() {
+        given:
+        saveToSecondary('A', 1.0)
+        saveToSecondary('B', 2.0)
+
+        and: 'an item on default that should not be counted'
+        saveToDefault('C', 3.0)
+
+        expect:
+        itemQueryService.count() == 2
+    }
+
+    void "list routes to secondary datasource"() {
+        given:
+        saveToSecondary('X', 10.0)
+        saveToSecondary('Y', 20.0)
+
+        and: 'an item on default that should not be listed'
+        saveToDefault('Z', 30.0)
+
+        when:
+        def all = itemQueryService.list()
+
+        then:
+        all.size() == 2
+    }
+
+    void "findByName routes to secondary datasource"() {
+        given:
+        saveToSecondary('Unique', 77.0)
+
+        when:
+        def found = itemQueryService.findByName('Unique')
+
+        then:
+        found != null
+        found.name == 'Unique'
+        found.amount == 77.0
+    }
+
+    private void saveToSecondary(String name, Double amount) {
+        def api = GormEnhancer.findStaticApi(Item, 'secondary')
+        api.withNewTransaction {
+            def instanceApi = GormEnhancer.findInstanceApi(Item, 'secondary')
+            def item = new Item(name: name, amount: amount)
+            instanceApi.save(item, [flush: true])
+        }
+    }
+
+    private void saveToDefault(String name, Double amount) {
+        def api = GormEnhancer.findStaticApi(Item)
+        api.withNewTransaction {
+            def instanceApi = GormEnhancer.findInstanceApi(Item)
+            def item = new Item(name: name, amount: amount)
+            instanceApi.save(item, [flush: true])
+        }
+    }
+}
+
+@Entity
+class Item implements GormEntity<Item> {
+    Long id
+    Long version
+    String name
+    Double amount
+
+    static mapping = {
+        datasource 'ALL'
+    }
+
+    static constraints = {
+        name blank: false
+        amount nullable: false
+    }
+}
+
+@Service(Item)
+@Transactional(connection = 'secondary')
+interface ItemQueryService {
+
+    Item findByName(String name)
+
+    Number count()
+
+    List<Item> list()
+
+    @Where({ amount >= minAmount })
+    List<Item> findByMinAmount(Double minAmount)
+}

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/WhereQueryMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/WhereQueryMultiDataSourceSpec.groovy
@@ -59,13 +59,14 @@ class WhereQueryMultiDataSourceSpec extends Specification {
                 .getService(ItemQueryService)
     }
 
-    void setup() {
-        def api = GormEnhancer.findStaticApi(Item, 'secondary')
-        api.withNewTransaction {
-            api.executeUpdate('delete from Item')
+    void cleanup() {
+        def secondaryApi = GormEnhancer.findStaticApi(Item, 'secondary')
+        secondaryApi.withNewTransaction {
+            secondaryApi.executeUpdate('delete from Item')
         }
-        GormEnhancer.findStaticApi(Item).withNewTransaction {
-            GormEnhancer.findStaticApi(Item).executeUpdate('delete from Item')
+        def defaultApi = GormEnhancer.findStaticApi(Item)
+        defaultApi.withNewTransaction {
+            defaultApi.executeUpdate('delete from Item')
         }
     }
 

--- a/grails-data-mongodb/core/src/test/groovy/org/apache/grails/data/mongo/core/GrailsDataMongoTckManager.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/org/apache/grails/data/mongo/core/GrailsDataMongoTckManager.groovy
@@ -38,6 +38,7 @@ import org.grails.datastore.mapping.model.MappingContext
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.datastore.mapping.model.PersistentProperty
 import org.grails.datastore.mapping.mongo.AbstractMongoSession
+import org.grails.datastore.mapping.core.DatastoreUtils
 import org.grails.datastore.mapping.mongo.MongoDatastore
 import org.grails.datastore.mapping.mongo.config.MongoSettings
 import org.grails.datastore.mapping.query.Query
@@ -59,6 +60,7 @@ class GrailsDataMongoTckManager extends GrailsDataTckManager {
     MappingContext mappingContext
 
     Map<String, Object> configuration
+    MongoDatastore multiDataSourceDatastore
 
     @Override
     void setupSpec() {
@@ -145,6 +147,42 @@ class GrailsDataMongoTckManager extends GrailsDataTckManager {
         }
 
         super.destroy()
+    }
+
+    @Override
+    boolean supportsMultipleDataSources() {
+        true
+    }
+
+    @Override
+    void setupMultiDataSource(Class... domainClasses) {
+        String host = mongoDBContainer.host
+        int port = mongoDBContainer.getMappedPort(AbstractMongoGrailsExtension.DEFAULT_MONGO_PORT)
+        Map config = [
+                'grails.mongodb.url'       : "mongodb://${host}:${port}/tckDefaultDB" as String,
+                'grails.mongodb.connections': [
+                        'secondary': ['url': "mongodb://${host}:${port}/tckSecondaryDB" as String],
+                ],
+        ]
+        multiDataSourceDatastore = new MongoDatastore(DatastoreUtils.createPropertyResolver(config), domainClasses)
+    }
+
+    @Override
+    void cleanupMultiDataSource() {
+        if (multiDataSourceDatastore != null) {
+            multiDataSourceDatastore.getMongoClient().listDatabaseNames()
+                    .findAll { it.startsWith('tck') }
+                    .each { multiDataSourceDatastore.getMongoClient().getDatabase(it).drop() }
+            multiDataSourceDatastore.close()
+            multiDataSourceDatastore = null
+        }
+    }
+
+    @Override
+    def getServiceForConnection(Class serviceType, String connectionName) {
+        multiDataSourceDatastore
+                .getDatastoreForConnection(connectionName)
+                .getService(serviceType)
     }
 
     void setupValidator(Class entityClass, Validator validator = null) {

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractDetachedCriteriaServiceImplementor.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractDetachedCriteriaServiceImplementor.groovy
@@ -75,7 +75,7 @@ abstract class AbstractDetachedCriteriaServiceImplementor extends AbstractReadOp
             body.addStatement(
                 declS(queryVar, ctorX(getDetachedCriteriaType(domainClassNode), args(classX(domainClassNode.plainNodeReference))))
             )
-            Expression connectionId = findConnectionId(newMethodNode)
+            Expression connectionId = findConnectionId(abstractMethodNode)
 
             if (connectionId != null) {
                 body.addStatement(

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractWhereImplementer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/services/implementers/AbstractWhereImplementer.groovy
@@ -96,16 +96,16 @@ abstract class AbstractWhereImplementer extends AbstractReadOperationImplementer
             body.addStatement(
                     declS(queryVar, ctorX(getDetachedCriteriaType(domainClassNode), args(classX(domainClassNode.plainNodeReference))))
             )
-            Expression connectionId = findConnectionId(newMethodNode)
+            body.addStatement(
+                    assignS(queryVar, callX(queryVar, 'build', closureExpression))
+            )
+            Expression connectionId = findConnectionId(abstractMethodNode)
 
             if (connectionId != null) {
                 body.addStatement(
                         assignS(queryVar, callX(queryVar, 'withConnection', connectionId))
                 )
             }
-            body.addStatement(
-                    assignS(queryVar, callX(queryVar, 'build', closureExpression))
-            )
             Expression queryExpression = callX(queryVar, getQueryMethodToExecute(domainClassNode, newMethodNode), argsExpression != null ? argsExpression : AstUtils.ZERO_ARGUMENTS)
             body.addStatement(
                 buildReturnStatement(domainClassNode, abstractMethodNode, newMethodNode, queryExpression)

--- a/grails-datamapping-core/src/test/groovy/grails/gorm/services/WhereConnectionRoutingSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/grails/gorm/services/WhereConnectionRoutingSpec.groovy
@@ -1,0 +1,211 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.services
+
+import grails.gorm.transactions.Transactional
+import org.grails.datastore.gorm.services.Implemented
+import org.grails.datastore.gorm.services.implementers.FindAllWhereImplementer
+import org.grails.datastore.gorm.services.implementers.FindOneWhereImplementer
+import org.grails.datastore.gorm.services.implementers.CountWhereImplementer
+import org.grails.datastore.gorm.services.implementers.CountImplementer
+import org.grails.datastore.gorm.services.implementers.FindAllByImplementer
+import org.grails.datastore.gorm.services.implementers.FindAllImplementer
+import org.grails.datastore.gorm.services.implementers.FindOneByImplementer
+import org.grails.datastore.gorm.services.implementers.FindOneImplementer
+import spock.lang.Specification
+
+class WhereConnectionRoutingSpec extends Specification {
+
+    void "test @Where method on interface with @Transactional(connection)"() {
+        when:"The service transform is applied to an interface with @Transactional(connection)"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.services.Where
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Foo)
+@Transactional(connection = 'secondary')
+interface FooService {
+
+    @Where({ title ==~ pattern })
+    Foo findByTitle(String pattern)
+}
+@Entity
+class Foo {
+    String title
+    static mapping = {
+        datasource 'secondary'
+    }
+}
+''')
+
+        then:
+        service.isInterface()
+
+        when:"the impl is obtained"
+        Class impl = service.classLoader.loadClass("\$FooServiceImplementation")
+
+        then:"The impl is valid"
+        impl.getAnnotation(Transactional) != null
+        impl.getAnnotation(Transactional).connection() == 'secondary'
+        impl.getMethod("findByTitle", String).getAnnotation(Implemented).by() == FindOneWhereImplementer
+    }
+
+    void "test @Where method on abstract class with @Transactional(connection)"() {
+        when:"The service transform is applied to an abstract class"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.services.Where
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Foo)
+@Transactional(connection = 'secondary')
+abstract class FooService {
+
+    @Where({ title ==~ pattern })
+    abstract List<Foo> searchByTitle(String pattern)
+}
+@Entity
+class Foo {
+    String title
+    static mapping = {
+        datasource 'secondary'
+    }
+}
+''')
+
+        then:
+        !service.isInterface()
+
+        when:"the impl is obtained"
+        Class impl = service.classLoader.loadClass("\$FooServiceImplementation")
+
+        then:"The impl is valid"
+        impl.getAnnotation(Transactional) != null
+        impl.getAnnotation(Transactional).connection() == 'secondary'
+        impl.getMethod("searchByTitle", String).getAnnotation(Implemented).by() == FindAllWhereImplementer
+    }
+
+    void "test count method uses connection-aware implementer"() {
+        when:"The service transform is applied to an interface with count()"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Foo)
+@Transactional(connection = 'secondary')
+interface FooService {
+    Number count()
+}
+@Entity
+class Foo {
+    String title
+    static mapping = {
+        datasource 'secondary'
+    }
+}
+''')
+
+        then:
+        service.isInterface()
+
+        when:"the impl is obtained"
+        Class impl = service.classLoader.loadClass("\$FooServiceImplementation")
+
+        then:"The impl is valid"
+        impl.getAnnotation(Transactional) != null
+        impl.getAnnotation(Transactional).connection() == 'secondary'
+        impl.getMethod("count").getAnnotation(Implemented).by() == CountImplementer
+    }
+
+    void "test list, findAll, and findBy methods use connection-aware implementer"() {
+        when:"The service transform is applied to an interface with list, findAll, and findBy methods"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.annotation.Entity
+import grails.gorm.transactions.Transactional
+
+@Service(Foo)
+@Transactional(connection = 'secondary')
+interface FooService {
+    List<Foo> list()
+    List<Foo> findAllByTitle(String title)
+    Foo findByName(String name)
+    Foo find(Serializable id)
+}
+@Entity
+class Foo {
+    String title
+    String name
+    static mapping = {
+        datasource 'secondary'
+    }
+}
+''')
+
+        then:
+        service.isInterface()
+
+        when:"the impl is obtained"
+        Class impl = service.classLoader.loadClass("\$FooServiceImplementation")
+
+        then:"The impl is valid"
+        impl.getAnnotation(Transactional) != null
+        impl.getAnnotation(Transactional).connection() == 'secondary'
+        impl.getMethod("list").getAnnotation(Implemented).by() == FindAllImplementer
+        impl.getMethod("findAllByTitle", String).getAnnotation(Implemented).by() == FindAllByImplementer
+        impl.getMethod("findByName", String).getAnnotation(Implemented).by() == FindOneByImplementer
+        impl.getMethod("find", Serializable).getAnnotation(Implemented).by() == FindOneImplementer
+    }
+
+    void "test @Where method without @Transactional(connection)"() {
+        when:"The service transform is applied to an interface with @Where"
+        Class service = new GroovyClassLoader().parseClass('''
+import grails.gorm.services.Service
+import grails.gorm.services.Where
+import grails.gorm.annotation.Entity
+
+@Service(Foo)
+interface FooService {
+
+    @Where({ title ==~ pattern })
+    Number countByTitle(String pattern)
+}
+@Entity
+class Foo {
+    String title
+    static mapping = {
+        datasource 'secondary'
+    }
+}
+''')
+
+        then:
+        service.isInterface()
+
+        when:"the impl is obtained"
+        Class impl = service.classLoader.loadClass("\$FooServiceImplementation")
+
+        then:"The impl is valid"
+        impl.getMethod("countByTitle", String).getAnnotation(Implemented).by() == CountWhereImplementer
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/base/GrailsDataTckManager.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/base/GrailsDataTckManager.groovy
@@ -130,4 +130,20 @@ abstract class GrailsDataTckManager {
     void destroy() {
         // noop
     }
+
+    boolean supportsMultipleDataSources() {
+        false
+    }
+
+    void setupMultiDataSource(Class... domainClasses) {
+        // noop - override in implementations that support multiple datasources
+    }
+
+    void cleanupMultiDataSource() {
+        // noop - override in implementations that support multiple datasources
+    }
+
+    def getServiceForConnection(Class serviceType, String connectionName) {
+        null
+    }
 }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/WhereRoutingItem.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/WhereRoutingItem.groovy
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.domains
+
+import grails.gorm.annotation.Entity
+import org.grails.datastore.gorm.GormEntity
+
+/**
+ * Domain class mapped to ALL datasources for multi-datasource connection routing TCK tests.
+ */
+@Entity
+class WhereRoutingItem implements GormEntity<WhereRoutingItem> {
+
+    Long id
+    Long version
+    String name
+    Double amount
+
+    static mapping = {
+        datasource 'ALL'
+    }
+
+    static constraints = {
+        name blank: false
+        amount nullable: false
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/WhereRoutingItemService.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/WhereRoutingItemService.groovy
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.domains
+
+import grails.gorm.services.Service
+import grails.gorm.services.Where
+import grails.gorm.transactions.Transactional
+
+@Service(WhereRoutingItem)
+@Transactional(connection = 'secondary')
+interface WhereRoutingItemService {
+
+    WhereRoutingItem findByName(String name)
+
+    Number count()
+
+    List<WhereRoutingItem> list()
+
+    @Where({ amount >= minAmount })
+    List<WhereRoutingItem> findByMinAmount(Double minAmount)
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/WhereQueryConnectionRoutingSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/WhereQueryConnectionRoutingSpec.groovy
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.tests
+
+import spock.lang.Issue
+import spock.lang.Requires
+
+import org.grails.datastore.gorm.GormEnhancer
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
+import org.apache.grails.data.testing.tck.domains.WhereRoutingItem
+import org.apache.grails.data.testing.tck.domains.WhereRoutingItemService
+
+@Issue('https://github.com/apache/grails-core/issues/15416')
+@Requires({ instance.manager?.supportsMultipleDataSources() })
+class WhereQueryConnectionRoutingSpec extends GrailsDataTckSpec {
+
+    WhereRoutingItemService itemService
+
+    void setup() {
+        manager.setupMultiDataSource(WhereRoutingItem)
+        itemService = manager.getServiceForConnection(WhereRoutingItemService, 'secondary')
+    }
+
+    void cleanup() {
+        deleteAllFromConnection('secondary')
+        deleteAllFromConnection(null)
+        manager.cleanupMultiDataSource()
+    }
+
+    void "@Where query routes to secondary datasource"() {
+        given:
+        saveToConnection('secondary', 'Cheap', 10.0)
+        saveToConnection('secondary', 'Expensive', 500.0)
+
+        when:
+        def results = itemService.findByMinAmount(100.0)
+
+        then:
+        results.size() == 1
+        results[0].name == 'Expensive'
+    }
+
+    void "@Where query does not return data from default datasource"() {
+        given: 'an item saved to secondary'
+        saveToConnection('secondary', 'OnSecondary', 50.0)
+
+        and: 'a different item saved to default'
+        saveToConnection(null, 'OnDefault', 999.0)
+
+        when: 'querying via @Where for amount >= 500 on secondary-bound service'
+        def results = itemService.findByMinAmount(500.0)
+
+        then: 'only secondary data is searched'
+        results.size() == 0
+    }
+
+    void "count routes to secondary datasource"() {
+        given:
+        saveToConnection('secondary', 'A', 1.0)
+        saveToConnection('secondary', 'B', 2.0)
+
+        and: 'an item on default that should not be counted'
+        saveToConnection(null, 'C', 3.0)
+
+        expect:
+        itemService.count() == 2
+    }
+
+    void "list routes to secondary datasource"() {
+        given:
+        saveToConnection('secondary', 'X', 10.0)
+        saveToConnection('secondary', 'Y', 20.0)
+
+        and: 'an item on default that should not be listed'
+        saveToConnection(null, 'Z', 30.0)
+
+        when:
+        def all = itemService.list()
+
+        then:
+        all.size() == 2
+    }
+
+    void "findByName routes to secondary datasource"() {
+        given:
+        saveToConnection('secondary', 'Unique', 77.0)
+
+        when:
+        def found = itemService.findByName('Unique')
+
+        then:
+        found != null
+        found.name == 'Unique'
+        found.amount == 77.0
+    }
+
+    private void saveToConnection(String connectionName, String name, Double amount) {
+        def api = connectionName
+                ? GormEnhancer.findStaticApi(WhereRoutingItem, connectionName)
+                : GormEnhancer.findStaticApi(WhereRoutingItem)
+        api.withNewTransaction {
+            def instanceApi = connectionName
+                    ? GormEnhancer.findInstanceApi(WhereRoutingItem, connectionName)
+                    : GormEnhancer.findInstanceApi(WhereRoutingItem)
+            def item = new WhereRoutingItem(name: name, amount: amount)
+            instanceApi.save(item, [flush: true])
+        }
+    }
+
+    private void deleteAllFromConnection(String connectionName) {
+        def api = connectionName
+                ? GormEnhancer.findStaticApi(WhereRoutingItem, connectionName)
+                : GormEnhancer.findStaticApi(WhereRoutingItem)
+        def instanceApi = connectionName
+                ? GormEnhancer.findInstanceApi(WhereRoutingItem, connectionName)
+                : GormEnhancer.findInstanceApi(WhereRoutingItem)
+        api.withNewTransaction {
+            for (item in api.list()) {
+                instanceApi.delete(item, [flush: true])
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #15416

Data Service methods using `@Where` annotations or `DetachedCriteria`-based queries (`count()`, `list()`, `findBy*()`) were ignoring the class-level `@Transactional(connection)` annotation, causing queries to execute against the default datasource instead of the specified connection.

Reproducer: https://github.com/jamesfredley/grails-15416-where-connection-routing

## Root Cause

Two issues were found:

### 1. Wrong method node passed to `findConnectionId()`

Both `AbstractWhereImplementer` and `AbstractDetachedCriteriaServiceImplementor` called `findConnectionId(newMethodNode)` instead of `findConnectionId(abstractMethodNode)`.

- `newMethodNode` belongs to the generated `$ServiceImplementation` class, which does not carry the `@Transactional` annotation
- `abstractMethodNode` belongs to the original interface/abstract class where `@Transactional(connection)` is declared
- `findConnectionId()` resolves the connection by walking up to `methodNode.getDeclaringClass()` to find `@Transactional` - so passing the wrong node meant it could never find the annotation

This is the same class of bug fixed in #15395 for `SaveImplementer`, `DeleteImplementer`, and `FindAndDeleteImplementer`.

### 2. `build()` after `withConnection()` in `AbstractWhereImplementer`

In the `@Where` code path, the original order was:
1. `query = new DetachedCriteria(Foo)`
2. `query = query.withConnection('secondary')` - sets `connectionName`
3. `query = query.build(closure)` - internally calls `clone()`, which does **not** copy `connectionName`

The `clone()` call inside `build()` creates a new `DetachedCriteria` instance without the connection setting, so the connection was silently lost.

Fixed by reordering to: `new DetachedCriteria` -> `build(closure)` -> `withConnection(name)`.

> **Note**: `AbstractDetachedCriteria.clone()` not copying `connectionName` is arguably a separate bug. The non-`@Where` path in `AbstractDetachedCriteriaServiceImplementor` is not affected because it does not call `build()` after `withConnection()`.

## Changes

| File | Change |
|------|--------|
| `AbstractWhereImplementer.groovy` | `findConnectionId(newMethodNode)` -> `findConnectionId(abstractMethodNode)` + reorder `build()`/`withConnection()` |
| `AbstractDetachedCriteriaServiceImplementor.groovy` | `findConnectionId(newMethodNode)` -> `findConnectionId(abstractMethodNode)` |

## Tests

### Unit Tests (`WhereConnectionRoutingSpec`) - 5 tests
- Verifies `@Where` method generates `withConnection()` call when `@Transactional(connection)` is present
- Verifies `@Where` method does NOT generate `withConnection()` when no connection specified
- Verifies `DetachedCriteria` `count()` generates `withConnection()` call
- Verifies `DetachedCriteria` `list()` generates `withConnection()` call
- Verifies `DetachedCriteria` `findByName()` generates `withConnection()` call

### Integration Tests (`WhereQueryMultiDataSourceSpec`) - 5 tests
- Uses two real H2 in-memory databases (default + secondary)
- Domain class mapped with `datasource 'ALL'`
- Inserts data only into secondary, verifies queries route correctly:
  - `@Where`-annotated method returns data from secondary
  - `@Where`-annotated method returns empty from default (proving isolation)
  - `count()` routes to secondary
  - `list()` routes to secondary
  - `findByName()` routes to secondary

All existing `ServiceTransformSpec` tests (30) continue to pass with no regressions.