### PR TITLE
test: add @Query Data Service connection routing tests

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
@@ -421,10 +421,15 @@ abstract class ProductService {
 
     abstract List<Product> findAllByName(String name)
 
+    /**
+     * Constructor-style save - GORM creates the entity from parameters.
+     * Tests that SaveImplementer routes multi-arg saves through connection-aware API.
+     */
     abstract Product saveProduct(String name, Integer amount)
 
     @Query("from ${Product p} where $p.name = $name")
     abstract Product findOneByQuery(String name)
+
 
     @Query("from ${Product p} where $p.amount >= $minAmount")
     abstract List<Product> findAllByQuery(Integer minAmount)
@@ -433,6 +438,11 @@ abstract class ProductService {
     abstract Number updateAmountByName(String name, Integer newAmount)
 }
 
+/**
+ * Interface-only Data Service pattern.
+ * Verifies that connection routing works identically whether the service
+ * is declared as an interface or an abstract class.
+ */
 @Service(Product)
 @Transactional(connection = 'books')
 interface ProductDataService {

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/DataServiceMultiDataSourceSpec.groovy
@@ -24,6 +24,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 import grails.gorm.annotation.Entity
+import grails.gorm.services.Query
 import grails.gorm.services.Service
 import grails.gorm.transactions.Transactional
 import org.grails.datastore.gorm.GormEnhancer
@@ -298,6 +299,93 @@ class DataServiceMultiDataSourceSpec extends Specification {
         productService.count() == productDataService.count()
     }
 
+    void "@Query find-one routes to books datasource - abstract service"() {
+        given: 'a product saved on books'
+        productService.save(new Product(name: 'QueryOne', amount: 50))
+
+        when: 'we find one by HQL query'
+        def found = productService.findOneByQuery('QueryOne')
+
+        then: 'the correct entity is returned from books'
+        found != null
+        found.name == 'QueryOne'
+        found.amount == 50
+    }
+
+    void "@Query find-one returns null for non-existent - abstract service"() {
+        expect: 'null for non-existent product'
+        productService.findOneByQuery('NonExistent') == null
+    }
+
+    void "@Query find-all routes to books datasource - abstract service"() {
+        given: 'products saved on books with varying amounts'
+        productService.save(new Product(name: 'Expensive1', amount: 500))
+        productService.save(new Product(name: 'Expensive2', amount: 600))
+        productService.save(new Product(name: 'Cheap1', amount: 10))
+
+        when: 'we find all by HQL query with threshold'
+        def found = productService.findAllByQuery(400)
+
+        then: 'only matching products from books are returned'
+        found.size() == 2
+        found*.name.containsAll(['Expensive1', 'Expensive2'])
+    }
+
+    void "@Query update routes to books datasource - abstract service"() {
+        given: 'a product saved on books'
+        productService.save(new Product(name: 'UpdateTarget', amount: 100))
+
+        when: 'we update amount by HQL query'
+        def updated = productService.updateAmountByName('UpdateTarget', 999)
+
+        then: 'one row updated'
+        updated == 1
+
+        and: 'the change is reflected on books'
+        productService.findByName('UpdateTarget').amount == 999
+    }
+
+    void "@Query find-one routes to books datasource - interface service"() {
+        given: 'a product saved on books'
+        productService.save(new Product(name: 'InterfaceQueryOne', amount: 75))
+
+        when: 'we find one by HQL query through the interface service'
+        def found = productDataService.findOneByQuery('InterfaceQueryOne')
+
+        then: 'the correct entity is returned from books'
+        found != null
+        found.name == 'InterfaceQueryOne'
+        found.amount == 75
+    }
+
+    void "@Query find-all routes to books datasource - interface service"() {
+        given: 'products saved on books'
+        productService.save(new Product(name: 'IfaceExpensive1', amount: 500))
+        productService.save(new Product(name: 'IfaceExpensive2', amount: 600))
+        productService.save(new Product(name: 'IfaceCheap1', amount: 10))
+
+        when: 'we find all by HQL query through the interface service'
+        def found = productDataService.findAllByQuery(400)
+
+        then: 'only matching products from books are returned'
+        found.size() == 2
+        found*.name.containsAll(['IfaceExpensive1', 'IfaceExpensive2'])
+    }
+
+    void "@Query update routes to books datasource - interface service"() {
+        given: 'a product saved on books'
+        productService.save(new Product(name: 'InterfaceUpdate', amount: 100))
+
+        when: 'we update amount by HQL query through the interface service'
+        def updated = productDataService.updateAmountByName('InterfaceUpdate', 888)
+
+        then: 'one row updated'
+        updated == 1
+
+        and: 'the change is reflected on books'
+        productDataService.findByName('InterfaceUpdate').amount == 888
+    }
+
 }
 
 @Entity
@@ -333,18 +421,18 @@ abstract class ProductService {
 
     abstract List<Product> findAllByName(String name)
 
-    /**
-     * Constructor-style save - GORM creates the entity from parameters.
-     * Tests that SaveImplementer routes multi-arg saves through connection-aware API.
-     */
     abstract Product saveProduct(String name, Integer amount)
+
+    @Query("from ${Product p} where $p.name = $name")
+    abstract Product findOneByQuery(String name)
+
+    @Query("from ${Product p} where $p.amount >= $minAmount")
+    abstract List<Product> findAllByQuery(Integer minAmount)
+
+    @Query("update ${Product p} set $p.amount = $newAmount where $p.name = $name")
+    abstract Number updateAmountByName(String name, Integer newAmount)
 }
 
-/**
- * Interface-only Data Service pattern.
- * Verifies that connection routing works identically whether the service
- * is declared as an interface or an abstract class.
- */
 @Service(Product)
 @Transactional(connection = 'books')
 interface ProductDataService {
@@ -362,4 +450,13 @@ interface ProductDataService {
     Product findByName(String name)
 
     List<Product> findAllByName(String name)
+
+    @Query("from ${Product p} where $p.name = $name")
+    Product findOneByQuery(String name)
+
+    @Query("from ${Product p} where $p.amount >= $minAmount")
+    List<Product> findAllByQuery(Integer minAmount)
+
+    @Query("update ${Product p} set $p.amount = $newAmount where $p.name = $name")
+    Number updateAmountByName(String name, Integer newAmount)
 }

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/services/example/ProductService.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/services/example/ProductService.groovy
@@ -23,6 +23,14 @@ import grails.gorm.services.Query
 import grails.gorm.services.Service
 import grails.gorm.transactions.Transactional
 
+/**
+ * GORM Data Service for the Product domain, routed to the 'secondary'
+ * datasource via @Transactional(connection).
+ *
+ * All auto-implemented methods (save, get, delete, findByName, count)
+ * should route through the connection-aware GormEnhancer APIs rather
+ * than falling through to the default datasource.
+ */
 @Service(Product)
 @Transactional(connection = 'secondary')
 abstract class ProductService {

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/services/example/ProductService.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/services/example/ProductService.groovy
@@ -19,17 +19,10 @@
 
 package example
 
+import grails.gorm.services.Query
 import grails.gorm.services.Service
 import grails.gorm.transactions.Transactional
 
-/**
- * GORM Data Service for the Product domain, routed to the 'secondary'
- * datasource via @Transactional(connection).
- *
- * All auto-implemented methods (save, get, delete, findByName, count)
- * should route through the connection-aware GormEnhancer APIs rather
- * than falling through to the default datasource.
- */
 @Service(Product)
 @Transactional(connection = 'secondary')
 abstract class ProductService {
@@ -45,4 +38,13 @@ abstract class ProductService {
     abstract Product findByName(String name)
 
     abstract List<Product> findAllByName(String name)
+
+    @Query("from ${Product p} where $p.name = $name")
+    abstract Product findOneByQuery(String name)
+
+    @Query("from ${Product p} where $p.amount >= $minAmount")
+    abstract List<Product> findAllByQuery(Integer minAmount)
+
+    @Query("update ${Product p} set $p.amount = $newAmount where $p.name = $name")
+    abstract Number updateAmountByName(String name, Integer newAmount)
 }

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/src/integration-test/groovy/functionaltests/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/src/integration-test/groovy/functionaltests/DataServiceMultiDataSourceSpec.groovy
@@ -27,6 +27,19 @@ import grails.testing.mixin.integration.Integration
 import org.grails.orm.hibernate.HibernateDatastore
 import spock.lang.Specification
 
+/**
+ * Integration test verifying that GORM Data Service auto-implemented
+ * CRUD methods (save, get, delete, findByName, count) route correctly
+ * to a non-default datasource when @Transactional(connection) is
+ * specified on the service.
+ *
+ * Product is mapped exclusively to the 'secondary' datasource.
+ * Without the connection-routing fix, auto-implemented save/get/delete
+ * would use the default datasource where no Product table exists.
+ *
+ * The service is obtained from the secondary child datastore
+ * (not auto-wired by Spring) to ensure proper session binding.
+ */
 @Integration
 class DataServiceMultiDataSourceSpec extends Specification {
 

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/src/integration-test/groovy/functionaltests/DataServiceMultiDataSourceSpec.groovy
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/src/integration-test/groovy/functionaltests/DataServiceMultiDataSourceSpec.groovy
@@ -27,19 +27,6 @@ import grails.testing.mixin.integration.Integration
 import org.grails.orm.hibernate.HibernateDatastore
 import spock.lang.Specification
 
-/**
- * Integration test verifying that GORM Data Service auto-implemented
- * CRUD methods (save, get, delete, findByName, count) route correctly
- * to a non-default datasource when @Transactional(connection) is
- * specified on the service.
- *
- * Product is mapped exclusively to the 'secondary' datasource.
- * Without the connection-routing fix, auto-implemented save/get/delete
- * would use the default datasource where no Product table exists.
- *
- * The service is obtained from the secondary child datastore
- * (not auto-wired by Spring) to ensure proper session binding.
- */
 @Integration
 class DataServiceMultiDataSourceSpec extends Specification {
 
@@ -130,5 +117,51 @@ class DataServiceMultiDataSourceSpec extends Specification {
         then:
         found.size() == 2
         found.every { it.name == 'Duplicate' }
+    }
+
+    void "@Query find-one routes to secondary datasource"() {
+        given:
+        productService.save(new Product(name: 'QueryOne', amount: 50))
+
+        when:
+        def found = productService.findOneByQuery('QueryOne')
+
+        then:
+        found != null
+        found.name == 'QueryOne'
+        found.amount == 50
+    }
+
+    void "@Query find-one returns null for non-existent"() {
+        expect:
+        productService.findOneByQuery('NonExistent') == null
+    }
+
+    void "@Query find-all routes to secondary datasource"() {
+        given:
+        productService.save(new Product(name: 'Expensive1', amount: 500))
+        productService.save(new Product(name: 'Expensive2', amount: 600))
+        productService.save(new Product(name: 'Cheap1', amount: 10))
+
+        when:
+        def found = productService.findAllByQuery(400)
+
+        then:
+        found.size() == 2
+        found*.name.containsAll(['Expensive1', 'Expensive2'])
+    }
+
+    void "@Query update routes to secondary datasource"() {
+        given:
+        productService.save(new Product(name: 'UpdateTarget', amount: 100))
+
+        when:
+        def updated = productService.updateAmountByName('UpdateTarget', 999)
+
+        then:
+        updated == 1
+
+        and:
+        productService.findByName('UpdateTarget').amount == 999
     }
 }


### PR DESCRIPTION
## Summary
- Add unit and functional tests for `@Query`-annotated Data Service methods routing to non-default datasources via `@Transactional(connection)`
- Tests cover `FindOneStringQueryImplementer`, `FindAllStringQueryImplementer`, and `UpdateStringQueryImplementer` - previously untested code paths
- Both abstract class and interface service patterns are tested

## Changes
- **Unit test** (`DataServiceMultiDataSourceSpec` in `grails-data-hibernate5-core`): 7 new tests covering `@Query` find-one, find-all, and update for both abstract and interface services
- **Functional test** (`DataServiceMultiDataSourceSpec` in `grails-test-examples`): 4 new integration tests covering `@Query` find-one, find-all, and update in a full Grails application context

## Test Results
- Unit: 23/23 pass (16 existing + 7 new)
- Functional: 10/10 pass (6 existing + 4 new)
- `codeStyle`: pass

## Context
During the exhaustive bug pattern sweep for connection routing issues (#15395, #15416), we identified that `findStaticApiForConnectionId(domainClassNode, newMethodNode)` in the 3 String Query implementers had no test coverage for multi-datasource routing. Investigation confirmed the pattern works correctly via the declaring-class fallback in `TransactionalTransform.findTransactionalAnnotation()`, but the code paths lacked regression tests.