### PR TITLE
fix: extend OSIV to manage sessions for all datasources

### DIFF
--- a/grails-data-hibernate5/grails-plugin/build.gradle
+++ b/grails-data-hibernate5/grails-plugin/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation 'org.spockframework:spock-core'
+    testImplementation 'jakarta.servlet:jakarta.servlet-api'
 
     testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.apache.tomcat:tomcat-jdbc'

--- a/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
+++ b/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
@@ -61,10 +61,12 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
      * that needs OSIV session management.
      */
     private static class AdditionalSessionFactoryConfig {
+        final String connectionName;
         final SessionFactory sessionFactory;
         final FlushMode flushMode;
 
-        AdditionalSessionFactoryConfig(SessionFactory sessionFactory, FlushMode flushMode) {
+        AdditionalSessionFactoryConfig(String connectionName, SessionFactory sessionFactory, FlushMode flushMode) {
+            this.connectionName = connectionName;
             this.sessionFactory = sessionFactory;
             this.flushMode = flushMode;
         }
@@ -91,7 +93,7 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
                 continue;
             }
             if (logger.isDebugEnabled()) {
-                logger.debug("Opening additional Hibernate Session for datasource in OpenSessionInViewInterceptor");
+                logger.debug("Opening additional Hibernate Session for datasource '" + config.connectionName + "' in OpenSessionInViewInterceptor");
             }
             Session session = sf.openSession();
             session.setHibernateFlushMode(config.flushMode);
@@ -131,7 +133,7 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
                     boolean additionalIsNotManual = additionalFlushMode != FlushMode.MANUAL && additionalFlushMode != FlushMode.COMMIT;
                     if (additionalIsNotManual) {
                         if (logger.isDebugEnabled()) {
-                            logger.debug("Eagerly flushing additional Hibernate session");
+                            logger.debug("Eagerly flushing additional Hibernate session for datasource '" + config.connectionName + "'");
                         }
                         additionalSession.flush();
                     }
@@ -154,13 +156,13 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
                     Session session = sessionHolder.getSession();
                     TransactionSynchronizationManager.unbindResource(sf);
                     if (logger.isDebugEnabled()) {
-                        logger.debug("Closing additional Hibernate Session in OpenSessionInViewInterceptor");
+                        logger.debug("Closing additional Hibernate Session for datasource '" + config.connectionName + "' in OpenSessionInViewInterceptor");
                     }
                     try {
                         SessionFactoryUtils.closeSession(session);
                     }
                     catch (RuntimeException closeEx) {
-                        logger.error("Unexpected exception on closing additional Hibernate Session", closeEx);
+                        logger.error("Unexpected exception on closing additional Hibernate Session for datasource '" + config.connectionName + "'", closeEx);
                     }
                 }
             }
@@ -194,7 +196,7 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
                         childFlushMode = FlushMode.valueOf(childDatastore.getDefaultFlushModeName());
                     }
                     additionalSessionFactories.add(
-                            new AdditionalSessionFactoryConfig(childDatastore.getSessionFactory(), childFlushMode)
+                            new AdditionalSessionFactoryConfig(connectionName, childDatastore.getSessionFactory(), childFlushMode)
                     );
                 }
             }

--- a/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
+++ b/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
@@ -145,6 +145,9 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
                             firstFlushException = ex;
                         }
                         else {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Additional flush exception for datasource '" + config.connectionName + "'", ex);
+                            }
                             firstFlushException.addSuppressed(ex);
                         }
                     }

--- a/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
+++ b/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
@@ -18,22 +18,34 @@
  */
 package org.grails.plugin.hibernate.support;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hibernate.FlushMode;
 import org.hibernate.Session;
+import org.hibernate.SessionFactory;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.orm.hibernate5.SessionFactoryUtils;
 import org.springframework.orm.hibernate5.SessionHolder;
 import org.springframework.orm.hibernate5.support.OpenSessionInViewInterceptor;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.context.request.WebRequest;
 
+import org.grails.datastore.mapping.core.connections.ConnectionSource;
 import org.grails.orm.hibernate.AbstractHibernateDatastore;
+import org.grails.orm.hibernate.HibernateDatastore;
+import org.grails.orm.hibernate.connections.HibernateConnectionSourceSettings;
 
 /**
- * Extends the default spring OSIV and doesn't flush the session if it has been set
- * to MANUAL on the session itself.
+ * Extends the default Spring OSIV to support multiple datasources.
+ * <p>
+ * The default datasource's SessionFactory is managed by the parent class.
+ * Additional (non-default) datasource SessionFactories are managed by this
+ * subclass, which opens and closes sessions for each one alongside the
+ * default session.
  *
  * @author Graeme Rocher
  * @since 0.5
@@ -41,6 +53,22 @@ import org.grails.orm.hibernate.AbstractHibernateDatastore;
 public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterceptor {
 
     protected FlushMode hibernateFlushMode = FlushMode.MANUAL;
+
+    private final List<AdditionalSessionFactoryConfig> additionalSessionFactories = new ArrayList<>();
+
+    /**
+     * Holds configuration for an additional (non-default) SessionFactory
+     * that needs OSIV session management.
+     */
+    private static class AdditionalSessionFactoryConfig {
+        final SessionFactory sessionFactory;
+        final FlushMode flushMode;
+
+        AdditionalSessionFactoryConfig(SessionFactory sessionFactory, FlushMode flushMode) {
+            this.sessionFactory = sessionFactory;
+            this.flushMode = flushMode;
+        }
+    }
 
     @Override
     protected Session openSession() throws DataAccessResourceFailureException {
@@ -51,6 +79,25 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
 
     protected void applyFlushMode(Session session) {
         session.setHibernateFlushMode(hibernateFlushMode);
+    }
+
+    @Override
+    public void preHandle(WebRequest request) throws DataAccessException {
+        super.preHandle(request);
+
+        for (AdditionalSessionFactoryConfig config : additionalSessionFactories) {
+            SessionFactory sf = config.sessionFactory;
+            if (TransactionSynchronizationManager.hasResource(sf)) {
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("Opening additional Hibernate Session for datasource in OpenSessionInViewInterceptor");
+            }
+            Session session = sf.openSession();
+            session.setHibernateFlushMode(config.flushMode);
+            SessionHolder sessionHolder = new SessionHolder(session);
+            TransactionSynchronizationManager.bindResource(sf, sessionHolder);
+        }
     }
 
     @Override
@@ -73,6 +120,46 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
                 session.setHibernateFlushMode(FlushMode.MANUAL);
             }
         }
+
+        for (AdditionalSessionFactoryConfig config : additionalSessionFactories) {
+            SessionFactory sf = config.sessionFactory;
+            SessionHolder additionalHolder = (SessionHolder) TransactionSynchronizationManager.getResource(sf);
+            if (additionalHolder != null) {
+                Session additionalSession = additionalHolder.getSession();
+                try {
+                    FlushMode additionalFlushMode = additionalSession.getHibernateFlushMode();
+                    boolean additionalIsNotManual = additionalFlushMode != FlushMode.MANUAL && additionalFlushMode != FlushMode.COMMIT;
+                    if (additionalIsNotManual) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Eagerly flushing additional Hibernate session");
+                        }
+                        additionalSession.flush();
+                    }
+                }
+                finally {
+                    additionalSession.setHibernateFlushMode(FlushMode.MANUAL);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void afterCompletion(WebRequest request, Exception ex) throws DataAccessException {
+        for (int i = additionalSessionFactories.size() - 1; i >= 0; i--) {
+            AdditionalSessionFactoryConfig config = additionalSessionFactories.get(i);
+            SessionFactory sf = config.sessionFactory;
+            SessionHolder sessionHolder = (SessionHolder) TransactionSynchronizationManager.getResource(sf);
+            if (sessionHolder != null) {
+                Session session = sessionHolder.getSession();
+                TransactionSynchronizationManager.unbindResource(sf);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Closing additional Hibernate Session in OpenSessionInViewInterceptor");
+                }
+                SessionFactoryUtils.closeSession(session);
+            }
+        }
+
+        super.afterCompletion(request, ex);
     }
 
     public void setHibernateDatastore(AbstractHibernateDatastore hibernateDatastore) {
@@ -84,5 +171,25 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
             this.hibernateFlushMode = FlushMode.valueOf(defaultFlushModeName);
         }
         setSessionFactory(hibernateDatastore.getSessionFactory());
+
+        if (hibernateDatastore instanceof HibernateDatastore) {
+            HibernateDatastore hibernateDs = (HibernateDatastore) hibernateDatastore;
+            for (ConnectionSource<SessionFactory, HibernateConnectionSourceSettings> connectionSource : hibernateDs.getConnectionSources().getAllConnectionSources()) {
+                String connectionName = connectionSource.getName();
+                if (!ConnectionSource.DEFAULT.equals(connectionName)) {
+                    AbstractHibernateDatastore childDatastore = hibernateDs.getDatastoreForConnection(connectionName);
+                    FlushMode childFlushMode;
+                    if (childDatastore.isOsivReadOnly()) {
+                        childFlushMode = FlushMode.MANUAL;
+                    }
+                    else {
+                        childFlushMode = FlushMode.valueOf(childDatastore.getDefaultFlushModeName());
+                    }
+                    additionalSessionFactories.add(
+                            new AdditionalSessionFactoryConfig(childDatastore.getSessionFactory(), childFlushMode)
+                    );
+                }
+            }
+        }
     }
 }

--- a/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
+++ b/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
@@ -123,25 +123,39 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
             }
         }
 
+        RuntimeException firstFlushException = null;
         for (AdditionalSessionFactoryConfig config : additionalSessionFactories) {
             SessionFactory sf = config.sessionFactory;
             SessionHolder additionalHolder = (SessionHolder) TransactionSynchronizationManager.getResource(sf);
             if (additionalHolder != null) {
                 Session additionalSession = additionalHolder.getSession();
                 try {
-                    FlushMode additionalFlushMode = additionalSession.getHibernateFlushMode();
-                    boolean additionalIsNotManual = additionalFlushMode != FlushMode.MANUAL && additionalFlushMode != FlushMode.COMMIT;
-                    if (additionalIsNotManual) {
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Eagerly flushing additional Hibernate session for datasource '" + config.connectionName + "'");
+                    try {
+                        FlushMode additionalFlushMode = additionalSession.getHibernateFlushMode();
+                        boolean additionalIsNotManual = additionalFlushMode != FlushMode.MANUAL && additionalFlushMode != FlushMode.COMMIT;
+                        if (additionalIsNotManual) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Eagerly flushing additional Hibernate session for datasource '" + config.connectionName + "'");
+                            }
+                            additionalSession.flush();
                         }
-                        additionalSession.flush();
+                    }
+                    catch (RuntimeException ex) {
+                        if (firstFlushException == null) {
+                            firstFlushException = ex;
+                        }
+                        else {
+                            firstFlushException.addSuppressed(ex);
+                        }
                     }
                 }
                 finally {
                     additionalSession.setHibernateFlushMode(FlushMode.MANUAL);
                 }
             }
+        }
+        if (firstFlushException != null) {
+            throw firstFlushException;
         }
     }
 

--- a/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
+++ b/grails-data-hibernate5/grails-plugin/src/main/groovy/org/grails/plugin/hibernate/support/GrailsOpenSessionInViewInterceptor.java
@@ -145,21 +145,29 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
 
     @Override
     public void afterCompletion(WebRequest request, Exception ex) throws DataAccessException {
-        for (int i = additionalSessionFactories.size() - 1; i >= 0; i--) {
-            AdditionalSessionFactoryConfig config = additionalSessionFactories.get(i);
-            SessionFactory sf = config.sessionFactory;
-            SessionHolder sessionHolder = (SessionHolder) TransactionSynchronizationManager.getResource(sf);
-            if (sessionHolder != null) {
-                Session session = sessionHolder.getSession();
-                TransactionSynchronizationManager.unbindResource(sf);
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Closing additional Hibernate Session in OpenSessionInViewInterceptor");
+        try {
+            for (int i = additionalSessionFactories.size() - 1; i >= 0; i--) {
+                AdditionalSessionFactoryConfig config = additionalSessionFactories.get(i);
+                SessionFactory sf = config.sessionFactory;
+                SessionHolder sessionHolder = (SessionHolder) TransactionSynchronizationManager.getResource(sf);
+                if (sessionHolder != null) {
+                    Session session = sessionHolder.getSession();
+                    TransactionSynchronizationManager.unbindResource(sf);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Closing additional Hibernate Session in OpenSessionInViewInterceptor");
+                    }
+                    try {
+                        SessionFactoryUtils.closeSession(session);
+                    }
+                    catch (RuntimeException closeEx) {
+                        logger.error("Unexpected exception on closing additional Hibernate Session", closeEx);
+                    }
                 }
-                SessionFactoryUtils.closeSession(session);
             }
         }
-
-        super.afterCompletion(request, ex);
+        finally {
+            super.afterCompletion(request, ex);
+        }
     }
 
     public void setHibernateDatastore(AbstractHibernateDatastore hibernateDatastore) {

--- a/grails-data-hibernate5/grails-plugin/src/test/groovy/org/grails/plugin/hibernate/support/MultiDataSourceSessionSpec.groovy
+++ b/grails-data-hibernate5/grails-plugin/src/test/groovy/org/grails/plugin/hibernate/support/MultiDataSourceSessionSpec.groovy
@@ -1,0 +1,193 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugin.hibernate.support
+
+import grails.gorm.annotation.Entity
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.orm.hibernate.HibernateDatastore
+import org.hibernate.Session
+import org.hibernate.SessionFactory
+import org.hibernate.dialect.H2Dialect
+import org.springframework.orm.hibernate5.SessionHolder
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.web.context.request.WebRequest
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MultiDataSourceSessionSpec extends Specification {
+
+    @Shared Map config = [
+            'dataSource.url':"jdbc:h2:mem:grailsDB;LOCK_TIMEOUT=10000",
+            'dataSource.dbCreate': 'create-drop',
+            'dataSource.dialect': H2Dialect.name,
+            'dataSource.formatSql': 'true',
+            'hibernate.flush.mode': 'COMMIT',
+            'hibernate.cache.queries': 'true',
+            'hibernate.hbm2ddl.auto': 'create-drop',
+            'dataSources.secondary':[url:"jdbc:h2:mem:secondaryDb;LOCK_TIMEOUT=10000"],
+    ]
+
+    @Shared @AutoCleanup HibernateDatastore datastore = new HibernateDatastore(DatastoreUtils.createPropertyResolver(config), OsivBook, OsivAuthor)
+
+    def "withSession on default datasource works with OSIV"() {
+        given: "OSIV interceptor configured with the datastore"
+        def interceptor = new GrailsOpenSessionInViewInterceptor()
+        interceptor.setHibernateDatastore(datastore)
+        WebRequest webRequest = Mock(WebRequest)
+
+        when: "OSIV preHandle is called"
+        interceptor.preHandle(webRequest)
+
+        then: "a session is bound for the default SessionFactory"
+        TransactionSynchronizationManager.hasResource(datastore.sessionFactory)
+
+        when: "withSession is called on default datasource"
+        boolean sessionObtained = false
+        OsivAuthor.withSession { Session s ->
+            sessionObtained = s != null
+        }
+
+        then: "session is available"
+        sessionObtained
+
+        cleanup:
+        interceptor.afterCompletion(webRequest, null)
+    }
+
+    def "withSession on secondary datasource works with OSIV"() {
+        given: "OSIV interceptor configured with the datastore"
+        def interceptor = new GrailsOpenSessionInViewInterceptor()
+        interceptor.setHibernateDatastore(datastore)
+        WebRequest webRequest = Mock(WebRequest)
+
+        when: "OSIV preHandle is called"
+        interceptor.preHandle(webRequest)
+
+        then: "a session is bound for both the default and secondary SessionFactory"
+        def secondaryDatastore = datastore.getDatastoreForConnection('secondary')
+        TransactionSynchronizationManager.hasResource(datastore.sessionFactory)
+        TransactionSynchronizationManager.hasResource(secondaryDatastore.sessionFactory)
+
+        when: "withSession is called on secondary datasource"
+        boolean sessionObtained = false
+        OsivBook.secondary.withSession { Session s ->
+            sessionObtained = s != null
+        }
+
+        then: "session is available without 'No Session found for current thread' error"
+        sessionObtained
+
+        cleanup:
+        interceptor.afterCompletion(webRequest, null)
+    }
+
+    def "afterCompletion cleans up sessions for all datasources"() {
+        given: "OSIV interceptor with preHandle already called"
+        def interceptor = new GrailsOpenSessionInViewInterceptor()
+        interceptor.setHibernateDatastore(datastore)
+        WebRequest webRequest = Mock(WebRequest)
+        interceptor.preHandle(webRequest)
+
+        def secondaryDatastore = datastore.getDatastoreForConnection('secondary')
+
+        when: "afterCompletion is called"
+        interceptor.afterCompletion(webRequest, null)
+
+        then: "sessions are unbound for all datasources"
+        !TransactionSynchronizationManager.hasResource(datastore.sessionFactory)
+        !TransactionSynchronizationManager.hasResource(secondaryDatastore.sessionFactory)
+    }
+
+    def "OSIV skips secondary datasource if session already bound"() {
+        given: "a pre-bound session for the secondary datasource"
+        def interceptor = new GrailsOpenSessionInViewInterceptor()
+        interceptor.setHibernateDatastore(datastore)
+        WebRequest webRequest = Mock(WebRequest)
+
+        def secondaryDatastore = datastore.getDatastoreForConnection('secondary')
+        SessionFactory secondarySf = secondaryDatastore.sessionFactory
+        Session preBoundSession = secondarySf.openSession()
+        SessionHolder preBoundHolder = new SessionHolder(preBoundSession)
+        TransactionSynchronizationManager.bindResource(secondarySf, preBoundHolder)
+
+        when: "OSIV preHandle is called"
+        interceptor.preHandle(webRequest)
+
+        then: "the pre-bound session is preserved (not replaced)"
+        def currentHolder = TransactionSynchronizationManager.getResource(secondarySf)
+        currentHolder.is(preBoundHolder)
+
+        cleanup:
+        interceptor.afterCompletion(webRequest, null)
+        if (TransactionSynchronizationManager.hasResource(secondarySf)) {
+            TransactionSynchronizationManager.unbindResource(secondarySf)
+        }
+        preBoundSession.close()
+    }
+
+    def "CRUD operations work on secondary datasource with OSIV"() {
+        given: "OSIV interceptor configured and preHandle called"
+        def interceptor = new GrailsOpenSessionInViewInterceptor()
+        interceptor.setHibernateDatastore(datastore)
+        WebRequest webRequest = Mock(WebRequest)
+        interceptor.preHandle(webRequest)
+
+        when: "data is saved to secondary datasource within a transaction"
+        OsivBook book = OsivBook.withTransaction {
+            new OsivBook(title: "Test Book").save(flush: true)
+            OsivBook.first()
+        }
+
+        then: "the book is saved successfully"
+        book != null
+        book.title == "Test Book"
+
+        when: "data is read from secondary datasource using withSession"
+        int count = 0
+        OsivBook.secondary.withSession { Session s ->
+            count = OsivBook.count()
+        }
+
+        then: "the count is correct"
+        count == 1
+
+        cleanup:
+        OsivBook.withTransaction {
+            OsivBook.list()*.delete(flush: true)
+        }
+        interceptor.afterCompletion(webRequest, null)
+    }
+}
+
+@Entity
+class OsivBook {
+    String title
+    Date dateCreated
+    Date lastUpdated
+
+    static mapping = {
+        datasource 'secondary'
+    }
+}
+
+@Entity
+class OsivAuthor {
+    String name
+}

--- a/grails-test-examples/datasources/grails-app/controllers/datasources/OsivBookController.groovy
+++ b/grails-test-examples/datasources/grails-app/controllers/datasources/OsivBookController.groovy
@@ -17,20 +17,21 @@
  *  under the License.
  */
 
-package ds2
+package datasources
 
-import static grails.gorm.hibernate.mapping.MappingBuilder.*
+import ds2.Book
+import ds2.Chapter
 
-class Book {
+class OsivBookController {
 
-    String title
-
-    static hasMany = [chapters: Chapter]
-
-    static constraints = {
-    }
-
-    static mapping = orm {
-        datasource 'secondary'
+    def show() {
+        Book.withTransaction {
+            Book book = new Book(title: 'OSIV Test Book')
+            book.addToChapters(new Chapter(title: 'Chapter One'))
+            book.addToChapters(new Chapter(title: 'Chapter Two'))
+            book.save(flush: true)
+        }
+        Book book = Book.secondary.first()
+        [book: book]
     }
 }

--- a/grails-test-examples/datasources/grails-app/controllers/datasources/OsivBookController.groovy
+++ b/grails-test-examples/datasources/grails-app/controllers/datasources/OsivBookController.groovy
@@ -31,7 +31,7 @@ class OsivBookController {
             book.addToChapters(new Chapter(title: 'Chapter Two'))
             book.save(flush: true)
         }
-        Book book = Book.secondary.first()
+        Book book = Book.secondary.findByTitle('OSIV Test Book')
         [book: book]
     }
 }

--- a/grails-test-examples/datasources/grails-app/controllers/datasources/UrlMappings.groovy
+++ b/grails-test-examples/datasources/grails-app/controllers/datasources/UrlMappings.groovy
@@ -17,20 +17,14 @@
  *  under the License.
  */
 
-package ds2
+package datasources
 
-import static grails.gorm.hibernate.mapping.MappingBuilder.*
+class UrlMappings {
 
-class Book {
-
-    String title
-
-    static hasMany = [chapters: Chapter]
-
-    static constraints = {
-    }
-
-    static mapping = orm {
-        datasource 'secondary'
+    static mappings = {
+        "/$controller/$action?/$id?(.$format)?" {
+            constraints {
+            }
+        }
     }
 }

--- a/grails-test-examples/datasources/grails-app/domain/ds2/Chapter.groovy
+++ b/grails-test-examples/datasources/grails-app/domain/ds2/Chapter.groovy
@@ -21,11 +21,11 @@ package ds2
 
 import static grails.gorm.hibernate.mapping.MappingBuilder.*
 
-class Book {
+class Chapter {
 
     String title
 
-    static hasMany = [chapters: Chapter]
+    static belongsTo = [book: Book]
 
     static constraints = {
     }

--- a/grails-test-examples/datasources/grails-app/views/osivBook/show.gsp
+++ b/grails-test-examples/datasources/grails-app/views/osivBook/show.gsp
@@ -1,0 +1,29 @@
+<%--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  --%>
+<html>
+<head><title>OSIV Test</title></head>
+<body>
+<h1 id="bookTitle">${book.title}</h1>
+<ul id="chapters">
+<g:each in="${book.chapters}" var="chapter">
+    <li class="chapter">${chapter.title}</li>
+</g:each>
+</ul>
+</body>
+</html>

--- a/grails-test-examples/datasources/src/integration-test/groovy/functionaltests/OsivGspRenderingSpec.groovy
+++ b/grails-test-examples/datasources/src/integration-test/groovy/functionaltests/OsivGspRenderingSpec.groovy
@@ -17,20 +17,26 @@
  *  under the License.
  */
 
-package ds2
+package functionaltests
 
-import static grails.gorm.hibernate.mapping.MappingBuilder.*
+import functionaltests.pages.OsivBookPage
 
-class Book {
+import grails.plugin.geb.ContainerGebSpec
+import grails.testing.mixin.integration.Integration
+import spock.lang.Issue
 
-    String title
+@Integration
+class OsivGspRenderingSpec extends ContainerGebSpec {
 
-    static hasMany = [chapters: Chapter]
+    @Issue('https://github.com/apache/grails-core/pull/15425')
+    void 'OSIV keeps secondary datasource session open during GSP view rendering'() {
+        when: 'visiting a GSP page that accesses lazy-loaded chapters from secondary datasource'
+        to(OsivBookPage)
 
-    static constraints = {
-    }
+        then: 'the book title from secondary datasource is rendered'
+        bookTitle == 'OSIV Test Book'
 
-    static mapping = orm {
-        datasource 'secondary'
+        and: 'the lazy-loaded chapters are accessible without LazyInitializationException'
+        chapterTitles.containsAll(['Chapter One', 'Chapter Two'])
     }
 }

--- a/grails-test-examples/datasources/src/integration-test/groovy/functionaltests/pages/OsivBookPage.groovy
+++ b/grails-test-examples/datasources/src/integration-test/groovy/functionaltests/pages/OsivBookPage.groovy
@@ -17,20 +17,17 @@
  *  under the License.
  */
 
-package ds2
+package functionaltests.pages
 
-import static grails.gorm.hibernate.mapping.MappingBuilder.*
+import geb.Page
 
-class Book {
+class OsivBookPage extends Page {
 
-    String title
+    static url = '/osivBook/show'
+    static at = { title == 'OSIV Test' }
 
-    static hasMany = [chapters: Chapter]
-
-    static constraints = {
-    }
-
-    static mapping = orm {
-        datasource 'secondary'
+    static content = {
+        bookTitle { $('#bookTitle').text() }
+        chapterTitles { $('#chapters .chapter')*.text() }
     }
 }

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/build.gradle
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/build.gradle
@@ -44,11 +44,17 @@ dependencies {
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'
     runtimeOnly 'org.apache.grails:grails-controllers'
+    runtimeOnly 'org.apache.grails:grails-url-mappings'
     runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'
 
     testImplementation 'org.apache.grails.testing:grails-testing-support-core'
+
+    integrationTestImplementation "io.micronaut:micronaut-http-client:$micronautHttpClientVersion"
+    integrationTestImplementation 'org.spockframework:spock-core'
+
+    integrationTestRuntimeOnly "io.micronaut.serde:micronaut-serde-jackson:$micronautSerdeJacksonVersion"
 
     testRuntimeOnly 'org.apache.grails:grails-testing-support-web'
 }

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/controllers/datasources/SecondaryBookController.groovy
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/controllers/datasources/SecondaryBookController.groovy
@@ -1,0 +1,78 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package datasources
+
+import ds2.Book
+import org.hibernate.Session
+
+class SecondaryBookController {
+
+    def withSessionTest() {
+        boolean sessionObtained = false
+        Book.secondary.withSession { Session session ->
+            sessionObtained = session != null
+        }
+        render "sessionObtained:${sessionObtained}"
+    }
+
+    def crudViaWithSession() {
+        Book.withTransaction {
+            new Book(title: 'OSIV Test').save(flush: true)
+        }
+        int count = 0
+        Book.secondary.withSession { Session session ->
+            count = Book.count()
+        }
+        render "count:${count}"
+    }
+
+    def validateCommandObject() {
+        Book book = new Book()
+        boolean validated = false
+        Book.secondary.withSession { Session session ->
+            validated = true
+            book.validate()
+        }
+        render "validated:${validated},hasErrors:${book.hasErrors()}"
+    }
+
+    def sessionAfterExecuteUpdate() {
+        Book.withTransaction {
+            new Book(title: 'Before Update').save(flush: true)
+        }
+        Book.secondary.withTransaction {
+            Book.executeUpdate('UPDATE Book b SET b.title = :newTitle WHERE b.title = :oldTitle',
+                    [newTitle: 'After Update', oldTitle: 'Before Update'])
+        }
+        String title = null
+        Book.secondary.withSession { Session session ->
+            session.clear()
+            title = Book.first()?.title
+        }
+        render "title:${title}"
+    }
+
+    def cleanup() {
+        Book.withTransaction {
+            Book.list()*.delete(flush: true)
+        }
+        render "cleaned"
+    }
+}

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/controllers/datasources/UrlMappings.groovy
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/controllers/datasources/UrlMappings.groovy
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package datasources
+
+class UrlMappings {
+
+    static mappings = {
+        "/$controller/$action?/$id?(.$format)?" {
+            constraints {
+            }
+        }
+
+        "/"(view: '/index')
+        "500"(view: '/error')
+        "404"(view: '/notFound')
+    }
+}

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/src/integration-test/groovy/functionaltests/MultiDataSourceWithSessionSpec.groovy
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/src/integration-test/groovy/functionaltests/MultiDataSourceWithSessionSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package functionaltests
+
+import datasources.Application
+import grails.testing.mixin.integration.Integration
+import grails.testing.spock.OnceBefore
+import io.micronaut.http.client.HttpClient
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@Integration(applicationClass = Application)
+@Stepwise
+class MultiDataSourceWithSessionSpec extends Specification {
+
+    @Shared
+    HttpClient client
+
+    @OnceBefore
+    void init() {
+        String baseUrl = "http://localhost:$serverPort"
+        this.client = HttpClient.create(baseUrl.toURL())
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/14333')
+    void "withSession on secondary datasource does not throw No Session found"() {
+        when:
+        String response = client.toBlocking().retrieve('/secondaryBook/withSessionTest')
+
+        then:
+        response.contains('sessionObtained:true')
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/14333')
+    void "CRUD via withSession on secondary datasource works"() {
+        when:
+        String response = client.toBlocking().retrieve('/secondaryBook/crudViaWithSession')
+
+        then:
+        response.contains('count:1')
+
+        cleanup:
+        client.toBlocking().retrieve('/secondaryBook/cleanup')
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/11798')
+    void "domain class on secondary datasource can be validated via withSession"() {
+        when:
+        String response = client.toBlocking().retrieve('/secondaryBook/validateCommandObject')
+
+        then:
+        response.contains('validated:true')
+        response.contains('hasErrors:true')
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/14333')
+    void "withSession works after executeUpdate on secondary datasource"() {
+        when:
+        String response = client.toBlocking().retrieve('/secondaryBook/sessionAfterExecuteUpdate')
+
+        then:
+        response.contains('title:After Update')
+
+        cleanup:
+        client.toBlocking().retrieve('/secondaryBook/cleanup')
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #14333 and #11798 - both have the same root cause.

`GrailsOpenSessionInViewInterceptor` only registered a session for the **default** datasource's `SessionFactory`. Calling `withSession` on a secondary datasource during a web request threw `No Session found for current thread` because no session was bound for that `SessionFactory` in `TransactionSynchronizationManager`.

## Root Cause

In `HibernateDatastoreSpringInitializer` (lines 189-194), only one OSIV interceptor is created referencing `hibernateDatastore` (the default). The interceptor's `setHibernateDatastore()` called `setSessionFactory(hibernateDatastore.getSessionFactory())` - binding only the default `SessionFactory`.

**Call chain for #14333:**
1. `GormEntity.withSession` -> `AbstractHibernateGormStaticApi.withSession`
2. -> `AbstractHibernateDatastore.withSession` -> `getHibernateTemplate().execute(callable)`
3. -> `GrailsHibernateTemplate.doExecute` -> `getSession()` -> `sessionFactory.getCurrentSession()`
4. -> `GrailsSessionContext.currentSession()` checks `TransactionSynchronizationManager.getResource(sessionFactory)` for the **secondary** `SessionFactory`
5. -> Nothing bound because OSIV only registered for **default** -> `No Session found`

**#11798** has the same root cause: domain class mapped to non-default datasource used as command object fails validation because `validate()` needs a session but OSIV never opened one.

## Fix

Modified `GrailsOpenSessionInViewInterceptor` to handle **multiple** datasource `SessionFactory` instances in a single interceptor:

- `setHibernateDatastore()` now iterates all connection sources from `HibernateDatastore` and stores non-default datasource `SessionFactory` references in an `additionalSessionFactories` list
- `preHandle()` opens sessions and binds `SessionHolder` to `TransactionSynchronizationManager` for each additional datasource (skipping any that already have a session bound)
- `postHandle()` flushes additional sessions if their flush mode warrants it
- `afterCompletion()` unbinds and closes additional sessions in reverse order

This approach keeps a single interceptor bean (backward compatible) and avoids the complexity of registering per-datasource OSIV beans.

## Tests

### Unit Tests (5 tests)
- `MultiDataSourceSessionSpec` - Tests OSIV interceptor directly:
  - Default datasource session binding
  - Secondary datasource session binding
  - Cleanup of all datasource sessions
  - Skip-if-already-bound behavior
  - CRUD operations on secondary datasource

### Functional/Integration Tests (4 tests via HTTP)
- `MultiDataSourceWithSessionSpec` - Tests through actual HTTP requests to a controller:
  - `withSession` on secondary datasource does not throw (covers #14333)
  - CRUD via `withSession` on secondary datasource
  - Domain validation via `withSession` on secondary datasource (covers #11798)
  - `withSession` works after `executeUpdate` on secondary datasource

### Existing Tests
- All 10 `grails-data-hibernate5` tests pass
- All 42 `grails-data-hibernate5-core` connection tests pass
- All 6 existing `grails-multiple-datasources` integration tests pass

## Changed Files

| File | Change |
|------|--------|
| `GrailsOpenSessionInViewInterceptor.java` | Multi-datasource OSIV support |
| `grails-data-hibernate5/grails-plugin/build.gradle` | Added servlet-api test dependency |
| `MultiDataSourceSessionSpec.groovy` | New unit tests |
| `SecondaryBookController.groovy` | New test controller |
| `UrlMappings.groovy` | URL mappings for test controller |
| `MultiDataSourceWithSessionSpec.groovy` | New functional tests via HTTP |
| `grails-multiple-datasources/build.gradle` | Added HTTP client + URL mappings dependencies |