### PR TITLE
fix: add jboss-threads 3.9.2 to Undertow feature for Java 25 compatibility

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootUndertowFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/spring/SpringBootUndertowFeature.java
@@ -54,6 +54,10 @@ public class SpringBootUndertowFeature extends SpringBootEmbeddedServlet {
                 .groupId("org.springframework.boot")
                 .artifactId("spring-boot-starter-undertow")
                 .implementation());
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("org.jboss.threads")
+                .lookupArtifactId("jboss-threads")
+                .runtimeOnly());
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/resources/pom.xml
+++ b/grails-forge/grails-forge-core/src/main/resources/pom.xml
@@ -74,5 +74,11 @@
             <artifactId>gradle-jrebel-plugin</artifactId>
             <version>1.2.1</version>
         </dependency>
+        <dependency>
+            <!-- Force newer version to fix sun.misc.Unsafe::objectFieldOffset warning on Java 25 -->
+            <groupId>org.jboss.threads</groupId>
+            <artifactId>jboss-threads</artifactId>
+            <version>3.9.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootSpec.groovy
@@ -20,10 +20,12 @@
 package org.grails.forge.feature.spring
 
 import org.grails.forge.BeanContextSpec
+import org.grails.forge.BuildBuilder
 import org.grails.forge.application.ApplicationType
 import org.grails.forge.fixture.CommandOutputFixture
 import org.grails.forge.options.JdkVersion
 import org.grails.forge.options.Options
+import org.grails.forge.options.ServletImpl
 import org.grails.forge.options.TestFramework
 import spock.lang.Unroll
 
@@ -64,5 +66,17 @@ class SpringBootSpec extends BeanContextSpec implements CommandOutputFixture {
         build.contains("implementation \"org.springframework.boot:spring-boot-starter-validation\"")
         build.contains("implementation \"org.springframework.boot:spring-boot-autoconfigure\"")
         !build.contains("implementation \"org.springframework.boot:spring-boot-starter-tomcat\"")
+    }
+
+    void "test undertow servlet includes jboss-threads dependency"() {
+        when:
+        String build = new BuildBuilder(beanContext)
+                .servletImpl(ServletImpl.UNDERTOW)
+                .render()
+
+        then:
+        build.contains('implementation "org.springframework.boot:spring-boot-starter-undertow"')
+        build.contains('runtimeOnly "org.jboss.threads:jboss-threads')
+        !build.contains('implementation "org.springframework.boot:spring-boot-starter-tomcat"')
     }
 }


### PR DESCRIPTION
## Summary

- When Undertow is selected as the servlet container in grails-forge, the generated `build.gradle` now includes `runtimeOnly "org.jboss.threads:jboss-threads:3.9.2"`
- This fixes the `sun.misc.Unsafe::objectFieldOffset` warning on Java 25 caused by undertow-core pulling in jboss-threads 3.7.0, which calls the terminally deprecated API in its static initializer
- Version is managed centrally in the forge's `pom.xml` using the `lookupArtifactId` pattern, consistent with how other third-party dependency versions are stored

## Changes

| File | Change |
|------|--------|
| `grails-forge/.../pom.xml` | Added `jboss-threads:3.9.2` dependency entry |
| `grails-forge/.../SpringBootUndertowFeature.java` | Added `runtimeOnly` dependency via `lookupArtifactId` |
| `grails-forge/.../SpringBootSpec.groovy` | Added test verifying jboss-threads appears in generated build |

## Testing

All 5 `SpringBootSpec` tests pass, including the new `test undertow servlet includes jboss-threads dependency` test.