### PR TITLE
test(tck): add Data Service connection routing spec to TCK

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/org/apache/grails/data/hibernate5/core/GrailsDataHibernate5TckManager.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/apache/grails/data/hibernate5/core/GrailsDataHibernate5TckManager.groovy
@@ -28,6 +28,8 @@ import org.grails.datastore.mapping.core.Session
 import org.grails.orm.hibernate.GrailsHibernateTransactionManager
 import org.grails.orm.hibernate.HibernateDatastore
 import org.grails.orm.hibernate.cfg.HibernateMappingContextConfiguration
+import org.grails.datastore.mapping.multitenancy.MultiTenancySettings
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
 import org.h2.Driver
 import org.hibernate.SessionFactory
 import org.hibernate.dialect.H2Dialect
@@ -50,6 +52,7 @@ class GrailsDataHibernate5TckManager extends GrailsDataTckManager {
     HibernateMappingContextConfiguration hibernateConfig
     ApplicationContext applicationContext
     HibernateDatastore multiDataSourceDatastore
+    HibernateDatastore multiTenantMultiDataSourceDatastore
 
     @Override
     void setup(Class<? extends Specification> spec) {
@@ -151,6 +154,47 @@ class GrailsDataHibernate5TckManager extends GrailsDataTckManager {
     @Override
     def getServiceForConnection(Class serviceType, String connectionName) {
         multiDataSourceDatastore
+                .getDatastoreForConnection(connectionName)
+                .getService(serviceType)
+    }
+
+    @Override
+    boolean supportsMultiTenantMultiDataSource() {
+        true
+    }
+
+    @Override
+    void setupMultiTenantMultiDataSource(Class... domainClasses) {
+        Map config = [
+                'grails.gorm.multiTenancy.mode'            : MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR,
+                'grails.gorm.multiTenancy.tenantResolverClass': SystemPropertyTenantResolver,
+                'dataSource.url'                            : "jdbc:h2:mem:tckMtDefaultDB;LOCK_TIMEOUT=10000",
+                'dataSource.dbCreate'                       : 'create-drop',
+                'dataSource.dialect'                        : H2Dialect.name,
+                'dataSource.formatSql'                      : 'true',
+                'hibernate.flush.mode'                      : 'COMMIT',
+                'hibernate.cache.queries'                   : 'true',
+                'hibernate.hbm2ddl.auto'                    : 'create-drop',
+                'dataSources.secondary'                     : [url: "jdbc:h2:mem:tckMtSecondaryDB;LOCK_TIMEOUT=10000"],
+        ]
+        multiTenantMultiDataSourceDatastore = new HibernateDatastore(
+                DatastoreUtils.createPropertyResolver(config), domainClasses
+        )
+    }
+
+    @Override
+    void cleanupMultiTenantMultiDataSource() {
+        if (multiTenantMultiDataSourceDatastore != null) {
+            multiTenantMultiDataSourceDatastore.destroy()
+            multiTenantMultiDataSourceDatastore = null
+            shutdownInMemDb('jdbc:h2:mem:tckMtDefaultDB')
+            shutdownInMemDb('jdbc:h2:mem:tckMtSecondaryDB')
+        }
+    }
+
+    @Override
+    def getServiceForMultiTenantConnection(Class serviceType, String connectionName) {
+        multiTenantMultiDataSourceDatastore
                 .getDatastoreForConnection(connectionName)
                 .getService(serviceType)
     }

--- a/grails-data-mongodb/core/src/test/groovy/grails/mongodb/bootstrap/MongoDbDataStoreSpringInitializerSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/grails/mongodb/bootstrap/MongoDbDataStoreSpringInitializerSpec.groovy
@@ -44,7 +44,7 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
 
     void "Test specify mongo database name settings"() {
         when: "the initializer used to setup GORM for MongoDB"
-        def initializer = new MongoDbDataStoreSpringInitializer([
+        def initializer = makeInitializer([
                 (MongoSettings.SETTING_DATABASE_NAME): 'foo',
                 (MongoSettings.SETTING_HOST): mongoHost,
                 (MongoSettings.SETTING_PORT): mongoPort,
@@ -61,7 +61,7 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
 
     void "Test that MongoDbDatastoreSpringInitializer can setup GORM for MongoDB from scratch"() {
         when: "the initializer used to setup GORM for MongoDB"
-        def initializer = new MongoDbDataStoreSpringInitializer([
+        def initializer = makeInitializer([
                 (MongoSettings.SETTING_HOST): mongoHost,
                 (MongoSettings.SETTING_PORT): mongoPort,
         ], Person)
@@ -75,7 +75,7 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
 
     void "Test the alias is created when it is the primary datastore"() {
         when: "the initializer used to setup GORM for MongoDB"
-        def initializer = new MongoDbDataStoreSpringInitializer([
+        def initializer = makeInitializer([
                 'grails.mongodb.databaseName': 'foo',
                 (MongoSettings.SETTING_HOST): mongoHost,
                 (MongoSettings.SETTING_PORT): mongoPort,
@@ -92,7 +92,7 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
 
     void "Test the alias is not created when it is the secondary datastore"() {
         when: "the initializer used to setup GORM for MongoDB"
-        def initializer = new MongoDbDataStoreSpringInitializer([
+        def initializer = makeInitializer([
                 'grails.mongodb.databaseName': 'foo',
                 (MongoSettings.SETTING_HOST): mongoHost,
                 (MongoSettings.SETTING_PORT): mongoPort,
@@ -134,7 +134,7 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
 
     void "Test that constraints and Geo types work"() {
         given: "the initializer used to setup GORM for MongoDB"
-        def initializer = new MongoDbDataStoreSpringInitializer([
+        def initializer = makeInitializer([
                 (MongoSettings.SETTING_HOST): mongoHost,
                 (MongoSettings.SETTING_PORT): mongoPort,
         ], Person)
@@ -162,7 +162,7 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
 
     void "Test custom codecs from Spring"() {
         given: "the initializer used to setup GORM for MongoDB"
-        def initializer = new MongoDbDataStoreSpringInitializer([
+        def initializer = makeInitializer([
                 (MongoSettings.SETTING_HOST): mongoHost,
                 (MongoSettings.SETTING_PORT): mongoPort,
         ], Person)
@@ -184,7 +184,7 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
 
     void "Test custom type marshallers from Spring"() {
         given: "the initializer used to setup GORM for MongoDB"
-        def initializer = new MongoDbDataStoreSpringInitializer([
+        def initializer = makeInitializer([
                 (MongoSettings.SETTING_HOST): mongoHost,
                 (MongoSettings.SETTING_PORT): mongoPort,
         ], Person)
@@ -203,6 +203,16 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
         Person.first().birthday == birthday
         Person.findByBirthday(birthday).birthday == birthday
         !Person.findByBirthday(new Birthday(new Date() - 7))
+
+    }
+
+    private MongoDbDataStoreSpringInitializer makeInitializer(Map config, Class... domainClasses) {
+        new MongoDbDataStoreSpringInitializer(config, domainClasses) {
+            @Override
+            protected Map<String, Class<?>> loadDataServices(String secondaryDatastore = null) {
+                [:]
+            }
+        }
     }
 }
 

--- a/grails-data-mongodb/core/src/test/groovy/org/apache/grails/data/mongo/core/GrailsDataMongoTckManager.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/org/apache/grails/data/mongo/core/GrailsDataMongoTckManager.groovy
@@ -33,6 +33,8 @@ import org.grails.datastore.gorm.mongo.Birthday
 import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
 import org.grails.datastore.mapping.core.Session
+import org.grails.datastore.mapping.multitenancy.MultiTenancySettings
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
 import org.grails.datastore.mapping.engine.types.AbstractMappingAwareCustomTypeMarshaller
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.datastore.mapping.model.PersistentEntity
@@ -61,6 +63,7 @@ class GrailsDataMongoTckManager extends GrailsDataTckManager {
 
     Map<String, Object> configuration
     MongoDatastore multiDataSourceDatastore
+    MongoDatastore multiTenantMultiDataSourceDatastore
 
     @Override
     void setupSpec() {
@@ -181,6 +184,46 @@ class GrailsDataMongoTckManager extends GrailsDataTckManager {
     @Override
     def getServiceForConnection(Class serviceType, String connectionName) {
         multiDataSourceDatastore
+                .getDatastoreForConnection(connectionName)
+                .getService(serviceType)
+    }
+
+    @Override
+    boolean supportsMultiTenantMultiDataSource() {
+        true
+    }
+
+    @Override
+    void setupMultiTenantMultiDataSource(Class... domainClasses) {
+        String host = mongoDBContainer.host
+        int port = mongoDBContainer.getMappedPort(AbstractMongoGrailsExtension.DEFAULT_MONGO_PORT)
+        Map config = [
+                'grails.gorm.multiTenancy.mode'               : MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR,
+                'grails.gorm.multiTenancy.tenantResolverClass' : SystemPropertyTenantResolver,
+                'grails.mongodb.url'                           : "mongodb://${host}:${port}/tckMtDefaultDB" as String,
+                'grails.mongodb.connections'                   : [
+                        'secondary': ['url': "mongodb://${host}:${port}/tckMtSecondaryDB" as String],
+                ],
+        ]
+        multiTenantMultiDataSourceDatastore = new MongoDatastore(
+                DatastoreUtils.createPropertyResolver(config), domainClasses
+        )
+    }
+
+    @Override
+    void cleanupMultiTenantMultiDataSource() {
+        if (multiTenantMultiDataSourceDatastore != null) {
+            multiTenantMultiDataSourceDatastore.getMongoClient().listDatabaseNames()
+                    .findAll { it.startsWith('tckMt') }
+                    .each { multiTenantMultiDataSourceDatastore.getMongoClient().getDatabase(it).drop() }
+            multiTenantMultiDataSourceDatastore.close()
+            multiTenantMultiDataSourceDatastore = null
+        }
+    }
+
+    @Override
+    def getServiceForMultiTenantConnection(Class serviceType, String connectionName) {
+        multiTenantMultiDataSourceDatastore
                 .getDatastoreForConnection(connectionName)
                 .getService(serviceType)
     }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
@@ -330,19 +330,6 @@ abstract class AbstractDatastoreInitializer implements ResourceLoaderAware {
                 final Class<Service> clazz = serviceDefinition.getType()
                 final Class<?> serviceClass = loadServiceClass(clazz)
                 final grails.gorm.services.Service ann = clazz.getAnnotation(grails.gorm.services.Service)
-
-                // Only register services whose domain class belongs to this datastore's configured
-                // persistent classes. When persistentClasses is non-empty, this datastore was
-                // initialised with a specific domain set (e.g. a secondary or standalone datastore),
-                // so a @Service mapped to a domain class outside that set cannot function here and
-                // would cause startup failures due to missing datasource configuration.
-                if (ann != null && !persistentClasses.isEmpty()) {
-                    Class domainClass = ann.value()
-                    if (domainClass != null && domainClass != Object && !persistentClasses.contains(domainClass)) {
-                        continue
-                    }
-                }
-
                 String serviceName = ann?.name()
                 if (!serviceName) {
                     serviceName = Introspector.decapitalize(serviceClass.simpleName)

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
@@ -331,11 +331,11 @@ abstract class AbstractDatastoreInitializer implements ResourceLoaderAware {
                 final Class<?> serviceClass = loadServiceClass(clazz)
                 final grails.gorm.services.Service ann = clazz.getAnnotation(grails.gorm.services.Service)
 
-                // Skip services whose domain class is not mapped in this initializer.
-                // When persistentClasses is explicitly set, only register services for
-                // domains that are actually configured - prevents classpath pollution from
-                // unrelated @Service implementations (e.g., TCK test services) causing
-                // startup failures due to missing datasource connections.
+                // Only register services whose domain class belongs to this datastore's configured
+                // persistent classes. When persistentClasses is non-empty, this datastore was
+                // initialised with a specific domain set (e.g. a secondary or standalone datastore),
+                // so a @Service mapped to a domain class outside that set cannot function here and
+                // would cause startup failures due to missing datasource configuration.
                 if (ann != null && !persistentClasses.isEmpty()) {
                     Class domainClass = ann.value()
                     if (domainClass != null && domainClass != Object && !persistentClasses.contains(domainClass)) {

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
@@ -330,6 +330,19 @@ abstract class AbstractDatastoreInitializer implements ResourceLoaderAware {
                 final Class<Service> clazz = serviceDefinition.getType()
                 final Class<?> serviceClass = loadServiceClass(clazz)
                 final grails.gorm.services.Service ann = clazz.getAnnotation(grails.gorm.services.Service)
+
+                // Skip services whose domain class is not mapped in this initializer.
+                // When persistentClasses is explicitly set, only register services for
+                // domains that are actually configured - prevents classpath pollution from
+                // unrelated @Service implementations (e.g., TCK test services) causing
+                // startup failures due to missing datasource connections.
+                if (ann != null && !persistentClasses.isEmpty()) {
+                    Class domainClass = ann.value()
+                    if (domainClass != null && domainClass != Object && !persistentClasses.contains(domainClass)) {
+                        continue
+                    }
+                }
+
                 String serviceName = ann?.name()
                 if (!serviceName) {
                     serviceName = Introspector.decapitalize(serviceClass.simpleName)

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/base/GrailsDataTckManager.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/base/GrailsDataTckManager.groovy
@@ -146,4 +146,20 @@ abstract class GrailsDataTckManager {
     def getServiceForConnection(Class serviceType, String connectionName) {
         null
     }
+
+    boolean supportsMultiTenantMultiDataSource() {
+        false
+    }
+
+    void setupMultiTenantMultiDataSource(Class... domainClasses) {
+        // noop - override in implementations that support DISCRIMINATOR multi-tenancy + multiple datasources
+    }
+
+    void cleanupMultiTenantMultiDataSource() {
+        // noop - override in implementations that support DISCRIMINATOR multi-tenancy + multiple datasources
+    }
+
+    def getServiceForMultiTenantConnection(Class serviceType, String connectionName) {
+        null
+    }
 }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingMetric.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingMetric.groovy
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.domains
+
+import grails.gorm.MultiTenant
+import grails.gorm.annotation.Entity
+import org.grails.datastore.gorm.GormEntity
+
+@Entity
+class DataServiceRoutingMetric implements GormEntity<DataServiceRoutingMetric>, MultiTenant<DataServiceRoutingMetric> {
+
+    Long id
+    Long version
+    String tenantId
+    String name
+    Integer amount
+
+    static mapping = {
+        datasource 'secondary'
+    }
+
+    static constraints = {
+        name blank: false
+        amount nullable: false
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingMetricService.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingMetricService.groovy
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.domains
+
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+
+@Service(DataServiceRoutingMetric)
+@Transactional(connection = 'secondary')
+abstract class DataServiceRoutingMetricService {
+
+    abstract DataServiceRoutingMetric get(Serializable id)
+
+    abstract DataServiceRoutingMetric save(DataServiceRoutingMetric metric)
+
+    abstract void delete(Serializable id)
+
+    abstract Number count()
+
+    abstract DataServiceRoutingMetric findByName(String name)
+
+    abstract List<DataServiceRoutingMetric> findAllByName(String name)
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingProduct.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingProduct.groovy
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.domains
+
+import grails.gorm.annotation.Entity
+import org.grails.datastore.gorm.GormEntity
+
+@Entity
+class DataServiceRoutingProduct implements GormEntity<DataServiceRoutingProduct> {
+
+    Long id
+    Long version
+    String name
+    Integer amount
+
+    static mapping = {
+        datasource 'ALL'
+    }
+
+    static constraints = {
+        name blank: false
+        amount nullable: false
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingProductDataService.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingProductDataService.groovy
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.domains
+
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+
+@Service(DataServiceRoutingProduct)
+@Transactional(connection = 'secondary')
+interface DataServiceRoutingProductDataService {
+
+    DataServiceRoutingProduct get(Serializable id)
+
+    DataServiceRoutingProduct save(DataServiceRoutingProduct product)
+
+    DataServiceRoutingProduct delete(Serializable id)
+
+    void deleteProduct(Serializable id)
+
+    Number count()
+
+    DataServiceRoutingProduct findByName(String name)
+
+    List<DataServiceRoutingProduct> findAllByName(String name)
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingProductService.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/DataServiceRoutingProductService.groovy
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.domains
+
+import grails.gorm.services.Service
+import grails.gorm.transactions.Transactional
+
+@Service(DataServiceRoutingProduct)
+@Transactional(connection = 'secondary')
+abstract class DataServiceRoutingProductService {
+
+    abstract DataServiceRoutingProduct get(Serializable id)
+
+    abstract DataServiceRoutingProduct save(DataServiceRoutingProduct product)
+
+    abstract DataServiceRoutingProduct delete(Serializable id)
+
+    abstract void deleteProduct(Serializable id)
+
+    abstract Number count()
+
+    abstract DataServiceRoutingProduct findByName(String name)
+
+    abstract List<DataServiceRoutingProduct> findAllByName(String name)
+
+    abstract DataServiceRoutingProduct saveProduct(String name, Integer amount)
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiDataSourceSpec.groovy
@@ -19,9 +19,6 @@
 package org.apache.grails.data.testing.tck.tests
 
 import spock.lang.Requires
-
-
-import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductDataService
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductService

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiDataSourceSpec.groovy
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.tests
+
+import spock.lang.Requires
+
+import org.grails.datastore.gorm.GormEnhancer
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductDataService
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductService
+
+@Requires({ instance.manager?.supportsMultipleDataSources() })
+class CrossLayerMultiDataSourceSpec extends GrailsDataTckSpec {
+
+    DataServiceRoutingProductService productService
+    DataServiceRoutingProductDataService productDataService
+
+    void setup() {
+        manager.setupMultiDataSource(DataServiceRoutingProduct)
+        productService = manager.getServiceForConnection(DataServiceRoutingProductService, 'secondary')
+        productDataService = manager.getServiceForConnection(DataServiceRoutingProductDataService, 'secondary')
+    }
+
+    void cleanup() {
+        deleteAllFromConnection('secondary')
+        deleteAllFromConnection(null)
+        manager.cleanupMultiDataSource()
+    }
+
+    void "domain save visible through data service"() {
+        given: 'a product saved via domain API'
+        def saved = saveDomainProduct('DomainVisible', 10)
+
+        when: 'it is retrieved through the data service'
+        def found = productDataService.findByName('DomainVisible')
+
+        then: 'the service sees the domain data'
+        found != null
+        found.id == saved.id
+    }
+
+    void "data service save visible through domain API"() {
+        given: 'a product saved via data service'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'ServiceVisible', amount: 20))
+
+        when: 'it is retrieved through the domain API'
+        def found = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').withNewTransaction {
+            GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').get(saved.id)
+        }
+
+        then: 'the domain API sees the service data'
+        found != null
+        found.id == saved.id
+        found.name == 'ServiceVisible'
+    }
+
+    void "domain delete reflected in data service count"() {
+        given: 'two products saved via data service'
+        def first = productService.save(new DataServiceRoutingProduct(name: 'First', amount: 1))
+        productService.save(new DataServiceRoutingProduct(name: 'Second', amount: 2))
+
+        when: 'one product is deleted via domain API'
+        deleteDomainProduct(first)
+
+        then: 'service count reflects deletion'
+        productDataService.count() == 1
+    }
+
+    void "data service delete reflected in domain API count"() {
+        given: 'two products saved via domain API'
+        def first = saveDomainProduct('Primary', 1)
+        saveDomainProduct('Secondary', 2)
+
+        when: 'one product is deleted via data service'
+        productService.delete(first.id)
+
+        then: 'domain count reflects deletion'
+        countOnConnection('secondary') == 1
+    }
+
+    void "domain and service counts match on secondary"() {
+        given: 'products saved across domain and service layers'
+        saveDomainProduct('Mixed1', 5)
+        productService.save(new DataServiceRoutingProduct(name: 'Mixed2', amount: 6))
+        productDataService.save(new DataServiceRoutingProduct(name: 'Mixed3', amount: 7))
+
+        when: 'counting via both layers'
+        def domainCount = countOnConnection('secondary')
+        def serviceCount = productService.count()
+
+        then: 'counts match on secondary'
+        domainCount == serviceCount
+    }
+
+    private DataServiceRoutingProduct saveDomainProduct(String name, Integer amount) {
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
+        staticApi.withNewTransaction {
+            def item = new DataServiceRoutingProduct(name: name, amount: amount)
+            instanceApi.save(item, [flush: true])
+            item
+        }
+    }
+
+    private void deleteDomainProduct(DataServiceRoutingProduct product) {
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
+        staticApi.withNewTransaction {
+            instanceApi.delete(product, [flush: true])
+        }
+    }
+
+    private long countOnConnection(String connectionName) {
+        def staticApi = connectionName
+                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
+        staticApi.withNewTransaction {
+            staticApi.count()
+        }
+    }
+
+    private void deleteAllFromConnection(String connectionName) {
+        def staticApi = connectionName
+                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
+        def instanceApi = connectionName
+                ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
+        staticApi.withNewTransaction {
+            for (item in staticApi.list()) {
+                instanceApi.delete(item, [flush: true])
+            }
+        }
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiDataSourceSpec.groovy
@@ -20,7 +20,6 @@ package org.apache.grails.data.testing.tck.tests
 
 import spock.lang.Requires
 
-import org.grails.datastore.gorm.GormEnhancer
 
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
@@ -62,8 +61,8 @@ class CrossLayerMultiDataSourceSpec extends GrailsDataTckSpec {
         def saved = productService.save(new DataServiceRoutingProduct(name: 'ServiceVisible', amount: 20))
 
         when: 'it is retrieved through the domain API'
-        def found = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').withNewTransaction {
-            GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').get(saved.id)
+        def found = DataServiceRoutingProduct.secondary.withNewTransaction {
+            DataServiceRoutingProduct.secondary.get(saved.id)
         }
 
         then: 'the domain API sees the service data'
@@ -111,42 +110,39 @@ class CrossLayerMultiDataSourceSpec extends GrailsDataTckSpec {
     }
 
     private DataServiceRoutingProduct saveDomainProduct(String name, Integer amount) {
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
-        staticApi.withNewTransaction {
+        DataServiceRoutingProduct.secondary.withNewTransaction {
             def item = new DataServiceRoutingProduct(name: name, amount: amount)
-            instanceApi.save(item, [flush: true])
+            item.secondary.save(flush: true)
             item
         }
     }
 
     private void deleteDomainProduct(DataServiceRoutingProduct product) {
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
-        staticApi.withNewTransaction {
-            instanceApi.delete(product, [flush: true])
+        DataServiceRoutingProduct.secondary.withNewTransaction {
+            product.secondary.delete(flush: true)
         }
     }
 
     private long countOnConnection(String connectionName) {
-        def staticApi = connectionName
-                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
-        staticApi.withNewTransaction {
-            staticApi.count()
+        if (connectionName) {
+            DataServiceRoutingProduct."${connectionName}".withNewTransaction {
+                DataServiceRoutingProduct."${connectionName}".count()
+            }
+        } else {
+            DataServiceRoutingProduct.withNewTransaction {
+                DataServiceRoutingProduct.count()
+            }
         }
     }
 
     private void deleteAllFromConnection(String connectionName) {
-        def staticApi = connectionName
-                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
-        def instanceApi = connectionName
-                ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
-        staticApi.withNewTransaction {
-            for (item in staticApi.list()) {
-                instanceApi.delete(item, [flush: true])
+        if (connectionName) {
+            DataServiceRoutingProduct."${connectionName}".withNewTransaction {
+                DataServiceRoutingProduct."${connectionName}".list().each { it."${connectionName}".delete(flush: true) }
+            }
+        } else {
+            DataServiceRoutingProduct.withNewTransaction {
+                DataServiceRoutingProduct.list().each { it.delete(flush: true) }
             }
         }
     }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiDataSourceSpec.groovy
@@ -19,6 +19,8 @@
 package org.apache.grails.data.testing.tck.tests
 
 import spock.lang.Requires
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductDataService
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductService

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiTenantMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiTenantMultiDataSourceSpec.groovy
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.tests
+
+import spock.lang.Requires
+import spock.util.environment.RestoreSystemProperties
+
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingMetric
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingMetricService
+
+@RestoreSystemProperties
+@Requires({ instance.manager?.supportsMultiTenantMultiDataSource() })
+class CrossLayerMultiTenantMultiDataSourceSpec extends GrailsDataTckSpec {
+
+    DataServiceRoutingMetricService metricService
+
+    void setup() {
+        manager.setupMultiTenantMultiDataSource(DataServiceRoutingMetric)
+        metricService = manager.getServiceForMultiTenantConnection(DataServiceRoutingMetricService, 'secondary')
+        deleteAllForTenant('tenant1')
+        deleteAllForTenant('tenant2')
+    }
+
+    void cleanup() {
+        try {
+            deleteAllForTenant('tenant1')
+            deleteAllForTenant('tenant2')
+        } finally {
+            System.clearProperty(SystemPropertyTenantResolver.PROPERTY_NAME)
+            manager.cleanupMultiTenantMultiDataSource()
+        }
+    }
+
+    void "domain save with tenant visible through service"() {
+        given: 'tenant1 selected'
+        setTenant('tenant1')
+        def saved = saveDomainMetric('domain_metric', 10)
+
+        when: 'retrieved through the service'
+        def found = metricService.findByName('domain_metric')
+
+        then: 'service sees tenant1 data'
+        found != null
+        found.id == saved.id
+    }
+
+    void "service save with tenant visible through domain API"() {
+        given: 'tenant1 selected'
+        setTenant('tenant1')
+        def saved = metricService.save(new DataServiceRoutingMetric(name: 'service_metric', amount: 20))
+
+        when: 'retrieved through the domain API'
+        def found = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary').withNewTransaction {
+            GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary').get(saved.id)
+        }
+
+        then: 'domain API sees service data'
+        found != null
+        found.id == saved.id
+        found.name == 'service_metric'
+    }
+
+    void "tenant isolation consistent across layers"() {
+        given: 'tenant1 data saved via domain API'
+        setTenant('tenant1')
+        saveDomainMetric('metric1', 1)
+
+        and: 'tenant2 data saved via service'
+        setTenant('tenant2')
+        metricService.save(new DataServiceRoutingMetric(name: 'metric2', amount: 2))
+
+        when: 'querying tenant1 through both layers'
+        setTenant('tenant1')
+        def tenant1DomainCount = countMetrics()
+        def tenant1ServiceCount = metricService.count()
+
+        and: 'querying tenant2 through both layers'
+        setTenant('tenant2')
+        def tenant2DomainCount = countMetrics()
+        def tenant2ServiceCount = metricService.count()
+
+        then: 'each tenant only sees its own data'
+        tenant1DomainCount == 1
+        tenant1ServiceCount == 1
+        tenant2DomainCount == 1
+        tenant2ServiceCount == 1
+    }
+
+    private static void setTenant(String tenantId) {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, tenantId)
+    }
+
+    private DataServiceRoutingMetric saveDomainMetric(String name, Integer amount) {
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
+        staticApi.withNewTransaction {
+            def item = new DataServiceRoutingMetric(name: name, amount: amount)
+            instanceApi.save(item, [flush: true])
+            item
+        }
+    }
+
+    private long countMetrics() {
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        staticApi.withNewTransaction {
+            staticApi.count()
+        }
+    }
+
+    private void deleteAllForTenant(String tenantId) {
+        setTenant(tenantId)
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
+        staticApi.withNewTransaction {
+            for (item in staticApi.list()) {
+                instanceApi.delete(item, [flush: true])
+            }
+        }
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiTenantMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/CrossLayerMultiTenantMultiDataSourceSpec.groovy
@@ -21,7 +21,6 @@ package org.apache.grails.data.testing.tck.tests
 import spock.lang.Requires
 import spock.util.environment.RestoreSystemProperties
 
-import org.grails.datastore.gorm.GormEnhancer
 import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
 
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
@@ -70,8 +69,8 @@ class CrossLayerMultiTenantMultiDataSourceSpec extends GrailsDataTckSpec {
         def saved = metricService.save(new DataServiceRoutingMetric(name: 'service_metric', amount: 20))
 
         when: 'retrieved through the domain API'
-        def found = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary').withNewTransaction {
-            GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary').get(saved.id)
+        def found = DataServiceRoutingMetric.secondary.withNewTransaction {
+            DataServiceRoutingMetric.secondary.get(saved.id)
         }
 
         then: 'domain API sees service data'
@@ -111,30 +110,23 @@ class CrossLayerMultiTenantMultiDataSourceSpec extends GrailsDataTckSpec {
     }
 
     private DataServiceRoutingMetric saveDomainMetric(String name, Integer amount) {
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
-        staticApi.withNewTransaction {
+        DataServiceRoutingMetric.secondary.withNewTransaction {
             def item = new DataServiceRoutingMetric(name: name, amount: amount)
-            instanceApi.save(item, [flush: true])
+            item.secondary.save(flush: true)
             item
         }
     }
 
     private long countMetrics() {
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        staticApi.withNewTransaction {
-            staticApi.count()
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            DataServiceRoutingMetric.secondary.count()
         }
     }
 
     private void deleteAllForTenant(String tenantId) {
         setTenant(tenantId)
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
-        staticApi.withNewTransaction {
-            for (item in staticApi.list()) {
-                instanceApi.delete(item, [flush: true])
-            }
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            DataServiceRoutingMetric.secondary.list().each { it.secondary.delete(flush: true) }
         }
     }
 }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceConnectionRoutingSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceConnectionRoutingSpec.groovy
@@ -19,9 +19,6 @@
 package org.apache.grails.data.testing.tck.tests
 
 import spock.lang.Requires
-
-
-import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductDataService
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductService

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceConnectionRoutingSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceConnectionRoutingSpec.groovy
@@ -20,7 +20,6 @@ package org.apache.grails.data.testing.tck.tests
 
 import spock.lang.Requires
 
-import org.grails.datastore.gorm.GormEnhancer
 
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
@@ -253,37 +252,37 @@ class DataServiceConnectionRoutingSpec extends GrailsDataTckSpec {
     // ---- Helper methods ----
 
     private void saveToConnection(String connectionName, String name, Integer amount) {
-        def api = connectionName
-                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
-        api.withNewTransaction {
-            def instanceApi = connectionName
-                    ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
-                    : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
-            def item = new DataServiceRoutingProduct(name: name, amount: amount)
-            instanceApi.save(item, [flush: true])
+        if (connectionName) {
+            DataServiceRoutingProduct."${connectionName}".withNewTransaction {
+                new DataServiceRoutingProduct(name: name, amount: amount)."${connectionName}".save(flush: true)
+            }
+        } else {
+            DataServiceRoutingProduct.withNewTransaction {
+                new DataServiceRoutingProduct(name: name, amount: amount).save(flush: true)
+            }
         }
     }
 
     private long countOnConnection(String connectionName) {
-        def api = connectionName
-                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
-        api.withNewTransaction {
-            api.count()
+        if (connectionName) {
+            DataServiceRoutingProduct."${connectionName}".withNewTransaction {
+                DataServiceRoutingProduct."${connectionName}".count()
+            }
+        } else {
+            DataServiceRoutingProduct.withNewTransaction {
+                DataServiceRoutingProduct.count()
+            }
         }
     }
 
     private void deleteAllFromConnection(String connectionName) {
-        def api = connectionName
-                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
-        def instanceApi = connectionName
-                ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
-        api.withNewTransaction {
-            for (item in api.list()) {
-                instanceApi.delete(item, [flush: true])
+        if (connectionName) {
+            DataServiceRoutingProduct."${connectionName}".withNewTransaction {
+                DataServiceRoutingProduct."${connectionName}".list().each { it."${connectionName}".delete(flush: true) }
+            }
+        } else {
+            DataServiceRoutingProduct.withNewTransaction {
+                DataServiceRoutingProduct.list().each { it.delete(flush: true) }
             }
         }
     }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceConnectionRoutingSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceConnectionRoutingSpec.groovy
@@ -19,6 +19,8 @@
 package org.apache.grails.data.testing.tck.tests
 
 import spock.lang.Requires
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductDataService
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductService

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceConnectionRoutingSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceConnectionRoutingSpec.groovy
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.tests
+
+import spock.lang.Requires
+
+import org.grails.datastore.gorm.GormEnhancer
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductDataService
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProductService
+
+@Requires({ instance.manager?.supportsMultipleDataSources() })
+class DataServiceConnectionRoutingSpec extends GrailsDataTckSpec {
+
+    DataServiceRoutingProductService productService
+    DataServiceRoutingProductDataService productDataService
+
+    void setup() {
+        manager.setupMultiDataSource(DataServiceRoutingProduct)
+        productService = manager.getServiceForConnection(DataServiceRoutingProductService, 'secondary')
+        productDataService = manager.getServiceForConnection(DataServiceRoutingProductDataService, 'secondary')
+    }
+
+    void cleanup() {
+        deleteAllFromConnection('secondary')
+        deleteAllFromConnection(null)
+        manager.cleanupMultiDataSource()
+    }
+
+    // ---- Abstract class service tests ----
+
+    void "save routes to secondary datasource"() {
+        when: 'a product is saved through the abstract Data Service'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'Widget', amount: 42))
+
+        then: 'it is persisted with an ID'
+        saved != null
+        saved.id != null
+        saved.name == 'Widget'
+        saved.amount == 42
+
+        and: 'it exists on the secondary datasource'
+        countOnConnection('secondary') == 1
+    }
+
+    void "get by ID routes to secondary datasource"() {
+        given: 'a product saved on secondary'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'Gadget', amount: 99))
+
+        when: 'we retrieve it by ID'
+        def found = productService.get(saved.id)
+
+        then: 'the correct entity is returned'
+        found != null
+        found.id == saved.id
+        found.name == 'Gadget'
+        found.amount == 99
+    }
+
+    void "count routes to secondary datasource"() {
+        given: 'two products saved on secondary'
+        productService.save(new DataServiceRoutingProduct(name: 'Alpha', amount: 10))
+        productService.save(new DataServiceRoutingProduct(name: 'Beta', amount: 20))
+
+        and: 'a product saved on default that should not be counted'
+        saveToConnection(null, 'DefaultOnly', 99)
+
+        expect: 'count returns only secondary items'
+        productService.count() == 2
+    }
+
+    void "delete by ID routes to secondary datasource - FindAndDeleteImplementer"() {
+        given: 'a product saved on secondary'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'Ephemeral', amount: 1))
+
+        when: 'we delete it using delete(id) which returns the domain object'
+        def deleted = productService.delete(saved.id)
+
+        then: 'the deleted entity is returned and no longer exists'
+        deleted != null
+        deleted.name == 'Ephemeral'
+        productService.get(saved.id) == null
+        productService.count() == 0
+    }
+
+    void "delete by ID routes to secondary datasource - DeleteImplementer"() {
+        given: 'a product saved on secondary'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'AlsoEphemeral', amount: 2))
+
+        when: 'we delete it using void deleteProduct(id)'
+        productService.deleteProduct(saved.id)
+
+        then: 'it no longer exists'
+        productService.get(saved.id) == null
+        productService.count() == 0
+    }
+
+    void "findByName routes to secondary datasource"() {
+        given: 'products saved on secondary'
+        productService.save(new DataServiceRoutingProduct(name: 'Unique', amount: 77))
+        productService.save(new DataServiceRoutingProduct(name: 'Other', amount: 88))
+
+        when: 'we find by name'
+        def found = productService.findByName('Unique')
+
+        then: 'the correct entity is returned'
+        found != null
+        found.name == 'Unique'
+        found.amount == 77
+    }
+
+    void "findAllByName routes to secondary datasource"() {
+        given: 'products with duplicate names on secondary'
+        productService.save(new DataServiceRoutingProduct(name: 'Duplicate', amount: 10))
+        productService.save(new DataServiceRoutingProduct(name: 'Duplicate', amount: 20))
+        productService.save(new DataServiceRoutingProduct(name: 'Singleton', amount: 30))
+
+        when: 'we find all by name'
+        def found = productService.findAllByName('Duplicate')
+
+        then: 'both matching entities are returned'
+        found.size() == 2
+        found.every { it.name == 'Duplicate' }
+    }
+
+    void "constructor-style save routes to secondary datasource"() {
+        when: 'a product is saved using property arguments'
+        def saved = productService.saveProduct('Constructed', 55)
+
+        then: 'it is persisted on secondary'
+        saved != null
+        saved.id != null
+        saved.name == 'Constructed'
+        saved.amount == 55
+
+        and: 'retrievable'
+        productService.get(saved.id) != null
+    }
+
+    void "save, get, and find round-trip through Data Service"() {
+        when: 'a product is saved, retrieved by ID, and found by name'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'RoundTrip', amount: 33))
+        def byId = productService.get(saved.id)
+        def byName = productService.findByName('RoundTrip')
+
+        then: 'all three references point to the same entity'
+        saved.id == byId.id
+        saved.id == byName.id
+        byId.name == 'RoundTrip'
+        byName.amount == 33
+    }
+
+    // ---- Interface service tests ----
+
+    void "interface service: save routes to secondary datasource"() {
+        when: 'a product is saved through the interface Data Service'
+        def saved = productDataService.save(new DataServiceRoutingProduct(name: 'InterfaceWidget', amount: 42))
+
+        then: 'it is persisted with an ID'
+        saved != null
+        saved.id != null
+        saved.name == 'InterfaceWidget'
+        saved.amount == 42
+
+        and: 'it exists on the secondary datasource'
+        countOnConnection('secondary') == 1
+    }
+
+    void "interface service: get by ID routes to secondary datasource"() {
+        given: 'a product saved on secondary via abstract service'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'InterfaceGet', amount: 99))
+
+        when: 'we retrieve it through the interface Data Service'
+        def found = productDataService.get(saved.id)
+
+        then: 'the correct entity is returned'
+        found != null
+        found.id == saved.id
+        found.name == 'InterfaceGet'
+    }
+
+    void "interface service: delete routes to secondary datasource"() {
+        given: 'a product saved on secondary'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'InterfaceDelete', amount: 1))
+
+        when: 'we delete through the interface Data Service (FindAndDeleteImplementer)'
+        def deleted = productDataService.delete(saved.id)
+
+        then: 'the entity is deleted'
+        deleted != null
+        deleted.name == 'InterfaceDelete'
+        productDataService.get(saved.id) == null
+    }
+
+    void "interface service: void delete routes to secondary datasource"() {
+        given: 'a product saved on secondary'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'InterfaceVoidDel', amount: 2))
+
+        when: 'we delete through the interface Data Service (DeleteImplementer)'
+        productDataService.deleteProduct(saved.id)
+
+        then: 'the entity is deleted'
+        productDataService.get(saved.id) == null
+    }
+
+    void "interface and abstract services share the same datasource"() {
+        given: 'a product saved through the abstract service'
+        def saved = productService.save(new DataServiceRoutingProduct(name: 'CrossService', amount: 77))
+
+        expect: 'the interface service can find it'
+        productDataService.findByName('CrossService') != null
+        productDataService.findByName('CrossService').id == saved.id
+
+        and: 'counts match across both service patterns'
+        productService.count() == productDataService.count()
+    }
+
+    void "secondary data is not visible on default datasource"() {
+        given: 'a product saved on secondary'
+        productService.save(new DataServiceRoutingProduct(name: 'SecondaryOnly', amount: 42))
+
+        expect: 'it is not visible on the default datasource'
+        countOnConnection(null) == 0
+    }
+
+    void "default data is not visible on secondary datasource"() {
+        given: 'a product saved on default'
+        saveToConnection(null, 'DefaultOnly', 42)
+
+        expect: 'it is not visible through the secondary-bound service'
+        productService.count() == 0
+        productService.findByName('DefaultOnly') == null
+    }
+
+    // ---- Helper methods ----
+
+    private void saveToConnection(String connectionName, String name, Integer amount) {
+        def api = connectionName
+                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
+        api.withNewTransaction {
+            def instanceApi = connectionName
+                    ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
+                    : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
+            def item = new DataServiceRoutingProduct(name: name, amount: amount)
+            instanceApi.save(item, [flush: true])
+        }
+    }
+
+    private long countOnConnection(String connectionName) {
+        def api = connectionName
+                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
+        api.withNewTransaction {
+            api.count()
+        }
+    }
+
+    private void deleteAllFromConnection(String connectionName) {
+        def api = connectionName
+                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
+        def instanceApi = connectionName
+                ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
+        api.withNewTransaction {
+            for (item in api.list()) {
+                instanceApi.delete(item, [flush: true])
+            }
+        }
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceMultiTenantConnectionRoutingSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceMultiTenantConnectionRoutingSpec.groovy
@@ -21,7 +21,6 @@ package org.apache.grails.data.testing.tck.tests
 import spock.lang.Requires
 import spock.util.environment.RestoreSystemProperties
 
-import org.grails.datastore.gorm.GormEnhancer
 import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
 
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
@@ -147,12 +146,8 @@ class DataServiceMultiTenantConnectionRoutingSpec extends GrailsDataTckSpec {
 
     private void deleteAllForTenant(String tenantId) {
         tenant = tenantId
-        def api = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
-        api.withNewTransaction {
-            for (item in api.list()) {
-                instanceApi.delete(item, [flush: true])
-            }
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            DataServiceRoutingMetric.secondary.list().each { it.secondary.delete(flush: true) }
         }
     }
 }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceMultiTenantConnectionRoutingSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DataServiceMultiTenantConnectionRoutingSpec.groovy
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.tests
+
+import spock.lang.Requires
+import spock.util.environment.RestoreSystemProperties
+
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingMetric
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingMetricService
+
+@RestoreSystemProperties
+@Requires({ instance.manager?.supportsMultiTenantMultiDataSource() })
+class DataServiceMultiTenantConnectionRoutingSpec extends GrailsDataTckSpec {
+
+    DataServiceRoutingMetricService metricService
+
+    void setup() {
+        manager.setupMultiTenantMultiDataSource(DataServiceRoutingMetric)
+        metricService = manager.getServiceForMultiTenantConnection(DataServiceRoutingMetricService, 'secondary')
+
+        deleteAllForTenant('tenant1')
+        deleteAllForTenant('tenant2')
+    }
+
+    void cleanup() {
+        try {
+            deleteAllForTenant('tenant1')
+            deleteAllForTenant('tenant2')
+        } finally {
+            System.clearProperty(SystemPropertyTenantResolver.PROPERTY_NAME)
+            manager.cleanupMultiTenantMultiDataSource()
+        }
+    }
+
+    void "save routes to secondary datasource with tenant isolation"() {
+        given:
+        tenant = 'tenant1'
+
+        when: 'a metric is saved under tenant1'
+        def saved = metricService.save(new DataServiceRoutingMetric(name: 'page_views', amount: 100))
+
+        then: 'it is persisted with an ID'
+        saved != null
+        saved.id != null
+        saved.name == 'page_views'
+        saved.amount == 100
+    }
+
+    void "get retrieves from secondary datasource"() {
+        given: 'a metric saved under tenant1'
+        tenant = 'tenant1'
+        def saved = metricService.save(new DataServiceRoutingMetric(name: 'sessions', amount: 42))
+
+        when: 'we retrieve it by ID'
+        def found = metricService.get(saved.id)
+
+        then: 'the correct metric is returned'
+        found != null
+        found.id == saved.id
+        found.name == 'sessions'
+        found.amount == 42
+    }
+
+    void "count is scoped to current tenant on secondary datasource"() {
+        given: 'metrics saved under tenant1'
+        tenant = 'tenant1'
+        metricService.save(new DataServiceRoutingMetric(name: 'alpha', amount: 1))
+        metricService.save(new DataServiceRoutingMetric(name: 'beta', amount: 2))
+
+        and: 'a metric saved under tenant2'
+        tenant = 'tenant2'
+        metricService.save(new DataServiceRoutingMetric(name: 'gamma', amount: 3))
+
+        when: 'counting under tenant1'
+        tenant = 'tenant1'
+        def count1 = metricService.count()
+
+        and: 'counting under tenant2'
+        tenant = 'tenant2'
+        def count2 = metricService.count()
+
+        then: 'each tenant sees only its own data'
+        count1 == 2
+        count2 == 1
+    }
+
+    void "delete removes from secondary datasource"() {
+        given: 'a metric saved under tenant1'
+        tenant = 'tenant1'
+        def saved = metricService.save(new DataServiceRoutingMetric(name: 'disposable', amount: 0))
+        def id = saved.id
+
+        when: 'the metric is deleted'
+        metricService.delete(id)
+
+        then: 'it no longer exists'
+        metricService.get(id) == null
+        metricService.count() == 0
+    }
+
+    void "findByName routes to secondary datasource with tenant isolation"() {
+        given: 'same-named metrics under different tenants'
+        tenant = 'tenant1'
+        metricService.save(new DataServiceRoutingMetric(name: 'shared_name', amount: 100))
+        tenant = 'tenant2'
+        metricService.save(new DataServiceRoutingMetric(name: 'shared_name', amount: 200))
+
+        when: 'finding by name under tenant1'
+        tenant = 'tenant1'
+        def found1 = metricService.findByName('shared_name')
+
+        and: 'finding by name under tenant2'
+        tenant = 'tenant2'
+        def found2 = metricService.findByName('shared_name')
+
+        then: 'each tenant gets its own metric'
+        found1 != null
+        found1.amount == 100
+
+        found2 != null
+        found2.amount == 200
+    }
+
+    private static void setTenant(String tenantId) {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, tenantId)
+    }
+
+    private void deleteAllForTenant(String tenantId) {
+        tenant = tenantId
+        def api = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
+        api.withNewTransaction {
+            for (item in api.list()) {
+                instanceApi.delete(item, [flush: true])
+            }
+        }
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DomainMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DomainMultiDataSourceSpec.groovy
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.tests
+
+import spock.lang.Requires
+
+import org.grails.datastore.gorm.GormEnhancer
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
+
+@Requires({ instance.manager?.supportsMultipleDataSources() })
+class DomainMultiDataSourceSpec extends GrailsDataTckSpec {
+
+    void setup() {
+        manager.setupMultiDataSource(DataServiceRoutingProduct)
+    }
+
+    void cleanup() {
+        deleteAllFromConnection('secondary')
+        deleteAllFromConnection(null)
+        manager.cleanupMultiDataSource()
+    }
+
+    void "save to secondary datasource via domain API"() {
+        given: 'a secondary connection API'
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
+
+        when: 'a product is saved through the instance API'
+        staticApi.withNewTransaction {
+            instanceApi.save(new DataServiceRoutingProduct(name: 'Widget', amount: 42), [flush: true])
+        }
+
+        then: 'the secondary datasource records the entity'
+        countOnConnection('secondary') == 1
+    }
+
+    void "get by ID from secondary datasource via domain API"() {
+        given: 'a product saved on secondary'
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
+        def id = staticApi.withNewTransaction {
+            def saved = new DataServiceRoutingProduct(name: 'Gadget', amount: 99)
+            instanceApi.save(saved, [flush: true])
+            saved.id
+        }
+
+        when: 'the product is retrieved by ID'
+        def found = staticApi.withNewTransaction {
+            staticApi.get(id)
+        }
+
+        then: 'the correct entity is returned'
+        found != null
+        found.id == id
+        found.name == 'Gadget'
+    }
+
+    void "count on secondary datasource via domain API"() {
+        given: 'two products saved on secondary'
+        saveToConnection('secondary', 'Alpha', 10)
+        saveToConnection('secondary', 'Beta', 20)
+
+        and: 'a product saved on default'
+        saveToConnection(null, 'DefaultOnly', 99)
+
+        expect: 'only secondary records are counted'
+        countOnConnection('secondary') == 2
+    }
+
+    void "list on secondary datasource via domain API"() {
+        given: 'three products on secondary'
+        saveToConnection('secondary', 'One', 1)
+        saveToConnection('secondary', 'Two', 2)
+        saveToConnection('secondary', 'Three', 3)
+
+        when: 'listing through the secondary static API'
+        def items = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').withNewTransaction {
+            GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').list()
+        }
+
+        then: 'all secondary items are returned'
+        items.size() == 3
+    }
+
+    void "criteria query on secondary datasource via domain API"() {
+        given: 'two products with different names'
+        saveToConnection('secondary', 'Match', 1)
+        saveToConnection('secondary', 'Other', 2)
+
+        when: 'querying by name'
+        def results = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').withNewTransaction {
+            GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').withCriteria {
+                eq 'name', 'Match'
+            }
+        }
+
+        then: 'only matching entities are returned'
+        results.size() == 1
+        results.first().name == 'Match'
+    }
+
+    void "delete from secondary datasource via domain API"() {
+        given: 'a product saved on secondary'
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
+        def saved = staticApi.withNewTransaction {
+            def item = new DataServiceRoutingProduct(name: 'Disposable', amount: 5)
+            instanceApi.save(item, [flush: true])
+            item
+        }
+
+        when: 'the product is deleted'
+        staticApi.withNewTransaction {
+            instanceApi.delete(saved, [flush: true])
+        }
+
+        then: 'the secondary datasource is empty'
+        countOnConnection('secondary') == 0
+    }
+
+    void "secondary data not visible on default via domain API"() {
+        given: 'a product saved on secondary'
+        saveToConnection('secondary', 'SecondaryOnly', 42)
+
+        expect: 'the default connection sees no records'
+        countOnConnection(null) == 0
+    }
+
+    void "default data not visible on secondary via domain API"() {
+        given: 'a product saved on default'
+        saveToConnection(null, 'DefaultOnly', 42)
+
+        expect: 'secondary does not see default data'
+        countOnConnection('secondary') == 0
+    }
+
+    private void saveToConnection(String connectionName, String name, Integer amount) {
+        def staticApi = connectionName
+                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
+        def instanceApi = connectionName
+                ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
+        staticApi.withNewTransaction {
+            instanceApi.save(new DataServiceRoutingProduct(name: name, amount: amount), [flush: true])
+        }
+    }
+
+    private long countOnConnection(String connectionName) {
+        def staticApi = connectionName
+                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
+        staticApi.withNewTransaction {
+            staticApi.count()
+        }
+    }
+
+    private void deleteAllFromConnection(String connectionName) {
+        def staticApi = connectionName
+                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
+        def instanceApi = connectionName
+                ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
+                : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
+        staticApi.withNewTransaction {
+            for (item in staticApi.list()) {
+                instanceApi.delete(item, [flush: true])
+            }
+        }
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DomainMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DomainMultiDataSourceSpec.groovy
@@ -20,8 +20,6 @@ package org.apache.grails.data.testing.tck.tests
 
 import spock.lang.Requires
 
-import org.grails.datastore.gorm.GormEnhancer
-
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.apache.grails.data.testing.tck.domains.DataServiceRoutingProduct
 
@@ -39,13 +37,9 @@ class DomainMultiDataSourceSpec extends GrailsDataTckSpec {
     }
 
     void "save to secondary datasource via domain API"() {
-        given: 'a secondary connection API'
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
-
-        when: 'a product is saved through the instance API'
-        staticApi.withNewTransaction {
-            instanceApi.save(new DataServiceRoutingProduct(name: 'Widget', amount: 42), [flush: true])
+        when: 'a product is saved through the secondary connection'
+        DataServiceRoutingProduct.secondary.withNewTransaction {
+            new DataServiceRoutingProduct(name: 'Widget', amount: 42).secondary.save(flush: true)
         }
 
         then: 'the secondary datasource records the entity'
@@ -54,17 +48,15 @@ class DomainMultiDataSourceSpec extends GrailsDataTckSpec {
 
     void "get by ID from secondary datasource via domain API"() {
         given: 'a product saved on secondary'
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
-        def id = staticApi.withNewTransaction {
+        def id = DataServiceRoutingProduct.secondary.withNewTransaction {
             def saved = new DataServiceRoutingProduct(name: 'Gadget', amount: 99)
-            instanceApi.save(saved, [flush: true])
+            saved.secondary.save(flush: true)
             saved.id
         }
 
         when: 'the product is retrieved by ID'
-        def found = staticApi.withNewTransaction {
-            staticApi.get(id)
+        def found = DataServiceRoutingProduct.secondary.withNewTransaction {
+            DataServiceRoutingProduct.secondary.get(id)
         }
 
         then: 'the correct entity is returned'
@@ -91,9 +83,9 @@ class DomainMultiDataSourceSpec extends GrailsDataTckSpec {
         saveToConnection('secondary', 'Two', 2)
         saveToConnection('secondary', 'Three', 3)
 
-        when: 'listing through the secondary static API'
-        def items = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').withNewTransaction {
-            GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').list()
+        when: 'listing through the secondary connection'
+        def items = DataServiceRoutingProduct.secondary.withNewTransaction {
+            DataServiceRoutingProduct.secondary.list()
         }
 
         then: 'all secondary items are returned'
@@ -106,8 +98,8 @@ class DomainMultiDataSourceSpec extends GrailsDataTckSpec {
         saveToConnection('secondary', 'Other', 2)
 
         when: 'querying by name'
-        def results = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').withNewTransaction {
-            GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary').withCriteria {
+        def results = DataServiceRoutingProduct.secondary.withNewTransaction {
+            DataServiceRoutingProduct.secondary.withCriteria {
                 eq 'name', 'Match'
             }
         }
@@ -119,17 +111,15 @@ class DomainMultiDataSourceSpec extends GrailsDataTckSpec {
 
     void "delete from secondary datasource via domain API"() {
         given: 'a product saved on secondary'
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingProduct, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingProduct, 'secondary')
-        def saved = staticApi.withNewTransaction {
+        def saved = DataServiceRoutingProduct.secondary.withNewTransaction {
             def item = new DataServiceRoutingProduct(name: 'Disposable', amount: 5)
-            instanceApi.save(item, [flush: true])
+            item.secondary.save(flush: true)
             item
         }
 
         when: 'the product is deleted'
-        staticApi.withNewTransaction {
-            instanceApi.delete(saved, [flush: true])
+        DataServiceRoutingProduct.secondary.withNewTransaction {
+            saved.secondary.delete(flush: true)
         }
 
         then: 'the secondary datasource is empty'
@@ -153,36 +143,37 @@ class DomainMultiDataSourceSpec extends GrailsDataTckSpec {
     }
 
     private void saveToConnection(String connectionName, String name, Integer amount) {
-        def staticApi = connectionName
-                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
-        def instanceApi = connectionName
-                ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
-        staticApi.withNewTransaction {
-            instanceApi.save(new DataServiceRoutingProduct(name: name, amount: amount), [flush: true])
+        if (connectionName) {
+            DataServiceRoutingProduct."${connectionName}".withNewTransaction {
+                new DataServiceRoutingProduct(name: name, amount: amount)."${connectionName}".save(flush: true)
+            }
+        } else {
+            DataServiceRoutingProduct.withNewTransaction {
+                new DataServiceRoutingProduct(name: name, amount: amount).save(flush: true)
+            }
         }
     }
 
     private long countOnConnection(String connectionName) {
-        def staticApi = connectionName
-                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
-        staticApi.withNewTransaction {
-            staticApi.count()
+        if (connectionName) {
+            DataServiceRoutingProduct."${connectionName}".withNewTransaction {
+                DataServiceRoutingProduct."${connectionName}".count()
+            }
+        } else {
+            DataServiceRoutingProduct.withNewTransaction {
+                DataServiceRoutingProduct.count()
+            }
         }
     }
 
     private void deleteAllFromConnection(String connectionName) {
-        def staticApi = connectionName
-                ? GormEnhancer.findStaticApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findStaticApi(DataServiceRoutingProduct)
-        def instanceApi = connectionName
-                ? GormEnhancer.findInstanceApi(DataServiceRoutingProduct, connectionName)
-                : GormEnhancer.findInstanceApi(DataServiceRoutingProduct)
-        staticApi.withNewTransaction {
-            for (item in staticApi.list()) {
-                instanceApi.delete(item, [flush: true])
+        if (connectionName) {
+            DataServiceRoutingProduct."${connectionName}".withNewTransaction {
+                DataServiceRoutingProduct."${connectionName}".list().each { it."${connectionName}".delete(flush: true) }
+            }
+        } else {
+            DataServiceRoutingProduct.withNewTransaction {
+                DataServiceRoutingProduct.list().each { it.delete(flush: true) }
             }
         }
     }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DomainMultiTenantMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DomainMultiTenantMultiDataSourceSpec.groovy
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.grails.data.testing.tck.tests
+
+import spock.lang.Requires
+import spock.util.environment.RestoreSystemProperties
+
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
+
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
+import org.apache.grails.data.testing.tck.domains.DataServiceRoutingMetric
+
+@RestoreSystemProperties
+@Requires({ instance.manager?.supportsMultiTenantMultiDataSource() })
+class DomainMultiTenantMultiDataSourceSpec extends GrailsDataTckSpec {
+
+    void setup() {
+        manager.setupMultiTenantMultiDataSource(DataServiceRoutingMetric)
+        deleteAllForTenant('tenant1')
+        deleteAllForTenant('tenant2')
+    }
+
+    void cleanup() {
+        try {
+            deleteAllForTenant('tenant1')
+            deleteAllForTenant('tenant2')
+        } finally {
+            System.clearProperty(SystemPropertyTenantResolver.PROPERTY_NAME)
+            manager.cleanupMultiTenantMultiDataSource()
+        }
+    }
+
+    void "save with tenant isolation on secondary via domain API"() {
+        given: 'a tenant selected'
+        setTenant('tenant1')
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
+
+        when: 'a metric is saved under tenant1'
+        staticApi.withNewTransaction {
+            instanceApi.save(new DataServiceRoutingMetric(name: 'page_views', amount: 100), [flush: true])
+        }
+
+        then: 'count reflects tenant scoped data'
+        staticApi.withNewTransaction {
+            staticApi.count()
+        } == 1
+    }
+
+    void "count scoped to tenant on secondary via domain API"() {
+        given: 'metrics under tenant1'
+        setTenant('tenant1')
+        saveMetric('alpha', 1)
+        saveMetric('beta', 2)
+
+        and: 'a metric under tenant2'
+        setTenant('tenant2')
+        saveMetric('gamma', 3)
+
+        when: 'counting under tenant1'
+        setTenant('tenant1')
+        def tenant1Count = countMetrics()
+
+        and: 'counting under tenant2'
+        setTenant('tenant2')
+        def tenant2Count = countMetrics()
+
+        then: 'each tenant sees only its data'
+        tenant1Count == 2
+        tenant2Count == 1
+    }
+
+    void "criteria query scoped to tenant on secondary via domain API"() {
+        given: 'same named metrics across tenants'
+        setTenant('tenant1')
+        saveMetric('shared', 10)
+        setTenant('tenant2')
+        saveMetric('shared', 20)
+
+        when: 'querying by name under tenant1'
+        setTenant('tenant1')
+        def tenant1Results = findByName('shared')
+
+        and: 'querying by name under tenant2'
+        setTenant('tenant2')
+        def tenant2Results = findByName('shared')
+
+        then: 'results are isolated per tenant'
+        tenant1Results.size() == 1
+        tenant1Results.first().amount == 10
+        tenant2Results.size() == 1
+        tenant2Results.first().amount == 20
+    }
+
+    void "delete with tenant isolation on secondary via domain API"() {
+        given: 'a metric saved under tenant1'
+        setTenant('tenant1')
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
+        def saved = staticApi.withNewTransaction {
+            def item = new DataServiceRoutingMetric(name: 'disposable', amount: 0)
+            instanceApi.save(item, [flush: true])
+            item
+        }
+
+        when: 'the metric is deleted'
+        staticApi.withNewTransaction {
+            instanceApi.delete(saved, [flush: true])
+        }
+
+        then: 'tenant1 has no metrics'
+        countMetrics() == 0
+    }
+
+    void "tenant1 data not visible to tenant2 via domain API"() {
+        given: 'data under tenant1'
+        setTenant('tenant1')
+        saveMetric('isolated', 5)
+
+        when: 'switching to tenant2'
+        setTenant('tenant2')
+
+        then: 'tenant2 sees no data'
+        countMetrics() == 0
+    }
+
+    private static void setTenant(String tenantId) {
+        System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, tenantId)
+    }
+
+    private void saveMetric(String name, Integer amount) {
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
+        staticApi.withNewTransaction {
+            instanceApi.save(new DataServiceRoutingMetric(name: name, amount: amount), [flush: true])
+        }
+    }
+
+    private long countMetrics() {
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        staticApi.withNewTransaction {
+            staticApi.count()
+        }
+    }
+
+    private List<DataServiceRoutingMetric> findByName(String name) {
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        staticApi.withNewTransaction {
+            staticApi.withCriteria {
+                eq 'name', name
+            }
+        }
+    }
+
+    private void deleteAllForTenant(String tenantId) {
+        setTenant(tenantId)
+        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
+        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
+        staticApi.withNewTransaction {
+            for (item in staticApi.list()) {
+                instanceApi.delete(item, [flush: true])
+            }
+        }
+    }
+}

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DomainMultiTenantMultiDataSourceSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/DomainMultiTenantMultiDataSourceSpec.groovy
@@ -21,7 +21,6 @@ package org.apache.grails.data.testing.tck.tests
 import spock.lang.Requires
 import spock.util.environment.RestoreSystemProperties
 
-import org.grails.datastore.gorm.GormEnhancer
 import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
 
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
@@ -50,17 +49,14 @@ class DomainMultiTenantMultiDataSourceSpec extends GrailsDataTckSpec {
     void "save with tenant isolation on secondary via domain API"() {
         given: 'a tenant selected'
         setTenant('tenant1')
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
-
         when: 'a metric is saved under tenant1'
-        staticApi.withNewTransaction {
-            instanceApi.save(new DataServiceRoutingMetric(name: 'page_views', amount: 100), [flush: true])
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            new DataServiceRoutingMetric(name: 'page_views', amount: 100).secondary.save(flush: true)
         }
 
         then: 'count reflects tenant scoped data'
-        staticApi.withNewTransaction {
-            staticApi.count()
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            DataServiceRoutingMetric.secondary.count()
         } == 1
     }
 
@@ -112,17 +108,15 @@ class DomainMultiTenantMultiDataSourceSpec extends GrailsDataTckSpec {
     void "delete with tenant isolation on secondary via domain API"() {
         given: 'a metric saved under tenant1'
         setTenant('tenant1')
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
-        def saved = staticApi.withNewTransaction {
+        def saved = DataServiceRoutingMetric.secondary.withNewTransaction {
             def item = new DataServiceRoutingMetric(name: 'disposable', amount: 0)
-            instanceApi.save(item, [flush: true])
+            item.secondary.save(flush: true)
             item
         }
 
         when: 'the metric is deleted'
-        staticApi.withNewTransaction {
-            instanceApi.delete(saved, [flush: true])
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            saved.secondary.delete(flush: true)
         }
 
         then: 'tenant1 has no metrics'
@@ -146,24 +140,20 @@ class DomainMultiTenantMultiDataSourceSpec extends GrailsDataTckSpec {
     }
 
     private void saveMetric(String name, Integer amount) {
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
-        staticApi.withNewTransaction {
-            instanceApi.save(new DataServiceRoutingMetric(name: name, amount: amount), [flush: true])
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            new DataServiceRoutingMetric(name: name, amount: amount).secondary.save(flush: true)
         }
     }
 
     private long countMetrics() {
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        staticApi.withNewTransaction {
-            staticApi.count()
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            DataServiceRoutingMetric.secondary.count()
         }
     }
 
     private List<DataServiceRoutingMetric> findByName(String name) {
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        staticApi.withNewTransaction {
-            staticApi.withCriteria {
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            DataServiceRoutingMetric.secondary.withCriteria {
                 eq 'name', name
             }
         }
@@ -171,12 +161,8 @@ class DomainMultiTenantMultiDataSourceSpec extends GrailsDataTckSpec {
 
     private void deleteAllForTenant(String tenantId) {
         setTenant(tenantId)
-        def staticApi = GormEnhancer.findStaticApi(DataServiceRoutingMetric, 'secondary')
-        def instanceApi = GormEnhancer.findInstanceApi(DataServiceRoutingMetric, 'secondary')
-        staticApi.withNewTransaction {
-            for (item in staticApi.list()) {
-                instanceApi.delete(item, [flush: true])
-            }
+        DataServiceRoutingMetric.secondary.withNewTransaction {
+            DataServiceRoutingMetric.secondary.list().each { it.secondary.delete(flush: true) }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds TCK specs that validate multi-datasource and multi-tenant GORM operations across all datastore implementations (Hibernate5, MongoDB), covering Data Services, direct domain operations, and cross-layer consistency. Also fixes a classpath pollution bug in `AbstractDatastoreInitializer.loadDataServices()`.

### Data Service Specs

**DataServiceConnectionRoutingSpec** (16 tests)
- save, get, count, delete (FindAndDelete + Delete implementers), findByName, findAllByName, constructor-style save
- Both abstract class and interface service patterns
- Cross-datasource isolation: secondary data not visible on default, and vice versa

**DataServiceMultiTenantConnectionRoutingSpec** (5 tests)
- DISCRIMINATOR multi-tenancy combined with secondary datasource routing
- Tenant isolation for save, get, count, delete, and findByName
- First-ever test of DISCRIMINATOR + multi-datasource on MongoDB

### Domain-Level Specs

**DomainMultiDataSourceSpec** (8 tests)
- Direct GORM operations on secondary datasource via GormEnhancer API
- save, get, count, list, criteria query, delete
- Cross-datasource isolation verification

**DomainMultiTenantMultiDataSourceSpec** (5 tests)
- Direct GORM operations with DISCRIMINATOR tenancy on secondary datasource
- Tenant-scoped count, criteria query, delete, and isolation

### Cross-Layer Specs

**CrossLayerMultiDataSourceSpec** (5 tests)
- Data saved via domain API visible through Data Services
- Data saved via Data Services visible through domain API
- Delete propagation and count consistency across layers

**CrossLayerMultiTenantMultiDataSourceSpec** (3 tests)
- Tenant-isolated data consistent across domain API and Data Service layers
- Mixed saves (domain + service) with tenant isolation verification

### TCK Infrastructure

- `GrailsDataTckManager`: new `supportsMultiTenantMultiDataSource()`, `setupMultiTenantMultiDataSource()`, `cleanupMultiTenantMultiDataSource()`, `getServiceForMultiTenantConnection()` methods
- `GrailsDataHibernate5TckManager`: DISCRIMINATOR mode with `SystemPropertyTenantResolver` and dual H2 in-memory databases
- `GrailsDataMongoTckManager`: DISCRIMINATOR mode with `SystemPropertyTenantResolver` and dual MongoDB databases

### Bug Fix

`AbstractDatastoreInitializer.loadDataServices()` previously loaded ALL `@Service` implementations from the classpath without filtering by mapped domain classes. This caused standalone initializers (e.g., `MongoDbDataStoreSpringInitializer`) to fail when unrelated services on the classpath referenced datasource connections not configured in the initializer. The fix filters discovered services to only those whose `@Service(value)` domain class is in the initializer's `persistentClasses` collection.

### Test Results

| Suite | Tests | Pass | Fail |
|-------|-------|------|------|
| Hibernate5 TCK | 279 | 279 | 0 |
| MongoDB TCK (new specs) | 21 | 21 | 0 |
| MongoDbDataStoreSpringInitializerSpec | 7 | 7 | 0 |
| grails-datastore-web | all | all | 0 |