### PR TITLE
ci: reduce indy=true to one job per test type

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -141,7 +141,10 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 21 ]
-        indy: [ false, true ]
+        indy: [ false ]
+        include:
+          - java: 17
+            indy: true
     runs-on: ubuntu-24.04
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
@@ -200,7 +203,10 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 21, 25 ]
-        indy: [ false, true ]
+        indy: [ false ]
+        include:
+          - java: 17
+            indy: true
     runs-on: ubuntu-24.04
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
@@ -237,7 +243,11 @@ jobs:
       matrix:
         java: [ 17, 25 ]
         mongodb-version: [ '7.0', '8.0' ] # test with supported versions https://www.mongodb.com/legal/support-policy/lifecycles
-        indy: [ false, true ]
+        indy: [ false ]
+        include:
+          - java: 17
+            mongodb-version: '7.0'
+            indy: true
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
         run: curl -s https://api.ipify.org
@@ -272,7 +282,10 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 25 ]
-        indy: [ false, true ]
+        indy: [ false ]
+        include:
+          - java: 17
+            indy: true
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
         run: curl -s https://api.ipify.org


### PR DESCRIPTION
## Summary

Follow-up to #15415. Instead of pairing \`indy=true\` with every Java version, run a single \`indy=true\` job (Java 17) per test type alongside all the existing \`indy=false\` combinations.

## Job count change

| Job | Before | After |
|-----|--------|-------|
| `buildForge` | 4 (2 Java × 2 indy) | 3 (2 Java indy=false + 1 indy=true) |
| `functional` | 6 (3 Java × 2 indy) | 4 (3 Java indy=false + 1 indy=true) |
| `mongodbFunctional` | 8 (2 Java × 2 MongoDB × 2 indy) | 5 (4 indy=false + 1 indy=true) |
| `hibernate5Functional` | 4 (2 Java × 2 indy) | 3 (2 Java indy=false + 1 indy=true) |

The single `indy=true` run per job type uses Java 17 (minimum supported version). For `mongodbFunctional` it also pins MongoDB 7.0.

Relates to #15321, follow-up to #15415