### PR TITLE
docs: add quality rules to AGENTS.md critical rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ export GRADLE_OPTS="-Xms2G -Xmx5G"
 4. **No wildcard imports** - Use explicit imports
 5. **4 spaces, no tabs** - See `.editorconfig`
 6. **Apache license header** - Required on all new source files
+7. **New features require docs** - Any user-facing change must include or update documentation in `grails-doc`; do not merge features without corresponding doc coverage
+8. **No internal APIs in docs** - Only document public APIs; never reference internal or package-private classes and methods in user-facing documentation
+9. **Test via public APIs** - Tests must exercise behavior through the same APIs an end user calls; never invoke internal implementations, package-private methods, or bypass the public surface directly
+10. **Always review and extend tests** - Review existing unit and functional tests before making changes; every code change must include new or enhanced tests that cover the affected behavior
 
 ## Available Skills
 


### PR DESCRIPTION
## Summary

Adds four rules to the **Critical Rules** section of `AGENTS.md` to enforce documentation hygiene, API surface discipline, and test coverage requirements for AI agents working in this repo.

- **Rule 7** - New user-facing features must include or update documentation in `grails-doc`
- **Rule 8** - User-facing docs must only reference public APIs; no internal or package-private classes
- **Rule 9** - Tests must exercise behavior through the public API surface as an end user would, never bypassing internals
- **Rule 10** - Always review existing tests before making changes and add/enhance tests to cover the affected behavior