### PR TITLE
fix(grails-gradle): change indy log level from lifecycle to info

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -234,8 +234,8 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 c.groovyOptions.optimizationOptions.indy = indyEnabled
             }
             if (!indyEnabled) {
-                project.logger.lifecycle('Grails: Groovy invokedynamic (indy) is disabled to improve performance (see issue #15293).')
-                project.logger.lifecycle('        To enable invokedynamic: grails { indy = true } in build.gradle')
+                project.logger.info('Grails: Groovy invokedynamic (indy) is disabled to improve performance (see issue #15293).')
+                project.logger.info('        To enable invokedynamic: grails { indy = true } in build.gradle')
             }
         }
     }


### PR DESCRIPTION
## Summary

- Change indy disabled message from `logger.lifecycle` to `logger.info` so it doesn't print on every build

## Context

Follow-up to #15375. The `lifecycle` log level causes the indy message to appear on every Gradle invocation, which is noisy. Using `info` keeps the message available via `--info` or `--debug` without cluttering default output.