### PR TITLE
fix: where query composition fails when variable is re-assigned in if/else blocks

### DIFF
--- a/grails-datamapping-core-test/src/test/groovy/grails/gorm/tests/WhereMethodSpec.groovy
+++ b/grails-datamapping-core-test/src/test/groovy/grails/gorm/tests/WhereMethodSpec.groovy
@@ -1553,6 +1553,73 @@ class Project {
         }
     }
 
+    def "Test where query composition with re-assigned variable in if/else blocks"() {
+        given: "A bunch of people"
+        createPeople()
+
+        when: "A where query variable is assigned inside an if/else block and then chained"
+        def condition = true
+        def query
+        if (condition) {
+            query = Person.where { lastName == 'Simpson' }
+        } else {
+            query = Person.where { lastName == 'Rubble' }
+        }
+        query = query.where { age > 10 }
+        def results = query.list()
+
+        then: "Both criteria from the if block and the chained where are applied"
+        results.size() == 2
+        results.every { it.lastName == 'Simpson' && it.age > 10 }
+
+        when: "The else branch is taken instead"
+        condition = false
+        if (condition) {
+            query = Person.where { lastName == 'Simpson' }
+        } else {
+            query = Person.where { lastName == 'Rubble' }
+        }
+        query = query.where { age > 10 }
+        results = query.list()
+
+        then: "Both criteria from the else block and the chained where are applied"
+        results.size() == 1
+        results[0].lastName == 'Rubble'
+        results[0].firstName == 'Barney'
+    }
+
+    def "Test where query composition with re-assigned variable without initializer"() {
+        given: "A bunch of people"
+        createPeople()
+
+        when: "A variable is declared without initializer and then assigned a where query"
+        def query
+        query = Person.where { lastName == 'Simpson' }
+        query = query.where { firstName == 'Bart' }
+        def results = query.list()
+
+        then: "Both criteria are applied"
+        results.size() == 1
+        results[0].firstName == 'Bart'
+        results[0].lastName == 'Simpson'
+    }
+
+    def "Test where query composition with chained where on re-assigned variable"() {
+        given: "A bunch of people"
+        createPeople()
+
+        when: "Multiple where queries are chained on a re-assigned variable"
+        def query
+        query = Person.where { age > 5 }
+        query = query.where { age < 42 }
+        query = query.where { lastName == 'Simpson' }
+        def results = query.list()
+
+        then: "All three criteria are applied"
+        results.size() == 3
+        results.every { it.age > 5 && it.age < 42 && it.lastName == 'Simpson' }
+    }
+
     protected createContinentWithCountries() {
         final continent = new Continent(name: "Africa")
         continent.countries << new Country(name: "SA", population: 304830) << new Country(name: "Zim", population: 304830)

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/criteria/AbstractDetachedCriteria.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/criteria/AbstractDetachedCriteria.groovy
@@ -881,6 +881,7 @@ abstract class AbstractDetachedCriteria<T> implements Criteria, Cloneable {
         criteria.defaultOffset = defaultOffset
         criteria.@fetchStrategies = new HashMap<>(this.fetchStrategies)
         criteria.@joinTypes = new HashMap<>(this.joinTypes)
+        criteria.@junctions = new ArrayList(this.junctions)
         criteria.@connectionName = this.connectionName
         criteria.@lazyQuery = this.lazyQuery
         criteria.@associationCriteriaMap = new LinkedHashMap<>(this.associationCriteriaMap)

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/DetachedCriteriaTransformer.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/DetachedCriteriaTransformer.java
@@ -364,9 +364,7 @@ public class DetachedCriteriaTransformer extends ClassCodeVisitorSupport {
                 VariableExpression var = (VariableExpression) leftExpression;
                 String variableName = var.getName();
                 ConstructorCallExpression cce = (ConstructorCallExpression) rightExpression;
-
-                ClassNode type = cce.getType();
-                if (DETACHED_CRITERIA_CLASS_NODE.getName().equals(type.getName())) {
+                if (DETACHED_CRITERIA_CLASS_NODE.getName().equals(cce.getType().getName())) {
                     Expression arguments = cce.getArguments();
                     if (arguments instanceof ArgumentListExpression) {
                         ArgumentListExpression ale = (ArgumentListExpression) arguments;
@@ -374,7 +372,20 @@ public class DetachedCriteriaTransformer extends ClassCodeVisitorSupport {
                             Expression exp = ale.getExpression(0);
                             if (exp instanceof ClassExpression) {
                                 ClassExpression clse = (ClassExpression) exp;
-                                detachedCriteriaVariables.put(variableName, clse.getType());
+                                ClassNode domainType = clse.getType();
+                                detachedCriteriaVariables.put(variableName, domainType);
+
+                                // Update the variable's type to DetachedCriteria<DomainClass>
+                                ClassNode classNode = new ClassNode(DetachedCriteria.class);
+                                classNode.setGenericsTypes(new GenericsType[]{new GenericsType(domainType)});
+                                if (var.isClosureSharedVariable()) {
+                                    Variable accessedVariable = var.getAccessedVariable();
+                                    if (accessedVariable instanceof VariableExpression) {
+                                        ((VariableExpression) accessedVariable).setType(classNode);
+                                    }
+                                } else {
+                                    var.setType(classNode);
+                                }
                             }
                         }
                     }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/DetachedCriteriaTransformer.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/DetachedCriteriaTransformer.java
@@ -71,6 +71,7 @@ import org.codehaus.groovy.ast.stmt.WhileStatement;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.messages.LocatedMessage;
 import org.codehaus.groovy.syntax.Token;
+import org.codehaus.groovy.syntax.Types;
 import org.codehaus.groovy.transform.trait.Traits;
 
 import grails.gorm.DetachedCriteria;
@@ -310,6 +311,77 @@ public class DetachedCriteriaTransformer extends ClassCodeVisitorSupport {
             }
         }
         super.visitDeclarationExpression(expression);
+    }
+
+    /**
+     * Handles re-assignment of variables to domain class where queries.
+     * For example: {@code zoneQuery = ComputeZone.where { field == value }}
+     * <p>
+     * This ensures that the variable is tracked in {@link #detachedCriteriaVariables}
+     * so that subsequent {@code zoneQuery.where { ... }} calls have their closures
+     * properly transformed.
+     * <p>
+     * Without this, only declarations ({@code def query = Domain.where { ... }}) are tracked,
+     * and re-assignments inside if/else blocks are silently ignored.
+     */
+    @Override
+    public void visitBinaryExpression(BinaryExpression expression) {
+        // Only handle assignment expressions (=), not comparisons (==) or other operators
+        if (expression.getOperation().getType() == Types.ASSIGN) {
+            Expression leftExpression = expression.getLeftExpression();
+            Expression rightExpression = expression.getRightExpression();
+
+            if (leftExpression instanceof VariableExpression && rightExpression instanceof MethodCallExpression) {
+                MethodCallExpression call = (MethodCallExpression) rightExpression;
+                Expression objectExpression = call.getObjectExpression();
+                Expression method = call.getMethod();
+                Expression arguments = call.getArguments();
+
+                if (isCandidateMethod(method.getText(), arguments, CANDIDATE_METHODS_WHERE_ONLY)) {
+                    ClassNode targetType = objectExpression.getType();
+                    if (AstUtils.isDomainClass(targetType)) {
+                        VariableExpression var = (VariableExpression) leftExpression;
+                        String variableName = var.getName();
+
+                        // Track this variable so subsequent .where{} calls are transformed
+                        detachedCriteriaVariables.put(variableName, targetType);
+
+                        // Update the variable's type to DetachedCriteria<DomainClass>
+                        ClassNode classNode = new ClassNode(DetachedCriteria.class);
+                        classNode.setGenericsTypes(new GenericsType[]{new GenericsType(targetType)});
+                        if (var.isClosureSharedVariable()) {
+                            Variable accessedVariable = var.getAccessedVariable();
+                            if (accessedVariable instanceof VariableExpression) {
+                                ((VariableExpression) accessedVariable).setType(classNode);
+                            }
+                        } else {
+                            var.setType(classNode);
+                        }
+                    }
+                }
+            } else if (leftExpression instanceof VariableExpression && rightExpression instanceof ConstructorCallExpression) {
+                // Handle: zoneQuery = new DetachedCriteria(ComputeZone)
+                VariableExpression var = (VariableExpression) leftExpression;
+                String variableName = var.getName();
+                ConstructorCallExpression cce = (ConstructorCallExpression) rightExpression;
+
+                ClassNode type = cce.getType();
+                if (DETACHED_CRITERIA_CLASS_NODE.getName().equals(type.getName())) {
+                    Expression arguments = cce.getArguments();
+                    if (arguments instanceof ArgumentListExpression) {
+                        ArgumentListExpression ale = (ArgumentListExpression) arguments;
+                        if (ale.getExpressions().size() == 1) {
+                            Expression exp = ale.getExpression(0);
+                            if (exp instanceof ClassExpression) {
+                                ClassExpression clse = (ClassExpression) exp;
+                                detachedCriteriaVariables.put(variableName, clse.getType());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        super.visitBinaryExpression(expression);
     }
 
     private void logTransformationError(ASTNode astNode, Exception e) {

--- a/grails-test-examples/gorm/src/integration-test/groovy/gorm/GormWhereQueryAdvancedSpec.groovy
+++ b/grails-test-examples/gorm/src/integration-test/groovy/gorm/GormWhereQueryAdvancedSpec.groovy
@@ -318,6 +318,53 @@ class GormWhereQueryAdvancedSpec extends Specification {
         expensiveInStock.list().every { it.inStock && it.price > 15.0 }
     }
 
+
+    // ============================================
+    // Where Query with Re-assigned Variables
+    // ============================================
+
+    void "test where query composition with re-assigned variable in if/else block"() {
+        when: "building a where query with conditional re-assignment"
+        boolean filterInStock = true
+        def query
+        if (filterInStock) {
+            query = Book.where { inStock == true }
+        } else {
+            query = Book.where { inStock == false }
+        }
+        query = query.where { price > 15.0 }
+        def results = query.list()
+
+        then: "both conditions are applied"
+        results.every { it.inStock && it.price > 15.0 }
+        results.size() >= 2
+    }
+
+    void "test where query composition with re-assigned variable without initializer"() {
+        when: "declaring variable without initializer then assigning a where query"
+        def query
+        query = Book.where { author.name == 'Stephen King' }
+        query = query.where { inStock == true }
+        def results = query.list()
+
+        then: "both conditions are applied"
+        results.every { it.author.name == 'Stephen King' && it.inStock }
+        results.size() == 2 // The Stand and It (The Shining is out of stock)
+    }
+
+    void "test where query with triple chained re-assigned variable"() {
+        when: "chaining three where clauses on a re-assigned variable"
+        def query
+        query = Book.where { inStock == true }
+        query = query.where { price >= 14.0 }
+        query = query.where { pageCount > 400 }
+        def results = query.list()
+
+        then: "all three conditions are applied"
+        results.every { it.inStock && it.price >= 14.0 && it.pageCount > 400 }
+        results.size() >= 2
+    }
+
     // ============================================
     // Where Query with Sorting
     // ============================================


### PR DESCRIPTION
## Summary

- Fix `DetachedCriteriaTransformer` AST transform to track variables that are re-assigned (not just declared with initializer), so `where` query composition works correctly inside `if/else` blocks
- Add `junctions` to `AbstractDetachedCriteria.clone()` for completeness

## Problem

When building dynamic GORM `where` queries with conditional logic, re-assigned variables are silently ignored:

```groovy
def query
if (someCondition) {
    query = DomainClass.where { visible == true }  // This was silently ignored!
} else {
    query = DomainClass.where { visible == false }
}
query = query.where { name == 'test' }  // This chained where also broken
```

The `DetachedCriteriaTransformer` only tracked variables declared with an initializer (`def query = DomainClass.where{...}`) via `visitDeclarationExpression()`, but not variables that were re-assigned (`query = DomainClass.where{...}`) which are `BinaryExpression` nodes. When the transformer encountered `query.where{...}`, it couldn't find `query` in its `detachedCriteriaVariables` map, so the closure body was left untransformed. At runtime, the untransformed closure's property access resolved via `propertyMissing` to a non-mutating clone, and the criteria were silently dropped.

## Reproducer

Sample Grails 7 app demonstrating the bug: https://github.com/jamesfredley/grails-where-query-reassignment-bug

## Root Cause

The `DetachedCriteriaTransformer` AST transform has a gap in its variable tracking:

1. `visitDeclarationExpression()` handles `def query = DomainClass.where{...}` - registers variable in `detachedCriteriaVariables`
2. **No handler** existed for re-assignment `query = DomainClass.where{...}` - this is a `BinaryExpression`, not a `DeclarationExpression`
3. When the transformer encounters `query.where{visible == true}`:
   - `detachedCriteriaVariables.get("query")` returns `null` (never tracked)
   - Fallback: `var.getType()` returns `Object` (declared as `def query` with no initializer)
   - Neither path matches, so the closure body is NOT transformed
4. At runtime, the untransformed closure evaluates as a no-op

## Fix

1. **`DetachedCriteriaTransformer.java`**: Added `visitBinaryExpression()` override that detects assignments where the RHS is a `DomainClass.where{...}` call or `new DetachedCriteria(DomainClass)` constructor, and registers the LHS variable in `detachedCriteriaVariables` with the correct type. Also updates the variable's declared type to `DetachedCriteria<DomainClass>` so subsequent `query.where{...}` calls are properly transformed.

2. **`AbstractDetachedCriteria.groovy`**: Added `junctions` to the `clone()` method to ensure complex AND/OR query compositions are preserved during cloning.

## Tests

Added 3 new test cases to `WhereMethodSpec.groovy`:
- Re-assigned variable in `if/else` blocks (both branches verified)
- Re-assigned variable without initializer (`def query; query = Person.where{...}`)
- Triple-chained `where` on re-assigned variable

All 80 WhereMethodSpec tests pass. Code style check passes.