### PR TITLE
fix: remove unused GroovyPlugin import from GrailsGradlePlugin

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -104,7 +104,7 @@ class GrailsGradlePlugin implements Plugin<Project> {
 
     void apply(Project project) {
 
-        project.pluginManager.apply('groovy')
+        project.pluginManager.apply(GroovyPlugin)
 
         // validate that only an app or a plugin is registered, and never both
         OnlyOneGrailsPlugin marker = (OnlyOneGrailsPlugin) project.getExtensions().findByName(OnlyOneGrailsPlugin.name)


### PR DESCRIPTION
## Summary
- Remove unused `org.gradle.api.plugins.GroovyPlugin` import from `GrailsGradlePlugin.groovy`
- The import was left behind when the class was changed from `extends GroovyPlugin` to `implements Plugin<Project>` on 8.0.x
- Fixes codenarc `UnusedImport` violation that blocks the 7.1.x → 8.0.x merge PR (#15450)