### PR TITLE
fix: flaky ersatz listener test due to async race condition

### DIFF
--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzAdvancedSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzAdvancedSpec.groovy
@@ -31,9 +31,12 @@ import micronaut.client.MicronautHeaderClient
 import micronaut.client.MicronautTestClient
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+
+import java.util.concurrent.CopyOnWriteArrayList
 
 import grails.testing.mixin.integration.Integration
 
@@ -556,7 +559,7 @@ class MicronautErsatzAdvancedSpec extends Specification {
 
     void "ersatz listener captures request details"() {
         given: 'ersatz captures request details'
-        List<Object> captured = []
+        CopyOnWriteArrayList<Object> captured = new CopyOnWriteArrayList<>()
         ersatz.expectations({ expect ->
             expect.GET('/micronaut-test/listen', { req ->
                 req.listener({ captured << it })
@@ -579,7 +582,11 @@ class MicronautErsatzAdvancedSpec extends Specification {
 
         then: 'a request was captured'
         response.status.code == 200
-        captured.size() == 1
+
+        and: 'the listener eventually captures the request'
+        new PollingConditions(timeout: 5).eventually {
+            assert captured.size() == 1
+        }
 
         and: 'ersatz verifies the call'
         ersatz.verify()


### PR DESCRIPTION
## Summary

- Fixes intermittent failure in `MicronautErsatzAdvancedSpec > ersatz listener captures request details` (seen in [Functional Tests (17) on PR #15420](https://github.com/apache/grails-core/actions/runs/22367572748/job/64752401657))
- The Ersatz listener callback runs asynchronously on a server thread, but the test asserted `captured.size() == 1` immediately - a race condition where the listener hadn't populated the list yet
- Uses `CopyOnWriteArrayList` for thread safety and Spock `PollingConditions` to wait up to 5 seconds for the async listener to complete

## Root Cause

```
captured.size() == 1
|        |      |
|        0      false
[{ GET /micronaut-test/listen(...) }]
```

The request was received (visible in the toString), but the listener closure `{ captured << it }` hadn't executed yet when the assertion ran. Plain `ArrayList` is also not thread-safe for cross-thread writes.