### PR TITLE
Fix DetachedCriteria join behavior for get() in Hibernate

### DIFF
--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateQuery.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateQuery.java
@@ -696,6 +696,17 @@ public abstract class AbstractHibernateQuery extends Query {
     }
 
     @Override
+    public Query join(String property, JoinType joinType) {
+        this.hasJoins = true;
+        this.joinTypes.put(property, joinType);
+        if (criteria != null)
+            criteria.setFetchMode(property, FetchMode.JOIN);
+        else if (detachedCriteria != null)
+            detachedCriteria.setFetchMode(property, FetchMode.JOIN);
+        return this;
+    }
+
+    @Override
     public Query select(String property) {
         this.hasJoins = true;
         if (criteria != null)

--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateQuery.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateQuery.java
@@ -685,6 +685,78 @@ public abstract class AbstractHibernateQuery extends Query {
         c.addOrder(order.isIgnoreCase() ? hibernateOrder.ignoreCase() : hibernateOrder);
     }
 
+    private String calculateProjectionPropertyName(String propertyName) {
+        int firstDot = propertyName.indexOf('.');
+        if (firstDot < 0) {
+            return calculatePropertyName(propertyName);
+        }
+
+        PersistentEntity currentEntity = getEntity();
+        String currentAlias = null;
+        StringBuilder associationPath = new StringBuilder();
+        String[] tokens = propertyName.split("\\.");
+
+        for (int i = 0; i < tokens.length - 1; i++) {
+            String token = tokens[i];
+            PersistentProperty persistentProperty = currentEntity != null ? currentEntity.getPropertyByName(token) : null;
+            if (!(persistentProperty instanceof Association) || persistentProperty instanceof Embedded) {
+                return calculatePropertyName(propertyName);
+            }
+
+            if (associationPath.length() > 0) {
+                associationPath.append('.');
+            }
+            associationPath.append(token);
+
+            CriteriaAndAlias criteriaAndAlias = getOrCreateAlias(associationPath.toString(), generateAlias(token));
+            if (criteriaAndAlias == null) {
+                return calculatePropertyName(propertyName);
+            }
+            currentAlias = criteriaAndAlias.alias;
+            currentEntity = ((Association) persistentProperty).getAssociatedEntity();
+        }
+
+        if (currentAlias == null) {
+            return calculatePropertyName(propertyName);
+        }
+        return currentAlias + '.' + tokens[tokens.length - 1];
+    }
+
+    private Query.Projection normalizeProjectionPropertyPath(Query.Projection projection) {
+        if (!(projection instanceof Query.PropertyProjection)) {
+            return projection;
+        }
+
+        String propertyName = ((Query.PropertyProjection) projection).getPropertyName();
+        String normalizedPropertyName = calculateProjectionPropertyName(propertyName);
+        if (propertyName.equals(normalizedPropertyName)) {
+            return projection;
+        }
+
+        if (projection instanceof Query.DistinctPropertyProjection) {
+            return org.grails.datastore.mapping.query.Projections.distinct(normalizedPropertyName);
+        }
+        if (projection instanceof Query.CountDistinctProjection) {
+            return org.grails.datastore.mapping.query.Projections.countDistinct(normalizedPropertyName);
+        }
+        if (projection instanceof Query.GroupPropertyProjection) {
+            return org.grails.datastore.mapping.query.Projections.groupProperty(normalizedPropertyName);
+        }
+        if (projection instanceof Query.SumProjection) {
+            return org.grails.datastore.mapping.query.Projections.sum(normalizedPropertyName);
+        }
+        if (projection instanceof Query.MinProjection) {
+            return org.grails.datastore.mapping.query.Projections.min(normalizedPropertyName);
+        }
+        if (projection instanceof Query.MaxProjection) {
+            return org.grails.datastore.mapping.query.Projections.max(normalizedPropertyName);
+        }
+        if (projection instanceof Query.AvgProjection) {
+            return org.grails.datastore.mapping.query.Projections.avg(normalizedPropertyName);
+        }
+        return org.grails.datastore.mapping.query.Projections.property(normalizedPropertyName);
+    }
+
     @Override
     public Query join(String property) {
         this.hasJoins = true;
@@ -957,19 +1029,19 @@ public abstract class AbstractHibernateQuery extends Query {
 
         @Override
         public ProjectionList add(Projection p) {
-            projectionList.add(new HibernateProjectionAdapter(p).toHibernateProjection());
+            projectionList.add(new HibernateProjectionAdapter(normalizeProjectionPropertyPath(p)).toHibernateProjection());
             return this;
         }
 
         @Override
         public org.grails.datastore.mapping.query.api.ProjectionList countDistinct(String property) {
-            projectionList.add(Projections.countDistinct(calculatePropertyName(property)));
+            projectionList.add(Projections.countDistinct(calculateProjectionPropertyName(property)));
             return this;
         }
 
         @Override
         public org.grails.datastore.mapping.query.api.ProjectionList distinct(String property) {
-            projectionList.add(Projections.distinct(Projections.property(calculatePropertyName(property))));
+            projectionList.add(Projections.distinct(Projections.property(calculateProjectionPropertyName(property))));
             return this;
         }
 
@@ -995,31 +1067,31 @@ public abstract class AbstractHibernateQuery extends Query {
 
         @Override
         public ProjectionList property(String name) {
-            projectionList.add(Projections.property(calculatePropertyName(name)));
+            projectionList.add(Projections.property(calculateProjectionPropertyName(name)));
             return this;
         }
 
         @Override
         public ProjectionList sum(String name) {
-            projectionList.add(Projections.sum(calculatePropertyName(name)));
+            projectionList.add(Projections.sum(calculateProjectionPropertyName(name)));
             return this;
         }
 
         @Override
         public ProjectionList min(String name) {
-            projectionList.add(Projections.min(calculatePropertyName(name)));
+            projectionList.add(Projections.min(calculateProjectionPropertyName(name)));
             return this;
         }
 
         @Override
         public ProjectionList max(String name) {
-            projectionList.add(Projections.max(calculatePropertyName(name)));
+            projectionList.add(Projections.max(calculateProjectionPropertyName(name)));
             return this;
         }
 
         @Override
         public ProjectionList avg(String name) {
-            projectionList.add(Projections.avg(calculatePropertyName(name)));
+            projectionList.add(Projections.avg(calculateProjectionPropertyName(name)));
             return this;
         }
 

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/DetachedCriteriaJoinSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/DetachedCriteriaJoinSpec.groovy
@@ -126,4 +126,34 @@ class DetachedCriteriaJoinSpec extends GrailsDataTckSpec<GrailsDataHibernate5Tck
         then:
         result == 'Inter'
     }
+
+    def 'check list with association subquery plus join and projection works'() {
+        given:
+        def club = new Club(name: 'Ajax').save(flush: true)
+        new Team(name: 'Amsterdammers', club: club).save(flush: true)
+
+        when:
+        def result = Team.where {
+            club {
+                name == 'Ajax'
+            }
+        }.join('club').property('club.name').list()
+
+        then:
+        result == ['Ajax']
+    }
+
+    def 'check list can sort by joined association property'() {
+        given:
+        def clubA = new Club(name: 'A Club').save(flush: true)
+        def clubB = new Club(name: 'B Club').save(flush: true)
+        new Team(name: 'Team B', club: clubB).save(flush: true)
+        new Team(name: 'Team A', club: clubA).save(flush: true)
+
+        when:
+        def result = Team.where {}.join('club').sort('club.name', 'asc').property('name').list()
+
+        then:
+        result == ['Team A', 'Team B']
+    }
 }

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/DetachedCriteriaJoinSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/DetachedCriteriaJoinSpec.groovy
@@ -23,6 +23,7 @@ import org.apache.grails.data.hibernate5.core.GrailsDataHibernate5TckManager
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.grails.datastore.gorm.finders.DynamicFinder
 import org.grails.orm.hibernate.query.HibernateQuery
+import org.hibernate.Hibernate
 
 import jakarta.persistence.criteria.JoinType
 
@@ -87,5 +88,18 @@ class DetachedCriteriaJoinSpec extends GrailsDataTckSpec<GrailsDataHibernate5Tck
         def joinType = query.hibernateCriteria.subcriteriaList.first().joinType
         expect:
         joinType == org.hibernate.sql.JoinType.RIGHT_OUTER_JOIN
+    }
+
+    def 'check get honours join and eagerly loads association'() {
+        given:
+        def club = new Club(name: 'Juventus').save(flush: true)
+        new Team(name: 'Torino', club: club).save(flush: true)
+
+        when:
+        Team team = Team.where { name == 'Torino' }.join('club').get()
+
+        then:
+        team != null
+        Hibernate.isInitialized(team.club)
     }
 }

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/DetachedCriteriaJoinSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/DetachedCriteriaJoinSpec.groovy
@@ -29,7 +29,7 @@ import jakarta.persistence.criteria.JoinType
 
 class DetachedCriteriaJoinSpec extends GrailsDataTckSpec<GrailsDataHibernate5TckManager> {
     void setupSpec() {
-        manager.domainClasses.addAll([Team, Club])
+        manager.domainClasses.addAll([Team, Club, Player, Contract])
     }
 
     def "check if count works as expected"() {
@@ -155,5 +155,59 @@ class DetachedCriteriaJoinSpec extends GrailsDataTckSpec<GrailsDataHibernate5Tck
 
         then:
         result == ['Team A', 'Team B']
+    }
+
+    def 'check get honours join with join type and eagerly loads association'() {
+        given:
+        def club = new Club(name: 'PSG').save(flush: true)
+        new Team(name: 'Paris', club: club).save(flush: true)
+
+        when:
+        Team team = Team.where { name == 'Paris' }.join('club', JoinType.LEFT).get()
+
+        then:
+        team != null
+        Hibernate.isInitialized(team.club)
+    }
+
+    def 'check list with multiple projections on joined association'() {
+        given:
+        def club = new Club(name: 'Benfica').save(flush: true)
+        new Team(name: 'Lisbon', club: club).save(flush: true)
+
+        when:
+        def result = Team.where { name == 'Lisbon' }.join('club').property('club.name').property('name').list()
+
+        then:
+        result.size() == 1
+        result[0][0] == 'Benfica'
+        result[0][1] == 'Lisbon'
+    }
+
+    def 'check list with deep nested projection path on players'() {
+        given:
+        def club = new Club(name: 'Boca Juniors').save(flush: true)
+        def team = new Team(name: 'Xeneizes', club: club).save(flush: true)
+        def player = new Player(name: 'Roman', team: team)
+        player.contract = new Contract(salary: 5_000_000G, player: player)
+        player.save(flush: true)
+
+        when:
+        def result = Team.where { name == 'Xeneizes' }.join('players').property('players.name').list()
+
+        then:
+        result == ['Roman']
+    }
+
+    def 'check invalid projection path throws exception'() {
+        when:
+        new DetachedCriteria(Team).build {
+            projections {
+                property('nonexistent.field')
+            }
+        }.list()
+
+        then:
+        thrown(Exception)
     }
 }

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/DetachedCriteriaJoinSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/DetachedCriteriaJoinSpec.groovy
@@ -102,4 +102,28 @@ class DetachedCriteriaJoinSpec extends GrailsDataTckSpec<GrailsDataHibernate5Tck
         team != null
         Hibernate.isInitialized(team.club)
     }
+
+    def 'check list with join and projected association property works without explicit alias'() {
+        given:
+        def club = new Club(name: 'Milan').save(flush: true)
+        new Team(name: 'Rossoneri', club: club).save(flush: true)
+
+        when:
+        def result = Team.where { name == 'Rossoneri' }.join('club').property('club.name').list()
+
+        then:
+        result == ['Milan']
+    }
+
+    def 'check get with join and projected association property works without explicit alias'() {
+        given:
+        def club = new Club(name: 'Inter').save(flush: true)
+        new Team(name: 'Nerazzurri', club: club).save(flush: true)
+
+        when:
+        def result = Team.where { name == 'Nerazzurri' }.join('club').property('club.name').get()
+
+        then:
+        result == 'Inter'
+    }
 }


### PR DESCRIPTION
## Summary
This PR now fixes two related DetachedCriteria/Hibernate issues:

1. `where { ... }.join(...).get()` did not consistently honor join handling like `.list()`
2. `join('association').property('association.field')` did not auto-create aliases for nested projection paths unless `createAlias(...)` was explicitly called

## Issue 1: `join(...).get()` behavior diverged from `.list()`
### Root cause
`DetachedCriteria` joins are applied via `DynamicFinder.applyDetachedCriteria(...)`, which can call:
- `query.join(property)` or
- `query.join(property, joinType)`

In `AbstractHibernateQuery`, only `join(String)` was overridden. `join(String, JoinType)` fell back to the base `Query` implementation, so Hibernate-specific join state used by single-result execution could diverge.

### Why `.list()` and `.get()` differed
- `.list()` path (`AbstractHibernateQuery.list()`) applies fetch strategies and executes list semantics.
- `.get()` uses `query.singleResult()` path, which relies on Hibernate query join state (`hasJoins`) when evaluating unique-result execution behavior.

### Fix
Add `AbstractHibernateQuery.join(String property, JoinType joinType)` override that:
- sets `hasJoins = true`
- records `joinTypes.put(property, joinType)`
- applies `FetchMode.JOIN` to criteria/detachedCriteria

## Issue 2: projection with joined association path required explicit `createAlias`
### Symptom
`Team.where { ... }.join('club').property('club.name').list()` / `.get()` raised:
- `QueryException: could not resolve property: club.name of: Team`

Unless users manually did `createAlias('club','club')`.

### Root cause
Detached-criteria projections are adapted via `HibernateProjectionAdapter` through `ProjectionList.add(...)`, and nested association property paths were not normalized to Hibernate aliases before projection adaptation.

### Fix
In `AbstractHibernateQuery`:
- Add projection-path normalization that auto-creates aliases for nested association paths (e.g. `club.name`)
- Normalize property-based projections before passing to `HibernateProjectionAdapter`
- Keep behavior safe for non-association and embedded paths

## Tests
Added/updated `DetachedCriteriaJoinSpec` coverage:
- `check get honours join and eagerly loads association`
- `check list with join and projected association property works without explicit alias`
- `check get with join and projected association property works without explicit alias`
- `check list with association subquery plus join and projection works`

All pass with:
- `./gradlew :grails-data-hibernate5-core:test --tests grails.gorm.tests.DetachedCriteriaJoinSpec`

Co-Authored-By: Oz <oz-agent@warp.dev>
