### PR TITLE
Deprecate Spring JSP theme support for removal in Grails 8.0.0

### DIFF
--- a/grails-spring/src/main/groovy/org/grails/spring/GrailsApplicationContext.java
+++ b/grails-spring/src/main/groovy/org/grails/spring/GrailsApplicationContext.java
@@ -98,12 +98,25 @@ public class GrailsApplicationContext extends GenericApplicationContext implemen
 
     /**
      * Initialize the theme capability.
+     *
+     * @deprecated since 7.1, for removal in 8.0. Spring's theme support ({@link ThemeSource},
+     * {@link UiApplicationContextUtils#initThemeSource}) is deprecated in Spring Boot 3 and
+     * removed in Spring Boot 4. This method will be removed in Grails 8.0.0.
      */
+    @Deprecated(since = "7.1", forRemoval = true)
     @Override
     protected void onRefresh() {
         themeSource = UiApplicationContextUtils.initThemeSource(this);
     }
 
+    /**
+     * Return the {@link Theme} instance for the given theme name.
+     *
+     * @deprecated since 7.1, for removal in 8.0. Spring's theme support ({@link ThemeSource},
+     * {@link Theme}) is deprecated in Spring Boot 3 and removed in Spring Boot 4.
+     * This method will be removed in Grails 8.0.0.
+     */
+    @Deprecated(since = "7.1", forRemoval = true)
     public Theme getTheme(String themeName) {
         return themeSource.getTheme(themeName);
     }

--- a/grails-web-core/src/main/groovy/grails/web/servlet/context/GrailsWebApplicationContext.java
+++ b/grails-web-core/src/main/groovy/grails/web/servlet/context/GrailsWebApplicationContext.java
@@ -48,6 +48,10 @@ import org.grails.spring.GrailsApplicationContext;
  * A WebApplicationContext that extends StaticApplicationContext to allow for programmatic
  * configuration at runtime. The code is adapted from StaticWebApplicationContext.
  *
+ * <p>Note: The {@link ThemeSource} interface implementation is deprecated since Grails 7.1 and
+ * will be removed in Grails 8.0.0. Spring's theme support is deprecated in Spring Boot 3 and
+ * removed in Spring Boot 4.
+ *
  * @author Graeme
  * @since 0.3
  */


### PR DESCRIPTION
## Summary

- Mark `GrailsApplicationContext.onRefresh()` and `GrailsApplicationContext.getTheme(String)` as `@Deprecated(since = "7.1", forRemoval = true)` with Javadoc explaining the rationale
- Add deprecation notice to `GrailsWebApplicationContext` Javadoc for its `ThemeSource` interface implementation

## Motivation

Spring's theme support (`ThemeSource`, `Theme`, `UiApplicationContextUtils`, `SessionThemeResolver`, etc.) is deprecated in Spring Framework 6 / Spring Boot 3 and **removed in Spring Boot 4**. Grails should surface these deprecation warnings to users now so they can migrate before Grails 8.0.0 removes the support entirely.

## Changes

| File | Change |
|------|--------|
| `GrailsApplicationContext.java` | `@Deprecated(since = "7.1", forRemoval = true)` on `onRefresh()` and `getTheme(String)` |
| `GrailsWebApplicationContext.java` | Javadoc deprecation note on `ThemeSource` implementation |