### PR TITLE
Add method-based TagLib syntax with legacy compatibility, benchmarks, and docs

### DIFF
--- a/grails-doc/src/en/guide/testing/unitTesting/unitTestingTagLibraries.adoc
+++ b/grails-doc/src/en/guide/testing/unitTesting/unitTestingTagLibraries.adoc
@@ -39,7 +39,7 @@ Adding the `TagLibUnitTest` trait to a test causes a new `tagLib` field to be
 automatically created for the TagLib class under test.  The `tagLib` property can
 be used to test calling tags as function calls. The return value of a function
 call is either a `org.grails.buffer,StreamCharBuffer`
-instance or the object returned from the tag closure when
+instance or the object returned from the tag handler when
 `returnObjectForTags` feature is used.
 
 To test a tag which accepts parameters, specify the parameter values as named

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs.adoc
@@ -71,6 +71,20 @@ Used as:
 <g:greeting name="Graeme" />
 ----
 
+For tags with strict validation/error handling, you can keep a `Map attrs` handler and add typed overloads that delegate to it:
+
+[source,groovy]
+----
+def field(Map attrs) {
+    // existing validation + rendering path
+}
+
+def field(String type, Map attrs) {
+    attrs.type = type
+    field(attrs)
+}
+----
+
 As demonstrated above there is an implicit `out` variable that refers to the output `Writer` which you can use to append content to the response. Then you can reference the tag inside your GSP; no imports are necessary:
 
 [source,xml]

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs.adoc
@@ -28,23 +28,26 @@ class SimpleTagLib {
 }
 ----
 
-Now to create a tag create a Closure property that takes two arguments: the tag attributes and the body content:
+Now create tags using methods. You can access tag attributes through the implicit `attrs` map and body through the implicit `body` closure:
 
 [source,groovy]
 ----
 class SimpleTagLib {
-    def simple = { attrs, body ->
+    def simple() {
+        // ...
 
     }
 }
 ----
 
-The `attrs` argument is a Map of the attributes of the tag, whilst the `body` argument is a Closure that returns the body content when invoked:
+Closure field-style tags are still supported for backward compatibility, but method-based tags are the recommended syntax.
+
+The implicit `attrs` property is a `Map` of the tag attributes, while `body()` returns the tag body content when invoked:
 
 [source,groovy]
 ----
 class SimpleTagLib {
-    def emoticon = { attrs, body ->
+    def emoticon() {
        out << body() << (attrs.happy == 'true' ? " :-)" : " :-(")
     }
 }
@@ -57,7 +60,7 @@ As demonstrated above there is an implicit `out` variable that refers to the out
 <g:emoticon happy="true">Hi John</g:emoticon>
 ----
 
-NOTE: To help IDEs like Spring Tool Suite (STS) and others autocomplete tag attributes, you should add Javadoc comments to your tag closures with `@attr` descriptions. Since taglibs use Groovy code it can be difficult to reliably detect all usable attributes.
+NOTE: To help IDEs like Spring Tool Suite (STS) and others autocomplete tag attributes, add Javadoc comments with `@attr` descriptions to your tag methods. Since taglibs use Groovy code it can be difficult to reliably detect all usable attributes.
 
 For example:
 
@@ -71,7 +74,7 @@ class SimpleTagLib {
      * @attr happy whether to show a happy emoticon ('true') or
      * a sad emoticon ('false')
      */
-    def emoticon = { attrs, body ->
+    def emoticon() {
        out << body() << (attrs.happy == 'true' ? " :-)" : " :-(")
     }
 }
@@ -89,7 +92,7 @@ class SimpleTagLib {
      * @attr name REQUIRED the field name
      * @attr value the field value
      */
-    def passwordField = { attrs ->
+    def passwordField() {
         attrs.type = "password"
         attrs.tagName = "passwordField"
         fieldImpl(out, attrs)

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs.adoc
@@ -53,6 +53,24 @@ class SimpleTagLib {
 }
 ----
 
+For method-based tags, named attributes can also bind directly to method signature arguments:
+
+[source,groovy]
+----
+class SimpleTagLib {
+    def greeting(String name) {
+        out << "Hello, ${name}!"
+    }
+}
+----
+
+Used as:
+
+[source,xml]
+----
+<g:greeting name="Graeme" />
+----
+
 As demonstrated above there is an implicit `out` variable that refers to the output `Writer` which you can use to append content to the response. Then you can reference the tag inside your GSP; no imports are necessary:
 
 [source,xml]

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/iterativeTags.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/iterativeTags.adoc
@@ -21,7 +21,7 @@ Iterative tags are easy too, since you can invoke the body multiple times:
 
 [source,groovy]
 ----
-def repeat = { attrs, body ->
+def repeat() {
     attrs.times?.toInteger()?.times { num ->
         out << body(num)
     }
@@ -48,7 +48,7 @@ That value is then passed as the default variable `it` to the tag. However, if y
 
 [source,groovy]
 ----
-def repeat = { attrs, body ->
+def repeat() {
     def var = attrs.var ?: "num"
     attrs.times?.toInteger()?.times { num ->
         out << body((var):num)

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/logicalTags.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/logicalTags.adoc
@@ -21,7 +21,7 @@ You can also create logical tags where the body of the tag is only output once a
 
 [source,groovy]
 ----
-def isAdmin = { attrs, body ->
+def isAdmin() {
     def user = attrs.user
     if (user && checkUserPrivs(user)) {
         out << body()

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/namespaces.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/namespaces.adoc
@@ -23,7 +23,7 @@ By default, tags are added to the default Grails namespace and are used with the
 ----
 class SimpleTagLib {
     static namespace = "my"
-
+    def example() {
     def example = { attrs ->
         //...
     }

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/simpleTags.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/simpleTags.adoc
@@ -21,7 +21,7 @@ As demonstrated in the previous example it is easy to write simple tags that hav
 
 [source,groovy]
 ----
-def dateFormat = { attrs, body ->
+def dateFormat() {
     out << new java.text.SimpleDateFormat(attrs.format).format(attrs.date)
 }
 ----
@@ -37,7 +37,7 @@ With simple tags sometimes you need to write HTML mark-up to the response. One a
 
 [source,groovy]
 ----
-def formatBook = { attrs, body ->
+def formatBook() {
     out << "<div id=\"${attrs.book.id}\">"
     out << "Title : ${attrs.book.title}"
     out << "</div>"
@@ -48,7 +48,7 @@ Although this approach may be tempting it is not very clean. A better approach w
 
 [source,groovy]
 ----
-def formatBook = { attrs, body ->
+def formatBook() {
     out << render(template: "bookTemplate", model: [book: attrs.book])
 }
 ----

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/simpleTags.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/simpleTags.adoc
@@ -33,6 +33,15 @@ The above uses Java's `SimpleDateFormat` class to format a date and then write i
 <g:dateFormat format="dd-MM-yyyy" date="${new Date()}" />
 ----
 
+With method-based tags, attributes may also bind directly to method parameters by name:
+
+[source,groovy]
+----
+def dateFormat(String format, Date date) {
+    out << new java.text.SimpleDateFormat(format).format(date)
+}
+----
+
 With simple tags sometimes you need to write HTML mark-up to the response. One approach would be to embed the content directly:
 
 [source,groovy]

--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/tagReturnValue.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/tagReturnValue.adoc
@@ -19,13 +19,13 @@ under the License.
 
 A taglib can be used in a GSP as an ordinary tag, or it might be used as a function in other taglibs or GSP expressions.
 
-Internally Grails intercepts calls to taglib closures.
+Internally Grails intercepts calls to tag handlers (method-based or closure-based).
 The "out" that is available in a taglib is mapped to a `java.io.Writer` implementation that writes to a buffer
 that "captures" the output of the taglib call. This buffer is the return value of a tag library call when it's 
 used as a function.
 
 If the tag is listed in the library's static `returnObjectForTags` array, then its return value will be written to 
-the output when it's used as a normal tag. The return value of the tag lib closure will be returned as-is 
+the output when it's used as a normal tag. The return value of the tag method/closure will be returned as-is 
 if it's used as a function in GSP expressions or other taglibs. 
 
 If the tag is not included in the returnObjectForTags array, then its return value will be discarded.
@@ -37,7 +37,7 @@ Example:
 class ObjectReturningTagLib {
 	static namespace = "cms"
 	static returnObjectForTags = ['content'] 
-
+	def content() {
 	def content = { attrs, body ->
 		CmsContent.findByCode(attrs.code)?.content	
     }

--- a/grails-doc/src/en/guide/theWebLayer/taglibs.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/taglibs.adoc
@@ -71,6 +71,20 @@ Used as:
 <g:greeting name="Graeme" />
 ----
 
+For tags with strict validation/error handling, keep a `Map attrs` handler and add typed overloads that delegate to it:
+
+[source,groovy]
+----
+def field(Map attrs) {
+    // existing validation + rendering path
+}
+
+def field(String type, Map attrs) {
+    attrs.type = type
+    field(attrs)
+}
+----
+
 As demonstrated above there is an implicit `out` variable that refers to the output `Writer` which you can use to append content to the response. Then you can reference the tag inside your GSP; no imports are necessary:
 
 [source,xml]

--- a/grails-doc/src/en/guide/theWebLayer/taglibs.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/taglibs.adoc
@@ -28,23 +28,26 @@ class SimpleTagLib {
 }
 ----
 
-Now to create a tag create a Closure property that takes two arguments: the tag attributes and the body content:
+Now create tags using methods. You can access tag attributes through the implicit `attrs` map and body through the implicit `body` closure:
 
 [source,groovy]
 ----
 class SimpleTagLib {
-    def simple = { attrs, body ->
+    def simple() {
+        // ...
 
     }
 }
 ----
 
-The `attrs` argument is a Map of the attributes of the tag, whilst the `body` argument is a Closure that returns the body content when invoked:
+Closure field-style tags are still supported for backward compatibility, but method-based tags are the recommended syntax.
+
+The implicit `attrs` property is a `Map` of the tag attributes, while `body()` returns the tag body content when invoked:
 
 [source,groovy]
 ----
 class SimpleTagLib {
-    def emoticon = { attrs, body ->
+    def emoticon() {
        out << body() << (attrs.happy == 'true' ? " :-)" : " :-(")
     }
 }
@@ -57,7 +60,7 @@ As demonstrated above there is an implicit `out` variable that refers to the out
 <g:emoticon happy="true">Hi John</g:emoticon>
 ----
 
-NOTE: To help IDEs autocomplete tag attributes, you should add Javadoc comments to your tag closures with `@attr` descriptions. Since taglibs use Groovy code it can be difficult to reliably detect all usable attributes.
+NOTE: To help IDEs autocomplete tag attributes, add Javadoc comments with `@attr` descriptions to your tag methods. Since taglibs use Groovy code it can be difficult to reliably detect all usable attributes.
 
 For example:
 
@@ -71,7 +74,7 @@ class SimpleTagLib {
      * @attr happy whether to show a happy emoticon ('true') or
      * a sad emoticon ('false')
      */
-    def emoticon = { attrs, body ->
+    def emoticon() {
        out << body() << (attrs.happy == 'true' ? " :-)" : " :-(")
     }
 }
@@ -89,7 +92,7 @@ class SimpleTagLib {
      * @attr name REQUIRED the field name
      * @attr value the field value
      */
-    def passwordField = { attrs ->
+    def passwordField() {
         attrs.type = "password"
         attrs.tagName = "passwordField"
         fieldImpl(out, attrs)

--- a/grails-doc/src/en/guide/theWebLayer/taglibs.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/taglibs.adoc
@@ -53,6 +53,24 @@ class SimpleTagLib {
 }
 ----
 
+For method-based tags, named attributes can also bind directly to method signature arguments:
+
+[source,groovy]
+----
+class SimpleTagLib {
+    def greeting(String name) {
+        out << "Hello, ${name}!"
+    }
+}
+----
+
+Used as:
+
+[source,xml]
+----
+<g:greeting name="Graeme" />
+----
+
 As demonstrated above there is an implicit `out` variable that refers to the output `Writer` which you can use to append content to the response. Then you can reference the tag inside your GSP; no imports are necessary:
 
 [source,xml]

--- a/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-fields/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -242,7 +242,7 @@ class FormFieldsTagLib {
                 widgetAttrs.remove('class')
             }
             if (hasBody(body)) {
-                model.widget = raw(body(model + [attrs: widgetAttrs] + widgetAttrs))
+                model.widget = body(model + [attrs: widgetAttrs] + widgetAttrs)?.encodeAsRaw()
             } else {
                 model.widget = renderWidget(propertyAccessor, model, widgetAttrs, widgetFolder ?: templatesFolder, theme)
             }
@@ -384,7 +384,7 @@ class FormFieldsTagLib {
                 out << render(template: "/templates/_fields/$template", model: attrs + [domainClass: domainClass, domainProperties: properties]) { prop ->
                     BeanPropertyAccessor propertyAccessor = resolveProperty(bean, prop.name)
                     Map model = buildModel(propertyAccessor, attrs, 'HTML')
-                    out << raw(renderDisplayWidget(propertyAccessor, model, attrs, templatesFolder, theme))
+                    out << renderDisplayWidget(propertyAccessor, model, attrs, templatesFolder, theme)?.encodeAsRaw()
                 }
             }
         } else {
@@ -410,7 +410,7 @@ class FormFieldsTagLib {
             String widgetsFolderToUse = widgetFolder ?: templatesFolder
 
             if (hasBody(body)) {
-                model.widget = raw(body(model + [attrs: widgetAttrs] + widgetAttrs))
+                model.widget = body(model + [attrs: widgetAttrs] + widgetAttrs)?.encodeAsRaw()
                 model.value = body(model)
             } else {
                 model.widget = renderDisplayWidget(propertyAccessor, model, widgetAttrs, widgetsFolderToUse, theme)
@@ -421,7 +421,7 @@ class FormFieldsTagLib {
             if (template) {
                 out << render(template: template.path, plugin: template.plugin, model: model + [attrs: wrapperAttrs] + wrapperAttrs)
             } else {
-                out << raw(renderDisplayWidget(propertyAccessor, model, attrs, widgetsFolderToUse, theme))
+                out << renderDisplayWidget(propertyAccessor, model, attrs, widgetsFolderToUse, theme)?.encodeAsRaw()
             }
         }
 
@@ -698,11 +698,11 @@ class FormFieldsTagLib {
         }
     }
 
-    CharSequence renderDefaultInput(Map model, Map attrs = [:]) {
+    protected CharSequence renderDefaultInput(Map model, Map attrs = [:]) {
         renderDefaultInput(null, model, attrs)
     }
 
-    CharSequence renderDefaultInput(BeanPropertyAccessor propertyAccessor, Map model, Map attrs = [:]) {
+    protected CharSequence renderDefaultInput(BeanPropertyAccessor propertyAccessor, Map model, Map attrs = [:]) {
         Constrained constrained = (Constrained) model.constraints
         attrs.name = (model.prefix ?: '') + model.property
         attrs.value = model.value
@@ -761,7 +761,7 @@ class FormFieldsTagLib {
         }
     }
 
-    CharSequence renderDateTimeInput(Map model, Map attrs) {
+    protected CharSequence renderDateTimeInput(Map model, Map attrs) {
         attrs.precision = model.type in [java.sql.Time, LocalDateTime] ? 'minute' : 'day'
         if (!model.required) {
             attrs.noSelection = ['': '']
@@ -770,7 +770,7 @@ class FormFieldsTagLib {
         return g.datePicker(attrs)
     }
 
-    CharSequence renderStringInput(Map model, Map attrs) {
+    protected CharSequence renderStringInput(Map model, Map attrs) {
         Constrained constrained = (Constrained) model.constraints
 
         if (!attrs.type) {
@@ -802,7 +802,7 @@ class FormFieldsTagLib {
         return g.field(attrs)
     }
 
-    CharSequence renderNumericInput(BeanPropertyAccessor propertyAccessor, Map model, Map attrs) {
+    protected CharSequence renderNumericInput(BeanPropertyAccessor propertyAccessor, Map model, Map attrs) {
         Constrained constrained = (Constrained) model.constraints
 
         if (!attrs.type && constrained?.inList) {
@@ -966,7 +966,7 @@ class FormFieldsTagLib {
         buffer << render(template: '/templates/_fields/list', model: [domainClass: domainClass, domainProperties: properties]) { prop ->
             def propertyAccessor = resolveProperty(bean, prop.name)
             def model = buildModel(propertyAccessor, attrs)
-            out << raw(renderDisplayWidget(propertyAccessor, model, attrs, templatesFolder, theme))
+            out << renderDisplayWidget(propertyAccessor, model, attrs, templatesFolder, theme)?.encodeAsRaw()
         }
         buffer.buffer
     }

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/GroovyPage.java
@@ -48,6 +48,8 @@ import org.grails.gsp.jsp.TagLibraryResolver;
 import org.grails.taglib.AbstractTemplateVariableBinding;
 import org.grails.taglib.GrailsTagException;
 import org.grails.taglib.GroovyPageAttributes;
+import org.grails.taglib.TagMethodContext;
+import org.grails.taglib.TagMethodInvoker;
 import org.grails.taglib.TagBodyClosure;
 import org.grails.taglib.TagLibraryLookup;
 import org.grails.taglib.TagOutput;
@@ -374,10 +376,13 @@ public abstract class GroovyPage extends Script {
             if (tagLib != null || (gspTagLibraryLookup != null && gspTagLibraryLookup.hasNamespace(tagNamespace))) {
                 if (tagLib != null) {
                     boolean returnsObject = gspTagLibraryLookup.doesTagReturnObject(tagNamespace, tagName);
-                    Object tagLibClosure = tagLib.getProperty(tagName);
+                    Object tagLibClosure = TagMethodInvoker.getClosureTagProperty(tagLib, tagName);
                     if (tagLibClosure instanceof Closure) {
                         Map<String, Object> encodeAsForTag = gspTagLibraryLookup.getEncodeAsForTag(tagNamespace, tagName);
                         invokeTagLibClosure(tagName, tagNamespace, (Closure) tagLibClosure, attrs, body, returnsObject, encodeAsForTag);
+                    } else if (TagMethodInvoker.hasInvokableTagMethod(tagLib, tagName)) {
+                        Map<String, Object> encodeAsForTag = gspTagLibraryLookup.getEncodeAsForTag(tagNamespace, tagName);
+                        invokeTagLibMethod(tagName, tagNamespace, tagLib, attrs, body, returnsObject, encodeAsForTag);
                     } else {
                         throw new GrailsTagException("Tag [" + tagName + "] does not exist in tag library [" + tagLib.getClass().getName() + "]", getGroovyPageFileName(), lineNumber);
                     }
@@ -468,6 +473,28 @@ public abstract class GroovyPage extends Script {
         }
     }
 
+    private void invokeTagLibMethod(String tagName, String tagNamespace, GroovyObject tagLib, Map<?, ?> attrs, Closure<?> body,
+            boolean returnsObject, Map<String, Object> defaultEncodeAs) {
+        if (!(attrs instanceof GroovyPageAttributes)) {
+            attrs = new GroovyPageAttributes(attrs);
+        }
+        ((GroovyPageAttributes) attrs).setGspTagSyntaxCall(true);
+        boolean encodeAsPushedToStack = false;
+        try {
+            Map<String, Object> codecSettings = TagOutput.createCodecSettings(tagNamespace, tagName, attrs, defaultEncodeAs);
+            if (codecSettings != null) {
+                outputStack.push(WithCodecHelper.createOutputStackAttributesBuilder(codecSettings, outputContext.getGrailsApplication()).build());
+                encodeAsPushedToStack = true;
+            }
+            Closure<?> actualBody = body != null ? body : TagOutput.EMPTY_BODY_CLOSURE;
+            TagMethodContext.push(attrs, actualBody);
+            Object tagResult = TagMethodInvoker.invokeTagMethod(tagLib, tagName, attrs, actualBody);
+            outputTagResult(returnsObject, tagResult);
+        } finally {
+            TagMethodContext.pop();
+            if (encodeAsPushedToStack) outputStack.pop();
+        }
+    }
     private void outputTagResult(boolean returnsObject, Object tagresult) {
         if (returnsObject && tagresult != null && !(tagresult instanceof Writer)) {
             if (tagresult instanceof String && isHtmlPart((String) tagresult)) {

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/core/gsp/DefaultGrailsTagLibClass.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/core/gsp/DefaultGrailsTagLibClass.java
@@ -33,6 +33,7 @@ import groovy.lang.MetaProperty;
 import grails.core.gsp.GrailsTagLibClass;
 import org.grails.core.AbstractInjectableGrailsClass;
 import org.grails.core.artefact.gsp.TagLibArtefactHandler;
+import org.grails.taglib.TagMethodInvoker;
 
 /**
  * Default implementation of a tag lib class.
@@ -69,6 +70,7 @@ public class DefaultGrailsTagLibClass extends AbstractInjectableGrailsClass impl
                 tags.add(prop.getName());
             }
         }
+        tags.addAll(TagMethodInvoker.getInvokableTagMethodNames(clazz));
 
         String ns = getStaticPropertyValue(NAMESPACE_FIELD_NAME, String.class);
         if (ns != null && !"".equals(ns.trim())) {

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagLibraryMetaUtils.groovy
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagLibraryMetaUtils.groovy
@@ -176,6 +176,34 @@ class TagLibraryMetaUtils {
         Object[] args = makeObjectArray(argsParam)
         final GroovyObject tagBean = gspTagLibraryLookup.lookupTagLibrary(namespace, name)
         if (tagBean != null) {
+            Object tagLibProp = TagMethodInvoker.getClosureTagProperty(tagBean, name)
+            if (tagLibProp instanceof Closure || TagMethodInvoker.hasInvokableTagMethod(tagBean, name)) {
+                Map attrs = [:]
+                Object body = null
+                switch (args.length) {
+                    case 0:
+                        break
+                    case 1:
+                        if (args[0] instanceof Map) {
+                            attrs = (Map) args[0]
+                        } else if (args[0] instanceof Closure || args[0] instanceof CharSequence) {
+                            body = args[0]
+                        } else {
+                            attrs = [(name): args[0]]
+                        }
+                        break
+                    case 2:
+                        if (args[0] instanceof Map) {
+                            attrs = (Map) args[0]
+                            body = args[1]
+                        }
+                        break
+                }
+                if (addMethodsToMetaClass) {
+                    registerMethodMissingForTags(mc, gspTagLibraryLookup, namespace, name)
+                }
+                return captureTagOutputForMethodCall(gspTagLibraryLookup, namespace, name, attrs, body)
+            }
             MetaClass tagBeanMc = tagBean.getMetaClass()
             final MetaMethod method = tagBeanMc.respondsTo(tagBean, name, args).find { it }
             if (method != null) {

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagLibraryMetaUtils.groovy
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagLibraryMetaUtils.groovy
@@ -29,6 +29,7 @@ import org.springframework.context.ApplicationContext
 import grails.core.gsp.GrailsTagLibClass
 import grails.util.GrailsClassUtils
 import org.grails.taglib.encoder.OutputContextLookupHelper
+import org.grails.taglib.encoder.OutputEncodingStack
 
 class TagLibraryMetaUtils {
 
@@ -44,8 +45,24 @@ class TagLibraryMetaUtils {
 
     @CompileStatic
     static void enhanceTagLibMetaClass(MetaClass mc, TagLibraryLookup gspTagLibraryLookup, String namespace) {
+        registerTagMethodContextMetaProperties(mc)
         registerTagMetaMethods(mc, gspTagLibraryLookup, namespace)
         registerNamespaceMetaProperties(mc, gspTagLibraryLookup)
+    }
+
+    @CompileStatic
+    static void registerTagMethodContextMetaProperties(MetaClass metaClass) {
+        GroovyObject mc = (GroovyObject) metaClass
+        if (!metaClass.hasProperty("attrs") && !doesMethodExist(metaClass, "getAttrs", [] as Class[])) {
+            mc.setProperty("getAttrs") { ->
+                TagMethodContext.currentAttrs()
+            }
+        }
+        if (!metaClass.hasProperty("body") && !doesMethodExist(metaClass, "getBody", [] as Class[])) {
+            mc.setProperty("getBody") { ->
+                TagMethodContext.currentBody()
+            }
+        }
     }
 
     @CompileStatic
@@ -57,9 +74,7 @@ class TagLibraryMetaUtils {
 
     @CompileStatic
     static void registerNamespaceMetaProperty(MetaClass metaClass, TagLibraryLookup gspTagLibraryLookup, String namespace) {
-        if (!metaClass.hasProperty(namespace) && !doesMethodExist(metaClass, GrailsClassUtils.getGetterName(namespace), [] as Class[])) {
-            registerPropertyMissingForTag(metaClass, namespace, gspTagLibraryLookup.lookupNamespaceDispatcher(namespace))
-        }
+        registerPropertyMissingForTag(metaClass, namespace, gspTagLibraryLookup.lookupNamespaceDispatcher(namespace))
     }
 
     @CompileStatic
@@ -68,31 +83,43 @@ class TagLibraryMetaUtils {
 
         if (overrideMethods || !doesMethodExist(metaClass, name, [Map, Closure] as Class[])) {
             mc.setProperty(name) { Map attrs, Closure body ->
-                TagOutput.captureTagOutput(gspTagLibraryLookup, namespace, name, attrs, body, OutputContextLookupHelper.lookupOutputContext())
+                captureTagOutputForMethodCall(gspTagLibraryLookup, namespace, name, attrs, body)
             }
         }
         if (overrideMethods || !doesMethodExist(metaClass, name, [Map, CharSequence] as Class[])) {
             mc.setProperty(name) { Map attrs, CharSequence body ->
-                TagOutput.captureTagOutput(gspTagLibraryLookup, namespace, name, attrs, new TagOutput.ConstantClosure(body), OutputContextLookupHelper.lookupOutputContext())
+                captureTagOutputForMethodCall(gspTagLibraryLookup, namespace, name, attrs, new TagOutput.ConstantClosure(body))
             }
         }
         if (overrideMethods || !doesMethodExist(metaClass, name, [Map] as Class[])) {
             mc.setProperty(name) { Map attrs ->
-                TagOutput.captureTagOutput(gspTagLibraryLookup, namespace, name, attrs, null, OutputContextLookupHelper.lookupOutputContext())
+                captureTagOutputForMethodCall(gspTagLibraryLookup, namespace, name, attrs, null)
             }
         }
         if (addAll) {
             if (overrideMethods || !doesMethodExist(metaClass, name, [Closure] as Class[])) {
                 mc.setProperty(name) { Closure body ->
-                    TagOutput.captureTagOutput(gspTagLibraryLookup, namespace, name, [:], body, OutputContextLookupHelper.lookupOutputContext())
+                    captureTagOutputForMethodCall(gspTagLibraryLookup, namespace, name, [:], body)
                 }
             }
             if (overrideMethods || !doesMethodExist(metaClass, name, [] as Class[])) {
                 mc.setProperty(name) { ->
-                    TagOutput.captureTagOutput(gspTagLibraryLookup, namespace, name, [:], null, OutputContextLookupHelper.lookupOutputContext())
+                    captureTagOutputForMethodCall(gspTagLibraryLookup, namespace, name, [:], null)
                 }
             }
         }
+    }
+
+    @CompileStatic
+    private static Object captureTagOutputForMethodCall(TagLibraryLookup gspTagLibraryLookup, String namespace, String name, Map attrs, Object body) {
+        Object output = TagOutput.captureTagOutput(gspTagLibraryLookup, namespace, name, attrs, body, OutputContextLookupHelper.lookupOutputContext())
+        boolean returnsObject = gspTagLibraryLookup.doesTagReturnObject(namespace, name)
+        boolean gspTagSyntaxCall = attrs instanceof GroovyPageAttributes && ((GroovyPageAttributes) attrs).isGspTagSyntaxCall()
+        if (gspTagSyntaxCall && !returnsObject && output != null) {
+            OutputEncodingStack.currentStack().taglibWriter.print(output)
+            return null
+        }
+        return output
     }
 
     static registerMethodMissingForTags(MetaClass mc, ApplicationContext ctx,
@@ -109,13 +136,13 @@ class TagLibraryMetaUtils {
     }
 
     @CompileStatic
-    static void registerTagMetaMethods(MetaClass emc, TagLibraryLookup lookup, String namespace) {
+    static void registerTagMetaMethods(MetaClass emc, TagLibraryLookup lookup, String namespace, boolean overrideMethods = true) {
         for (String tagName : lookup.getAvailableTags(namespace)) {
             boolean addAll = !(namespace == TagOutput.DEFAULT_NAMESPACE && tagName == 'hasErrors')
-            registerMethodMissingForTags(emc, lookup, namespace, tagName, addAll, false)
+            registerMethodMissingForTags(emc, lookup, namespace, tagName, addAll, overrideMethods)
         }
         if (namespace != TagOutput.DEFAULT_NAMESPACE) {
-            registerTagMetaMethods(emc, lookup, TagOutput.DEFAULT_NAMESPACE)
+            registerTagMetaMethods(emc, lookup, TagOutput.DEFAULT_NAMESPACE, false)
         }
     }
 

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagMethodContext.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagMethodContext.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.taglib;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+
+import groovy.lang.Closure;
+
+public final class TagMethodContext {
+
+    private static final ThreadLocal<Deque<TagMethodContextEntry>> CONTEXT_STACK = ThreadLocal.withInitial(ArrayDeque::new);
+    private TagMethodContext() {
+    }
+
+    public static void push(Map<?, ?> attrs, Closure<?> body) {
+        CONTEXT_STACK.get().push(new TagMethodContextEntry(attrs, body));
+    }
+
+    public static void pop() {
+        Deque<TagMethodContextEntry> stack = CONTEXT_STACK.get();
+        if (!stack.isEmpty()) {
+            stack.pop();
+        }
+        if (stack.isEmpty()) {
+            CONTEXT_STACK.remove();
+        }
+    }
+
+    public static Map<?, ?> currentAttrs() {
+        Deque<TagMethodContextEntry> stack = CONTEXT_STACK.get();
+        return stack.isEmpty() ? null : stack.peek().attrs();
+    }
+
+    public static Closure<?> currentBody() {
+        Deque<TagMethodContextEntry> stack = CONTEXT_STACK.get();
+        return stack.isEmpty() ? null : stack.peek().body();
+    }
+
+    private record TagMethodContextEntry(Map<?, ?> attrs, Closure<?> body) { }
+}

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagMethodInvoker.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagMethodInvoker.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +35,22 @@ import groovy.lang.GroovyObject;
 import groovy.lang.MissingMethodException;
 
 public final class TagMethodInvoker {
+    private static final ClassValue<Map<String, List<Method>>> INVOKABLE_METHODS_BY_NAME = new ClassValue<>() {
+        @Override
+        protected Map<String, List<Method>> computeValue(Class<?> type) {
+            Map<String, List<Method>> methodsByName = new HashMap<>();
+            for (Method method : type.getMethods()) {
+                if (isTagMethodCandidate(method)) {
+                    methodsByName.computeIfAbsent(method.getName(), ignored -> new ArrayList<>()).add(method);
+                }
+            }
+            Map<String, List<Method>> immutableMethodsByName = new HashMap<>(methodsByName.size());
+            for (Map.Entry<String, List<Method>> entry : methodsByName.entrySet()) {
+                immutableMethodsByName.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
+            }
+            return Collections.unmodifiableMap(immutableMethodsByName);
+        }
+    };
     private TagMethodInvoker() {
     }
 
@@ -70,19 +87,16 @@ public final class TagMethodInvoker {
     }
 
     public static boolean hasInvokableTagMethod(GroovyObject tagLib, String tagName) {
-        for (Method method : tagLib.getClass().getMethods()) {
-            if (isTagMethodCandidate(method) && method.getName().equals(tagName)) {
-                return true;
-            }
-        }
-        return false;
+        List<Method> methods = INVOKABLE_METHODS_BY_NAME.get(tagLib.getClass()).get(tagName);
+        return methods != null && !methods.isEmpty();
     }
 
     public static Object invokeTagMethod(GroovyObject tagLib, String tagName, Map<?, ?> attrs, Closure<?> body) {
-        for (Method method : tagLib.getClass().getMethods()) {
-            if (!isTagMethodCandidate(method) || !method.getName().equals(tagName)) {
-                continue;
-            }
+        List<Method> methods = INVOKABLE_METHODS_BY_NAME.get(tagLib.getClass()).get(tagName);
+        if (methods == null) {
+            throw new MissingMethodException(tagName, tagLib.getClass(), new Object[] { attrs, body });
+        }
+        for (Method method : methods) {
             Object[] args = toMethodArguments(method, attrs, body);
             if (args != null) {
                 try {

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagMethodInvoker.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagMethodInvoker.java
@@ -126,8 +126,9 @@ public final class TagMethodInvoker {
         Parameter[] parameters = method.getParameters();
         Object[] args = new Object[parameters.length];
         for (int i = 0; i < parameters.length; i++) {
+            String parameterName = parameters[i].getName();
             Class<?> parameterType = parameters[i].getType();
-            if (Map.class.isAssignableFrom(parameterType)) {
+            if (Map.class.isAssignableFrom(parameterType) && "attrs".equals(parameterName)) {
                 args[i] = attrs;
                 continue;
             }
@@ -135,7 +136,6 @@ public final class TagMethodInvoker {
                 args[i] = body != null ? body : TagOutput.EMPTY_BODY_CLOSURE;
                 continue;
             }
-            String parameterName = parameters[i].getName();
             Object value = attrs != null ? attrs.get(parameterName) : null;
             if (value == null && parameters.length == 1 && attrs != null && attrs.size() == 1) {
                 value = attrs.values().iterator().next();

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagMethodInvoker.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagMethodInvoker.java
@@ -1,0 +1,150 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.taglib;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import groovy.lang.Closure;
+import groovy.lang.GroovyObject;
+import groovy.lang.MissingMethodException;
+
+public final class TagMethodInvoker {
+    private TagMethodInvoker() {
+    }
+
+    public static Object getClosureTagProperty(GroovyObject tagLib, String tagName) {
+        Class<?> type = tagLib.getClass();
+        while (type != null && type != Object.class) {
+            try {
+                Field field = type.getDeclaredField(tagName);
+                if (!Modifier.isStatic(field.getModifiers()) && Closure.class.isAssignableFrom(field.getType())) {
+                    field.setAccessible(true);
+                    return field.get(tagLib);
+                }
+                return null;
+            } catch (NoSuchFieldException ignored) {
+                type = type.getSuperclass();
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return null;
+    }
+
+    public static Collection<String> getInvokableTagMethodNames(Class<?> tagLibClass) {
+        if (tagLibClass == null) {
+            return Collections.emptyList();
+        }
+        List<String> names = new ArrayList<>();
+        for (Method method : tagLibClass.getDeclaredMethods()) {
+            if (isTagMethodCandidate(method)) {
+                names.add(method.getName());
+            }
+        }
+        return names;
+    }
+
+    public static boolean hasInvokableTagMethod(GroovyObject tagLib, String tagName) {
+        for (Method method : tagLib.getClass().getMethods()) {
+            if (isTagMethodCandidate(method) && method.getName().equals(tagName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static Object invokeTagMethod(GroovyObject tagLib, String tagName, Map<?, ?> attrs, Closure<?> body) {
+        for (Method method : tagLib.getClass().getMethods()) {
+            if (!isTagMethodCandidate(method) || !method.getName().equals(tagName)) {
+                continue;
+            }
+            Object[] args = toMethodArguments(method, attrs, body);
+            if (args != null) {
+                try {
+                    return method.invoke(tagLib, args);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                } catch (InvocationTargetException e) {
+                    Throwable targetException = e.getTargetException();
+                    if (targetException instanceof RuntimeException runtimeException) {
+                        throw runtimeException;
+                    }
+                    throw new RuntimeException(targetException);
+                }
+            }
+        }
+        throw new MissingMethodException(tagName, tagLib.getClass(), new Object[] { attrs, body });
+    }
+
+    public static boolean isTagMethodCandidate(Method method) {
+        int modifiers = method.getModifiers();
+        if (!Modifier.isPublic(modifiers) || Modifier.isStatic(modifiers) || method.isBridge() || method.isSynthetic()) {
+            return false;
+        }
+        String name = method.getName();
+        if ("afterPropertiesSet".equals(name)) {
+            return false;
+        }
+        if (name.startsWith("get") && method.getParameterCount() == 0) {
+            return false;
+        }
+        if (name.startsWith("set") && method.getParameterCount() == 1) {
+            return false;
+        }
+        if ("invokeMethod".equals(name) || "methodMissing".equals(name) || "propertyMissing".equals(name)) {
+            return false;
+        }
+        return method.getDeclaringClass() != Object.class && method.getDeclaringClass() != GroovyObject.class;
+    }
+
+    private static Object[] toMethodArguments(Method method, Map<?, ?> attrs, Closure<?> body) {
+        Parameter[] parameters = method.getParameters();
+        Object[] args = new Object[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            Class<?> parameterType = parameters[i].getType();
+            if (Map.class.isAssignableFrom(parameterType)) {
+                args[i] = attrs;
+                continue;
+            }
+            if (Closure.class.isAssignableFrom(parameterType)) {
+                args[i] = body != null ? body : TagOutput.EMPTY_BODY_CLOSURE;
+                continue;
+            }
+            String parameterName = parameters[i].getName();
+            Object value = attrs != null ? attrs.get(parameterName) : null;
+            if (value == null && parameters.length == 1 && attrs != null && attrs.size() == 1) {
+                value = attrs.values().iterator().next();
+            }
+            if (value == null) {
+                return null;
+            }
+            args[i] = value;
+        }
+        return args;
+    }
+}

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagOutput.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagOutput.java
@@ -54,10 +54,11 @@ public class TagOutput {
             throw new GrailsTagException("Tag [" + tagName + "] does not exist. No corresponding tag library found.");
         }
 
+        boolean gspTagSyntaxCall = attrs instanceof GroovyPageAttributes && ((GroovyPageAttributes) attrs).isGspTagSyntaxCall();
         if (!(attrs instanceof GroovyPageAttributes)) {
             attrs = new GroovyPageAttributes(attrs, false);
         }
-        ((GroovyPageAttributes) attrs).setGspTagSyntaxCall(false);
+        ((GroovyPageAttributes) attrs).setGspTagSyntaxCall(gspTagSyntaxCall);
         Closure actualBody = createOutputCapturingClosure(tagLib, body, outputContext);
 
         final GroovyPageTagWriter tagOutput = new GroovyPageTagWriter();
@@ -74,7 +75,7 @@ public class TagOutput {
             builder.topWriter(tagOutput);
             outputStack.push(builder.build());
 
-            Object tagLibProp = tagLib.getProperty(tagName); // retrieve tag lib and create wrapper writer
+            Object tagLibProp = TagMethodInvoker.getClosureTagProperty(tagLib, tagName); // retrieve tag closure field
             if (tagLibProp instanceof Closure) {
                 Closure tag = (Closure) ((Closure) tagLibProp).clone();
                 Object bodyResult;
@@ -120,6 +121,26 @@ public class TagOutput {
                     return taglibEncoder.encode(tagOutput.getBuffer());
                 } else {
                     return tagOutput.getBuffer();
+                }
+            }
+            if (TagMethodInvoker.hasInvokableTagMethod(tagLib, tagName)) {
+                try {
+                    TagMethodContext.push(attrs, actualBody);
+                    Object bodyResult = TagMethodInvoker.invokeTagMethod(tagLib, tagName, attrs, actualBody);
+                    Encoder taglibEncoder = outputStack.getTaglibEncoder();
+                    boolean returnsObject = gspTagLibraryLookup.doesTagReturnObject(namespace, tagName);
+                    if (returnsObject && bodyResult != null && !(bodyResult instanceof Writer)) {
+                        if (taglibEncoder != null) {
+                            bodyResult = taglibEncoder.encode(bodyResult);
+                        }
+                        return bodyResult;
+                    }
+                    if (taglibEncoder != null) {
+                        return taglibEncoder.encode(tagOutput.getBuffer());
+                    }
+                    return tagOutput.getBuffer();
+                } finally {
+                    TagMethodContext.pop();
                 }
             }
 

--- a/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/TagLibrary.groovy
+++ b/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/TagLibrary.groovy
@@ -34,10 +34,14 @@ import grails.web.api.WebAttributes
 import org.grails.buffer.GrailsPrintWriter
 import org.grails.encoder.Encoder
 import org.grails.taglib.GrailsTagException
+import org.grails.taglib.GroovyPageAttributes
 import org.grails.taglib.TagLibraryLookup
 import org.grails.taglib.TagLibraryMetaUtils
+import org.grails.taglib.TagMethodContext
+import org.grails.taglib.TagMethodInvoker
 import org.grails.taglib.TagOutput
 import org.grails.taglib.TemplateVariableBinding
+import org.grails.taglib.encoder.OutputContextLookupHelper
 import org.grails.taglib.encoder.OutputEncodingStack
 import org.grails.taglib.encoder.WithCodecHelper
 import org.grails.web.servlet.mvc.GrailsWebRequest
@@ -131,8 +135,21 @@ trait TagLibrary implements WebAttributes, ServletAttributes, TagLibraryInvoker 
      * @throws MissingPropertyException When no tag namespace or tag is found
      */
     Object propertyMissing(String name) {
+        if (name == 'attrs') {
+            def contextAttrs = TagMethodContext.currentAttrs()
+            if (contextAttrs != null) {
+                return contextAttrs
+            }
+        }
+        if (name == 'body') {
+            def contextBody = TagMethodContext.currentBody()
+            if (contextBody != null) {
+                return contextBody
+            }
+        }
         TagLibraryLookup gspTagLibraryLookup = getTagLibraryLookup()
         if (gspTagLibraryLookup != null) {
+            boolean methodTagFallback = false
 
             Object result = gspTagLibraryLookup.lookupNamespaceDispatcher(name)
             if (result == null) {
@@ -143,14 +160,26 @@ trait TagLibrary implements WebAttributes, ServletAttributes, TagLibraryInvoker 
                 }
 
                 if (tagLibrary != null) {
-                    Object tagProperty = tagLibrary.getProperty(name)
+                    Object tagProperty = TagMethodInvoker.getClosureTagProperty(tagLibrary, name)
                     if (tagProperty instanceof Closure) {
                         result = ((Closure<?>) tagProperty).clone()
+                    } else if (TagMethodInvoker.hasInvokableTagMethod(tagLibrary, name)) {
+                        methodTagFallback = true
+                        final String currentNamespace = namespace
+                        result = { Map attrs = [:], Closure body = null ->
+                            Object output = TagOutput.captureTagOutput(gspTagLibraryLookup, currentNamespace, name, attrs, body, OutputContextLookupHelper.lookupOutputContext())
+                            boolean gspTagSyntaxCall = attrs instanceof GroovyPageAttributes && ((GroovyPageAttributes) attrs).isGspTagSyntaxCall()
+                            boolean returnsObject = gspTagLibraryLookup.doesTagReturnObject(currentNamespace, name)
+                            if (gspTagSyntaxCall && !returnsObject && output != null) {
+                                OutputEncodingStack.currentStack().taglibWriter.print(output)
+                                return null
+                            }
+                            output
+                        }
                     }
                 }
             }
-
-            if (result != null && !Environment.isDevelopmentMode()) {
+            if (result != null && !Environment.isDevelopmentMode() && !methodTagFallback) {
                 MetaClass mc = GrailsMetaClassUtils.getExpandoMetaClass(getClass())
 
                 // Register the property for the already-existing singleton instance of the taglib

--- a/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/TagLibrary.groovy
+++ b/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/TagLibrary.groovy
@@ -149,13 +149,13 @@ trait TagLibrary implements WebAttributes, ServletAttributes, TagLibraryInvoker 
         }
         TagLibraryLookup gspTagLibraryLookup = getTagLibraryLookup()
         if (gspTagLibraryLookup != null) {
-            boolean methodTagFallback = false
 
             Object result = gspTagLibraryLookup.lookupNamespaceDispatcher(name)
             if (result == null) {
-                String namespace = getTaglibNamespace()
-                GroovyObject tagLibrary = gspTagLibraryLookup.lookupTagLibrary(namespace, name)
+                String resolvedNamespace = getTaglibNamespace()
+                GroovyObject tagLibrary = gspTagLibraryLookup.lookupTagLibrary(resolvedNamespace, name)
                 if (tagLibrary == null) {
+                    resolvedNamespace = TagOutput.DEFAULT_NAMESPACE
                     tagLibrary = gspTagLibraryLookup.lookupTagLibrary(TagOutput.DEFAULT_NAMESPACE, name)
                 }
 
@@ -164,8 +164,7 @@ trait TagLibrary implements WebAttributes, ServletAttributes, TagLibraryInvoker 
                     if (tagProperty instanceof Closure) {
                         result = ((Closure<?>) tagProperty).clone()
                     } else if (TagMethodInvoker.hasInvokableTagMethod(tagLibrary, name)) {
-                        methodTagFallback = true
-                        final String currentNamespace = namespace
+                        final String currentNamespace = resolvedNamespace
                         result = { Map attrs = [:], Closure body = null ->
                             Object output = TagOutput.captureTagOutput(gspTagLibraryLookup, currentNamespace, name, attrs, body, OutputContextLookupHelper.lookupOutputContext())
                             boolean gspTagSyntaxCall = attrs instanceof GroovyPageAttributes && ((GroovyPageAttributes) attrs).isGspTagSyntaxCall()
@@ -179,7 +178,7 @@ trait TagLibrary implements WebAttributes, ServletAttributes, TagLibraryInvoker 
                     }
                 }
             }
-            if (result != null && !Environment.isDevelopmentMode() && !methodTagFallback) {
+            if (result != null && !Environment.isDevelopmentMode()) {
                 MetaClass mc = GrailsMetaClassUtils.getExpandoMetaClass(getClass())
 
                 // Register the property for the already-existing singleton instance of the taglib

--- a/grails-gsp/grails-web-taglib/src/main/groovy/grails/gsp/taglib/compiler/TagLibArtefactTypeAstTransformation.java
+++ b/grails-gsp/grails-web-taglib/src/main/groovy/grails/gsp/taglib/compiler/TagLibArtefactTypeAstTransformation.java
@@ -18,9 +18,11 @@
  */
 
 package grails.gsp.taglib.compiler;
+import groovy.lang.Closure;
 
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.control.CompilePhase;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.transform.GroovyASTTransformation;
@@ -31,14 +33,32 @@ import org.grails.compiler.injection.ArtefactTypeAstTransformation;
 @GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
 public class TagLibArtefactTypeAstTransformation extends ArtefactTypeAstTransformation {
     private static final ClassNode MY_TYPE = new ClassNode(TagLib.class);
+    private static final ClassNode CLOSURE_TYPE = new ClassNode(Closure.class);
 
     @Override
     protected String resolveArtefactType(SourceUnit sourceUnit, AnnotationNode annotationNode, ClassNode classNode) {
+        addClosureTagDeprecationWarnings(sourceUnit, classNode);
         return "TagLibrary";
     }
 
     @Override
     protected ClassNode getAnnotationType() {
         return MY_TYPE;
+    }
+
+    protected void addClosureTagDeprecationWarnings(SourceUnit sourceUnit, ClassNode classNode) {
+        if (classNode.getPackageName() != null && classNode.getPackageName().startsWith("org.grails.plugins.web.taglib")) {
+            return;
+        }
+        for (FieldNode field : classNode.getFields()) {
+            if (field.isStatic()) {
+                continue;
+            }
+            if (field.getType() != null && CLOSURE_TYPE.equals(field.getType())) {
+                String message = "Closure-based tag definition [" + field.getName() + "] in TagLib [" + classNode.getName() + "] is deprecated. " +
+                        "Define tag handlers as methods instead.";
+                org.grails.compiler.injection.GrailsASTUtils.warning(sourceUnit, field, message);
+            }
+        }
     }
 }

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -91,7 +91,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      *
      * @attr name REQUIRED the cookie name
      */
-    Closure cookie = { attrs ->
+    def cookie(Map attrs) {
         request.cookies.find { it.name == attrs.name }?.value
     }
 
@@ -102,7 +102,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      *
      * @attr name REQUIRED the header name
      */
-    Closure header = { attrs ->
+    def header(Map attrs) {
         attrs.name ? request.getHeader(attrs.name) : null
     }
 
@@ -115,7 +115,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      * @attr bean the name or the type of a bean in the applicationContext; the type can be an interface or superclass
      * @attr scope the scope name; defaults to pageScope
      */
-    Closure set = { attrs, body ->
+    def set(Map attrs, Closure body) {
         def var = attrs.var
         if (!var) throw new IllegalArgumentException('[var] attribute must be specified to for <g:set>!')
 
@@ -142,7 +142,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      *
      * @emptyTag
      */
-    Closure createLinkTo = { attrs ->
+    def createLinkTo(Map attrs) {
         GrailsUtil.deprecated('Tag [createLinkTo] is deprecated please use [resource] instead')
         return resource(attrs)
     }
@@ -161,7 +161,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      * @attr absolute If set to "true" will prefix the link target address with the value of the grails.serverURL property from Config, or http://localhost:&lt;port&gt; if no value in Config and not running in production.
      * @attr plugin The plugin to look for the resource in
      */
-    Closure resource = { attrs ->
+    def resource(Map attrs) {
         if (!attrs.pluginContextPath && pageScope.pluginContextPath) {
             attrs.pluginContextPath = pageScope.pluginContextPath
         }
@@ -179,7 +179,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      * @attr plugin Optional the name of the grails plugin if the resource is not part of the application
      * @attr uri Optional app-relative URI path of the resource if not using dir/file attributes - only if Resources plugin is in use
      */
-    Closure img = { attrs ->
+    def img(Map attrs) {
         if (!attrs.uri && !attrs.dir) {
             attrs.dir = 'images'
         }
@@ -308,7 +308,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      * @attr plugin
      * @attr type
      */
-    Closure external = { attrs ->
+    def external(Map attrs) {
         if (!attrs.uri) {
             attrs.uri = resource(attrs).toString()
         }
@@ -363,7 +363,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      * @attr mapping The named URL mapping to use to rewrite the link
      * @attr event Webflow _eventId parameter
      */
-    Closure createLink = { attrs ->
+    def createLink(Map attrs) {
         return doCreateLink(attrs instanceof  Map ? (Map) attrs : Collections.emptyMap())
     }
 
@@ -403,7 +403,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      * @attr name REQUIRED the tag name
      * @attr attrs tag attributes
      */
-    Closure withTag = { attrs, body ->
+    def withTag(Map attrs, Closure body) {
         def writer = out
         writer << "<${attrs.name}"
         attrs.attrs?.each { k, v ->
@@ -431,7 +431,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      * @attr REQUIRED in The collection to iterate over
      * @attr delimiter The value of the delimiter to use during the join. If no delimiter is specified then ", " (a comma followed by a space) will be used as the delimiter.
      */
-    Closure join = { attrs ->
+    def join(Map attrs) {
         def collection = attrs.'in'
         if (collection == null) {
             throwTagError('Tag ["join"] missing required attribute ["in"]')
@@ -448,7 +448,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
      *
      * @attr name REQUIRED the metadata key
      */
-    Closure meta = { attrs ->
+    def meta(Map attrs) {
         if (!attrs.name) {
             throwTagError('Tag ["meta"] missing required attribute ["name"]')
         }
@@ -458,7 +458,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
     /**
      * Filters the url through the RequestDataValueProcessor bean if it is registered.
      */
-    String processedUrl(String link, request) {
+    private String processedUrl(String link, request) {
         if (requestDataValueProcessor == null) {
             return link
         }
@@ -466,7 +466,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         return requestDataValueProcessor.processUrl(request, link)
     }
 
-    Closure applyCodec = { Map attrs, Closure body ->
+    def applyCodec(Map attrs, Closure body) {
         // encoding is handled in GroovyPage.invokeTag and GroovyPage.captureTagOutput
         body()
     }

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/CountryTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/CountryTagLib.groovy
@@ -307,7 +307,7 @@ class CountryTagLib implements TagLibrary {
      * @attr noSelection A single-entry map detailing the key and value to use for the "no selection made" choice in the select box. If there is no current selection this will be shown as it is first in the list, and if submitted with this selected, the key that you provide will be submitted. Typically this will be blank - but you can also use 'null' in the case that you're passing the ID of an object
      * @attr disabled boolean value indicating whether the select is disabled or enabled (defaults to false - enabled)
      */
-    Closure countrySelect = { attrs ->
+    def countrySelect(Map attrs) {
         if (!attrs.from) {
             attrs.from = COUNTRY_CODES_BY_NAME_ORDER
         }
@@ -328,7 +328,7 @@ class CountryTagLib implements TagLibrary {
      *
      * @attr code REQUIRED the ISO3166_3 country code
      */
-    Closure country = { attrs ->
+    def country(Map attrs) {
         if (!attrs.code) {
             throwTagError('[country] requires [code] attribute to specify the country code')
         }

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -84,7 +84,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         configureCsrf()
     }
 
-    void configureCsrf() {
+    private void configureCsrf() {
         try {
             var filterChainProxy = applicationContext.getBean(
                     Class.forName('org.springframework.security.web.FilterChainProxy'))
@@ -105,7 +105,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr name REQUIRED the field name
      * @attr value the field value
      */
-    Closure textField = { attrs ->
+    def textField(Map attrs) {
         attrs.type = 'text'
         attrs.tagName = 'textField'
         fieldImpl(out, attrs)
@@ -119,7 +119,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr name REQUIRED the field name
      * @attr value the field value
      */
-    Closure passwordField = { attrs ->
+    def passwordField(Map attrs) {
         attrs.type = 'password'
         attrs.tagName = 'passwordField'
         fieldImpl(out, attrs)
@@ -131,11 +131,11 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr name REQUIRED the field name
      * @attr value the field value
      */
-    Closure hiddenField = { attrs ->
+    def hiddenField(Map attrs) {
         hiddenFieldImpl(out, attrs)
     }
 
-    def hiddenFieldImpl(out, attrs) {
+    private def hiddenFieldImpl(out, attrs) {
         attrs.type = 'hidden'
         attrs.tagName = 'hiddenField'
         fieldImpl(out, attrs)
@@ -151,7 +151,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr type input type; defaults to 'submit'
      * @attr event the webflow event id
      */
-    Closure submitButton = { attrs ->
+    def submitButton(Map attrs) {
         attrs.type = attrs.type ?: 'submit'
         attrs.tagName = 'submitButton'
         if (request.flowExecutionKey) {
@@ -168,13 +168,13 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      *
      * @attr type REQUIRED the input type
      */
-    Closure field = { attrs ->
+    def field(Map attrs) {
         attrs.tagName = 'field'
         fieldImpl(out, attrs)
     }
 
     @CompileStatic
-    def fieldImpl(GrailsPrintWriter out, Map attrs) {
+    private def fieldImpl(GrailsPrintWriter out, Map attrs) {
         resolveAttributes(attrs)
 
         attrs.value = processFormFieldValueIfNecessary(attrs.name, attrs.value, attrs.type)
@@ -206,7 +206,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr readonly if evaluates to true, sets to checkbox to read only
      * @attr id DOM element id; defaults to name
      */
-    Closure checkBox = { attrs ->
+    def checkBox(Map attrs) {
         def value = attrs.remove('value')
         def name = attrs.remove('name')
         def formName = attrs.get('form')
@@ -288,7 +288,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr escapeHtml if true escapes the text as HTML
      * @attr id DOM element id; defaults to name
      */
-    Closure textArea = { attrs, body ->
+    def textArea(Map attrs, Closure body) {
         resolveAttributes(attrs)
         // Pull out the value to use as content not attrib
         def value = attrs.remove('value')
@@ -338,7 +338,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     /**
      * Check required attributes, set the id to name if no id supplied, extract bean values etc.
      */
-    void resolveAttributes(Map attrs) {
+    private void resolveAttributes(Map attrs) {
         if (!attrs.name && !attrs.field) {
             throwTagError("Tag [${attrs.tagName}] is missing required attribute [name] or [field]")
         }
@@ -366,7 +366,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * Dump out attributes in HTML compliant fashion.
      */
     @CompileStatic
-    void outputAttributes(Map attrs, GrailsPrintWriter writer, boolean useNameAsIdIfIdDoesNotExist = false) {
+    private void outputAttributes(Map attrs, GrailsPrintWriter writer, boolean useNameAsIdIfIdDoesNotExist = false) {
         attrs.remove('tagName') // Just in case one is left
         Encoder htmlEncoder = codecLookup?.lookupEncoder('HTML')
         attrs.each { k, v ->
@@ -393,9 +393,9 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr useToken Set whether to send a token in the request to handle duplicate form submissions. See Handling Duplicate Form Submissions
      * @attr method the form method to use, either 'POST' or 'GET'; defaults to 'POST'
      */
-    Closure uploadForm = { attrs, body ->
+    def uploadForm(Map attrs, Closure body) {
         attrs.enctype = 'multipart/form-data'
-        out << form(attrs, body)
+        form(attrs, body)
     }
 
     /**
@@ -412,7 +412,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr useToken Set whether to send a token in the request to handle duplicate form submissions. See Handling Duplicate Form Submissions
      * @attr method the form method to use, either 'POST' or 'GET'; defaults to 'POST'
      */
-    Closure form = { attrs, body ->
+    def form(Map attrs, Closure body) {
 
         boolean useToken = false
         if (attrs.containsKey('useToken')) {
@@ -526,7 +526,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      *
      */
     @Deprecated(since = '7.0.0')
-    Closure actionSubmit = { attrs ->
+    def actionSubmit(Map attrs) {
         if (!attrs.value) {
             throwTagError('Tag [actionSubmit] is missing required attribute [value]')
         }
@@ -580,7 +580,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr base Sets the prefix to be added to the link target address, typically an absolute server URL. This overrides the behaviour of the absolute property, if both are specified.
      * @attr event Webflow _eventId parameter
      */
-    def formActionSubmit = { Map attrs ->
+    def formActionSubmit(Map attrs) {
         if (!attrs.value) {
             throwTagError('Tag [formActionSubmit] is missing required attribute [value]')
         }
@@ -634,7 +634,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr src The source of the image to use
      * @attr disabled Makes the button to be disabled. Will be interpreted as a Groovy Truth
      */
-    Closure actionSubmitImage = { attrs ->
+    def actionSubmitImage(Map attrs) {
         attrs.tagName = 'actionSubmitImage'
 
         if (!attrs.value) {
@@ -683,7 +683,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr locale The locale to use for display formatting. Defaults to the current request locale and then the system default locale if not specified.
      * @attr selectDateClass css class added to each select tag
      */
-    Closure datePicker = { attrs ->
+    def datePicker(Map attrs) {
         def out = out // let x = x ?
         def xdefault = attrs['default']
         if (xdefault == null) {
@@ -939,11 +939,11 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         }
     }
 
-    Closure renderNoSelectionOption = { noSelectionKey, noSelectionValue, value ->
+    def renderNoSelectionOption(noSelectionKey, noSelectionValue, value) {
         renderNoSelectionOptionImpl(out, noSelectionKey, noSelectionValue, value)
     }
 
-    def renderNoSelectionOptionImpl(out, noSelectionKey, noSelectionValue, value) {
+    private def renderNoSelectionOptionImpl(out, noSelectionKey, noSelectionValue, value) {
         // If a label for the '--Please choose--' first item is supplied, write it out
         out << "<option value=\"${(noSelectionKey == null ? '' : noSelectionKey)}\"${noSelectionKey == value ? ' selected="selected"' : ''}>${noSelectionValue.encodeAsHTML()}</option>"
     }
@@ -958,7 +958,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr value An instance of java.util.TimeZone. Defaults to the time zone for the current Locale if not specified
      * @attr locale The locale to use for formatting the time zone names. Defaults to the current request locale and then system default locale if not specified
      */
-    Closure timeZoneSelect = { attrs ->
+    def timeZoneSelect(Map attrs) {
         attrs.from = TimeZone.getAvailableIDs()
         attrs.value = (attrs.value ? attrs.value.ID : TimeZone.getDefault().ID)
         def date = new Date()
@@ -978,7 +978,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         }
 
         // use generic select
-        out << select(attrs)
+        select(attrs)
     }
 
     /**
@@ -992,7 +992,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr value The set locale, defaults to the current request locale if not specified
      * @attr locale The locale to use for formatting the locale names. Defaults to the current request locale and then the system default locale if not specified
      */
-    Closure localeSelect = { attrs ->
+    def localeSelect(Map attrs) {
         attrs.from = Locale.getAvailableLocales()
         attrs.value = (attrs.value ?: RCU.getLocale(request))?.toString()
         // set the key as a closure that formats the locale
@@ -1014,7 +1014,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr from The currency symbols to select from, defaults to the major ones if not specified
      * @attr value The currency value as the currency code. Defaults to the currency for the current Locale if not specified
      */
-    Closure currencySelect = { attrs, body ->
+    def currencySelect(Map attrs, Closure body) {
         if (!attrs.from) {
             attrs.from = DEFAULT_CURRENCY_CODES
         }
@@ -1053,7 +1053,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr dataAttrs a Map that adds data-* attributes to the &lt;option&gt; elements. Map's keys will be used as names of the data-* attributes like so: data-${key} (i.e. with a "data-" prefix). The object belonging to a Map's key determines the value of the data-* attribute. It can be a string referring to a property of beans in {@code from}, a Closure that accepts an item from {@code from} and returns the value or a List that contains a value for each of the &lt;option&gt;s.
      * @attr locale The locale to use for formatting. Defaults to the current request locale and then the system default locale if not specified
      */
-    Closure select = { attrs ->
+    def select(Map attrs) {
         if (!attrs.name) {
             throwTagError('Tag [select] is missing required attribute [name]')
         }
@@ -1257,7 +1257,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr readonly boolean to indicate that the radio button should not be editable
      * @attr id the DOM element id
      */
-    Closure radio = { attrs ->
+    def radio(Map attrs) {
         def value = attrs.remove('value')
         def name = attrs.remove('name')
         booleanToAttribute(attrs, 'disabled')
@@ -1286,7 +1286,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr disabled Disables the resulting radio buttons.
      * @attr readonly Makes the resulting radio buttons to not be editable
      */
-    Closure radioGroup = { attrs, body ->
+    def radioGroup(Map attrs, Closure body) {
         def value = attrs.remove('value')
         def values = attrs.remove('values')
         def labels = attrs.remove('labels')
@@ -1318,7 +1318,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         }
     }
 
-    private processFormFieldValueIfNecessary(name, value, type) {
+    private def processFormFieldValueIfNecessary(name, value, type) {
         if (requestDataValueProcessor != null) {
             return requestDataValueProcessor.processFormFieldValue(request, name, "${value}", type)
         }
@@ -1328,7 +1328,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     /**
      * Filters the url through the RequestDataValueProcessor bean if it is registered.
      */
-    String processedUrl(String link, request) {
+    private String processedUrl(String link, request) {
         if (requestDataValueProcessor == null) {
             return link
         }

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -104,8 +104,19 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      *
      * @attr name REQUIRED the field name
      * @attr value the field value
+     * @param name required field name
+     * @param attrs optional tag attributes including value, id, class and other HTML attributes
      */
     def textField(Map attrs) {
+        textFieldImpl(attrs)
+    }
+
+    def textField(String name, Map attrs) {
+        attrs.name = name
+        textFieldImpl(attrs)
+    }
+
+    private void textFieldImpl(Map attrs) {
         attrs.type = 'text'
         attrs.tagName = 'textField'
         fieldImpl(out, attrs)
@@ -118,8 +129,19 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      *
      * @attr name REQUIRED the field name
      * @attr value the field value
+     * @param name required field name
+     * @param attrs optional tag attributes including value, id, class and other HTML attributes
      */
     def passwordField(Map attrs) {
+        passwordFieldImpl(attrs)
+    }
+
+    def passwordField(String name, Map attrs) {
+        attrs.name = name
+        passwordFieldImpl(attrs)
+    }
+
+    private void passwordFieldImpl(Map attrs) {
         attrs.type = 'password'
         attrs.tagName = 'passwordField'
         fieldImpl(out, attrs)
@@ -130,8 +152,19 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      *
      * @attr name REQUIRED the field name
      * @attr value the field value
+     * @param name required field name
+     * @param attrs optional tag attributes including value and additional HTML attributes
      */
     def hiddenField(Map attrs) {
+        hiddenFieldTagImpl(attrs)
+    }
+
+    def hiddenField(String name, Map attrs) {
+        attrs.name = name
+        hiddenFieldTagImpl(attrs)
+    }
+
+    private void hiddenFieldTagImpl(Map attrs) {
         hiddenFieldImpl(out, attrs)
     }
 
@@ -150,8 +183,19 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr value the button text
      * @attr type input type; defaults to 'submit'
      * @attr event the webflow event id
+     * @param name required field name
+     * @param attrs optional tag attributes including value, type, event and additional HTML attributes
      */
     def submitButton(Map attrs) {
+        submitButtonImpl(attrs)
+    }
+
+    def submitButton(String name, Map attrs) {
+        attrs.name = name
+        submitButtonImpl(attrs)
+    }
+
+    private void submitButtonImpl(Map attrs) {
         attrs.type = attrs.type ?: 'submit'
         attrs.tagName = 'submitButton'
         if (request.flowExecutionKey) {
@@ -171,6 +215,17 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     def field(Map attrs) {
         attrs.tagName = 'field'
         fieldImpl(out, attrs)
+    }
+
+    /**
+     * A general tag for creating fields with method-argument binding for required type.
+     *
+     * @param type required input type
+     * @param attrs tag attributes, including required name/field and optional value/id/class/etc
+     */
+    def field(String type, Map attrs) {
+        attrs.type = type
+        field(attrs)
     }
 
     @CompileStatic

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -112,7 +112,6 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     }
 
     def textField(String name, Map attrs) {
-        attrs.name = name
         textFieldImpl(attrs)
     }
 
@@ -137,7 +136,6 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     }
 
     def passwordField(String name, Map attrs) {
-        attrs.name = name
         passwordFieldImpl(attrs)
     }
 
@@ -160,7 +158,6 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     }
 
     def hiddenField(String name, Map attrs) {
-        attrs.name = name
         hiddenFieldTagImpl(attrs)
     }
 
@@ -191,7 +188,6 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     }
 
     def submitButton(String name, Map attrs) {
-        attrs.name = name
         submitButtonImpl(attrs)
     }
 

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormatTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormatTagLib.groovy
@@ -94,7 +94,7 @@ class FormatTagLib implements TagLibrary {
      * @attr false text label for boolean false value
      * @attr locale Force the locale for formatting.
      */
-    Closure formatBoolean = { attrs ->
+    def formatBoolean(Map attrs) {
         if (!attrs.containsKey('boolean')) {
             throwTagError('Tag [formatBoolean] is missing required attribute [boolean]')
         }
@@ -144,7 +144,7 @@ class FormatTagLib implements TagLibrary {
      * @attr dateStyle Set separate style for the date part.
      * @attr timeStyle Set separate style for the time part.
      */
-    Closure formatDate = { attrs ->
+    def formatDate(Map attrs) {
 
         def date
         if (attrs.containsKey('date')) {
@@ -230,7 +230,7 @@ class FormatTagLib implements TagLibrary {
      * @attr roundingMode Sets the RoundingMode used in this DecimalFormat. Usual values: HALF_UP, HALF_DOWN. If roundingMode is UNNECESSARY and ArithemeticException raises, the original number formatted with default number formatting will be returned.
      * @attr nan String to be used for display if numberic value is NaN
      */
-    Closure formatNumber = { attrs ->
+    def formatNumber(Map attrs) {
         if (!attrs.containsKey('number')) {
             throwTagError('Tag [formatNumber] is missing required attribute [number]')
         }
@@ -360,7 +360,7 @@ class FormatTagLib implements TagLibrary {
      *
      * @attr codec REQUIRED the codec name
      */
-    Closure encodeAs = { attrs, body ->
+    def encodeAs(Map attrs, Closure body) {
         if (!attrs.codec) {
             throwTagError('Tag [encodeAs] requires a codec name in the [codec] attribute')
         }

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/JavascriptTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/JavascriptTagLib.groovy
@@ -71,7 +71,7 @@ class JavascriptTagLib implements ApplicationContextAware, TagLibrary {
      * @attr contextPath the context path to use (relative to the application context path). Defaults to "" or path to the plugin for a plugin view or template.
      * @attr base specifies the full base url to prepend to the library name
      */
-    Closure javascript = { attrs, body ->
+    Closure javascript = { Map attrs, body ->
         if (attrs.src) {
             javascriptInclude(attrs)
         } else {
@@ -121,7 +121,7 @@ class JavascriptTagLib implements ApplicationContextAware, TagLibrary {
      *
      * &lt;g:escapeJavascript&gt;This is some "text" to be escaped&lt;/g:escapeJavascript&gt;
      */
-    Closure escapeJavascript = { attrs, body ->
+    Closure escapeJavascript = { Map attrs, body ->
         if (body) {
             out << body()
         }

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/PluginTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/PluginTagLib.groovy
@@ -42,7 +42,7 @@ class PluginTagLib implements TagLibrary {
      *
      * @attr name REQUIRED the plugin name
      */
-    Closure path = { attrs, body ->
+    def path(Map attrs, Closure body) {
         out << pluginManager.getPluginPath(attrs.name)
     }
 
@@ -54,7 +54,7 @@ class PluginTagLib implements TagLibrary {
      * @attr name REQUIRED the plugin name
      * @attr version the plugin version
      */
-    Closure isAvailable = { attrs, body ->
+    def isAvailable(Map attrs, Closure body) {
         if (checkPluginExists(attrs.version, attrs.name)) {
             out << body()
         }
@@ -68,7 +68,7 @@ class PluginTagLib implements TagLibrary {
      * @attr name REQUIRED the plugin name
      * @attr version the plugin version
      */
-    Closure isNotAvailable = { attrs, body ->
+    def isNotAvailable(Map attrs, Closure body) {
         if (!checkPluginExists(attrs.version, attrs.name)) {
             out << body()
         }

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
@@ -66,7 +66,7 @@ class UrlMappingTagLib implements TagLibrary {
      * @attr view The name of the view. Cannot be specified in combination with controller/action/id
      * @attr model A model to pass onto the included controller in the request
      */
-    Closure include = { Map attrs, body ->
+    def include(Map attrs, Closure body) {
         if (attrs.action && !attrs.controller) {
             def controller = request?.getAttribute(GrailsApplicationAttributes.CONTROLLER)
             def controllerName = ((GroovyObject) controller)?.getProperty('controllerName')
@@ -119,7 +119,7 @@ class UrlMappingTagLib implements TagLibrary {
      * @attr mapping The named URL mapping to use to rewrite the link
      * @attr fragment The link fragment (often called anchor tag) to use
      */
-    Closure paginate = { Map attrsMap ->
+    def paginate(Map attrsMap) {
         TypeConvertingMap attrs = (TypeConvertingMap) attrsMap
         def writer = out
         if (attrs.total == null) {
@@ -184,14 +184,14 @@ class UrlMappingTagLib implements TagLibrary {
         // display previous link when not on firststep unless omitPrev is true
         if (currentstep > firststep && !attrs.boolean('omitPrev')) {
             linkParams.offset = offset - max
-            writer << callLink(appendClass((Map) linkTagAttrs.clone(), 'prevLink')) {
+            writer << callLink(appendClass(new LinkedHashMap(linkTagAttrs), 'prevLink')) {
                 (attrs.prev ?: messageSource.getMessage('paginate.prev', null, messageSource.getMessage('default.paginate.prev', null, 'Previous', locale), locale))
             }
         }
 
         // display steps when steps are enabled and laststep is not firststep
         if (steps && laststep > firststep) {
-            Map stepAttrs = appendClass((Map) linkTagAttrs.clone(), 'step')
+            Map stepAttrs = appendClass(new LinkedHashMap(linkTagAttrs), 'step')
 
             // determine begin and endstep paging variables
             int beginstep = currentstep - (Math.round(maxsteps / 2.0d) as int) + (maxsteps % 2)
@@ -212,7 +212,7 @@ class UrlMappingTagLib implements TagLibrary {
             // display firststep link when beginstep is not firststep
             if (beginstep > firststep && !attrs.boolean('omitFirst')) {
                 linkParams.offset = 0
-                writer << callLink((Map) stepAttrs.clone()) { firststep.toString() }
+                writer << callLink(new LinkedHashMap(stepAttrs)) { firststep.toString() }
             }
             //show a gap if beginstep isn't immediately after firststep, and if were not omitting first or rev
             if (beginstep > firststep + 1 && (!attrs.boolean('omitFirst') || !attrs.boolean('omitPrev'))) {
@@ -226,7 +226,7 @@ class UrlMappingTagLib implements TagLibrary {
                 }
                 else {
                     linkParams.offset = (i - 1) * max
-                    writer << callLink((Map) stepAttrs.clone()) { i.toString() }
+                    writer << callLink(new LinkedHashMap(stepAttrs)) { i.toString() }
                 }
             }
 
@@ -237,14 +237,14 @@ class UrlMappingTagLib implements TagLibrary {
             // display laststep link when endstep is not laststep
             if (endstep < laststep && !attrs.boolean('omitLast')) {
                 linkParams.offset = (laststep - 1) * max
-                writer << callLink((Map) stepAttrs.clone()) { laststep.toString() }
+                writer << callLink(new LinkedHashMap(stepAttrs)) { laststep.toString() }
             }
         }
 
         // display next link when not on laststep unless omitNext is true
         if (currentstep < laststep && !attrs.boolean('omitNext')) {
             linkParams.offset = offset + max
-            writer << callLink(appendClass((Map) linkTagAttrs.clone(), 'nextLink')) {
+            writer << callLink(appendClass(new LinkedHashMap(linkTagAttrs), 'nextLink')) {
                 (attrs.next ? attrs.next : messageSource.getMessage('paginate.next', null, messageSource.getMessage('default.paginate.next', null, 'Next', locale), locale))
             }
         }
@@ -277,7 +277,7 @@ class UrlMappingTagLib implements TagLibrary {
      * @attr params A map containing URL query parameters
      * @attr class CSS class name
      */
-    Closure sortableColumn = { Map attrs ->
+    def sortableColumn(Map attrs) {
         def writer = out
         if (!attrs.property) {
             throwTagError('Tag [sortableColumn] is missing required attribute [property]')

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
@@ -119,8 +119,8 @@ class UrlMappingTagLib implements TagLibrary {
      * @attr mapping The named URL mapping to use to rewrite the link
      * @attr fragment The link fragment (often called anchor tag) to use
      */
-    def paginate(Map attrsMap) {
-        TypeConvertingMap attrs = (TypeConvertingMap) attrsMap
+    def paginate(Map attrs) {
+        attrs = (TypeConvertingMap) attrs
         def writer = out
         if (attrs.total == null) {
             throwTagError('Tag [paginate] is missing required attribute [total]')

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/ValidationTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/ValidationTagLib.groovy
@@ -122,6 +122,10 @@ class ValidationTagLib implements TagLibrary {
         }
     }
 
+    def fieldValue(Map attrs) {
+        fieldValue(attrs, null)
+    }
+
     private Object parseForRejectedValue(bean, field) {
         def rejectedValue = bean
         for (String fieldPart in field.split('\\.')) {

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/ValidationTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/ValidationTagLib.groovy
@@ -65,7 +65,7 @@ class ValidationTagLib implements TagLibrary {
      * @attr encodeAs The name of a codec to apply, i.e. HTML, JavaScript, URL etc
      * @attr locale override locale to use instead of the one detected
      */
-    Closure fieldError = { attrs, body ->
+    def fieldError(Map attrs, Closure body) {
         def bean = attrs.bean
         def field = attrs.field
         def encodeAs = attrs.encodeAs
@@ -91,7 +91,7 @@ class ValidationTagLib implements TagLibrary {
      * @attr valueMessagePrefix Setting this allows the value to be resolved from the I18n messages.
      *
      */
-    Closure fieldValue = { attrs, body ->
+    def fieldValue(Map attrs, Closure body) {
         def bean = attrs.bean
         String field = attrs.field?.toString()
         if (!bean || !field) {
@@ -130,7 +130,7 @@ class ValidationTagLib implements TagLibrary {
         return rejectedValue
     }
 
-    def extractErrors(attrs) {
+    private def extractErrors(Map attrs) {
         def model = attrs.model
         def checkList = []
         if (attrs.containsKey('bean')) {
@@ -186,7 +186,7 @@ class ValidationTagLib implements TagLibrary {
      * @attr field The field of the bean or model reference to check
      * @attr model The model reference to check for errors
      */
-    Closure hasErrors = { attrs, body ->
+    def hasErrors(Map attrs, Closure body) {
         def errorsList = extractErrors(attrs)
         if (errorsList) {
             out << body()
@@ -201,16 +201,16 @@ class ValidationTagLib implements TagLibrary {
      * @attr field The field of the bean or model reference to check
      * @attr model The model reference to check for errors
      */
-    Closure eachError = { attrs, body ->
+    def eachError(Map attrs, Closure body) {
         eachErrorInternal(attrs, body, true)
     }
 
-    def eachErrorInternal(attrs, body, boolean outputResult = false) {
+    private def eachErrorInternal(Map attrs, Closure body, boolean outputResult = false) {
         def errorsList = extractErrors(attrs)
         eachErrorInternalForList(attrs, errorsList, body, outputResult)
     }
 
-    def eachErrorInternalForList(attrs, errorsList, body, boolean outputResult = false) {
+    private def eachErrorInternalForList(Map attrs, errorsList, Closure body, boolean outputResult = false) {
         def var = attrs.var
         def field = attrs.field
 
@@ -290,12 +290,12 @@ class ValidationTagLib implements TagLibrary {
      * @attr encodeAs The name of a codec to apply, i.e. HTML, JavaScript, URL etc
      * @attr locale override locale to use instead of the one detected
      */
-    Closure message = { attrs ->
+    def message(Map attrs) {
         messageImpl(attrs)
     }
 
     @CompileStatic
-    def messageImpl(Map attrs) {
+    private def messageImpl(Map attrs) {
         Locale locale = FormatTagLib.resolveLocale(attrs.locale)
         def tagSyntaxCall = (attrs instanceof GroovyPageAttributes) ? attrs.isGspTagSyntaxCall() : false
 
@@ -383,7 +383,7 @@ class ValidationTagLib implements TagLibrary {
      * @attr form REQUIRED the HTML form name
      * @attr againstClass REQUIRED the domain class name
      */
-    Closure validate = { attrs, body ->
+    def validate(Map attrs, Closure body) {
         def form = attrs.form
         if (!form) {
             throwTagError('Tag [validate] is missing required attribute [form]')

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/MethodDefinedTagLibSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/MethodDefinedTagLibSpec.groovy
@@ -1,0 +1,128 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.taglib
+
+import grails.artefact.Artefact
+import grails.compiler.GrailsCompileStatic
+import grails.testing.web.taglib.TagLibUnitTest
+import spock.lang.Specification
+
+class MethodDefinedTagLibSpec extends Specification implements TagLibUnitTest<MethodTagLib> {
+
+    void setupSpec() {
+        mockTagLibs(MethodTagLib, SharedNsMethodTagLib, SharedNsClosureTagLib, StaticMethodTagLib)
+    }
+
+    void "method tag can use implicit attrs"() {
+        expect:
+        applyTemplate('<g:methodTag blah="duh" />') == 'duh - is this'
+    }
+
+    void "method tag can bind named attribute to typed argument"() {
+        expect:
+        applyTemplate('<g:typedTag blah="duh" />') == 'duh - typed'
+    }
+    void "method tag can bind multiple named attributes to multiple typed arguments"() {
+        expect:
+        applyTemplate('<g:multiTypedTag first="hello" second="world" />') == 'hello-world'
+    }
+
+    void "method tag can use implicit body closure"() {
+        expect:
+        applyTemplate('<g:bodyTag>abc</g:bodyTag>') == 'before-abc-after'
+    }
+
+    void "closure tag remains supported"() {
+        expect:
+        applyTemplate('<g:legacyTag blah="duh" />') == 'legacy-duh'
+    }
+
+    void "multiple taglibs sharing the same namespace resolve independently"() {
+        expect:
+        applyTemplate('<shared:fromMethod one="1" /> <shared:fromClosure two="2" />') == 'method-1 closure-2'
+    }
+
+    void "statically compiled method tag can use implicit attrs and typed args"() {
+        expect:
+        applyTemplate('<g:staticImplicitTag blah="duh" /> <g:staticTypedTag blah="duh2" />') == 'duh - static implicit duh2 - static typed'
+    }
+
+    void "statically compiled method tag can render body"() {
+        expect:
+        applyTemplate('<g:staticBodyTag>abc</g:staticBodyTag>') == 'before-abc-after'
+    }
+}
+
+@GrailsCompileStatic
+@Artefact('TagLib')
+class StaticMethodTagLib {
+    def staticImplicitTag() {
+        Map tagAttrs = (Map) propertyMissing('attrs')
+        out << "${tagAttrs.blah} - static implicit"
+    }
+
+    def staticTypedTag(String blah) {
+        out << "${blah} - static typed"
+    }
+
+    def staticBodyTag() {
+        Closure tagBody = (Closure) propertyMissing('body')
+        out << "before-${tagBody?.call()}-after"
+    }
+}
+
+@Artefact('TagLib')
+class MethodTagLib {
+    def methodTag() {
+        out << "${attrs.blah} - is this"
+    }
+
+    def typedTag(String blah) {
+        out << "${blah} - typed"
+    }
+    def multiTypedTag(String first, String second) {
+        out << "${first}-${second}"
+    }
+
+    def bodyTag() {
+        out << "before-${body()}-after"
+    }
+
+    Closure legacyTag = { attrs, body ->
+        out << "legacy-${attrs.blah}"
+    }
+}
+
+@Artefact('TagLib')
+class SharedNsMethodTagLib {
+    static namespace = 'shared'
+
+    def fromMethod(String one) {
+        out << "method-${one}"
+    }
+}
+
+@Artefact('TagLib')
+class SharedNsClosureTagLib {
+    static namespace = 'shared'
+
+    Closure fromClosure = { attrs ->
+        out << "closure-${attrs.two}"
+    }
+}

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/MethodDefinedTagLibSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/MethodDefinedTagLibSpec.groovy
@@ -21,6 +21,7 @@ package org.grails.web.taglib
 import grails.artefact.Artefact
 import grails.compiler.GrailsCompileStatic
 import grails.testing.web.taglib.TagLibUnitTest
+import org.grails.taglib.GrailsTagException
 import spock.lang.Specification
 
 class MethodDefinedTagLibSpec extends Specification implements TagLibUnitTest<MethodTagLib> {
@@ -76,6 +77,18 @@ class MethodDefinedTagLibSpec extends Specification implements TagLibUnitTest<Me
         expect:
         applyTemplate('<g:staticBodyTag>abc</g:staticBodyTag>') == 'before-abc-after'
     }
+
+    void "private and protected methods are not exposed as tags"() {
+        when:
+        applyTemplate('<g:privateOnlyTag/>')
+        then:
+        thrown(GrailsTagException)
+
+        when:
+        applyTemplate('<g:protectedOnlyTag/>')
+        then:
+        thrown(GrailsTagException)
+    }
 }
 
 @GrailsCompileStatic
@@ -115,6 +128,14 @@ class MethodTagLib {
 
     def attrsMapTag(Map attrs) {
         out << "${attrs.blah}"
+    }
+
+    private def privateOnlyTag() {
+        out << 'private'
+    }
+
+    protected def protectedOnlyTag() {
+        out << 'protected'
     }
 
     def bodyTag() {

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/MethodDefinedTagLibSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/MethodDefinedTagLibSpec.groovy
@@ -43,6 +43,15 @@ class MethodDefinedTagLibSpec extends Specification implements TagLibUnitTest<Me
         applyTemplate('<g:multiTypedTag first="hello" second="world" />') == 'hello-world'
     }
 
+    void "method tag can bind map-valued attribute to map-typed argument by parameter name"() {
+        expect:
+        applyTemplate('<g:mapValueTag config="${[k:\'v\']}" />') == 'v'
+    }
+    void "method tag still supports reserved attrs map parameter"() {
+        expect:
+        applyTemplate('<g:attrsMapTag blah="duh" />') == 'duh'
+    }
+
     void "method tag can use implicit body closure"() {
         expect:
         applyTemplate('<g:bodyTag>abc</g:bodyTag>') == 'before-abc-after'
@@ -98,6 +107,14 @@ class MethodTagLib {
     }
     def multiTypedTag(String first, String second) {
         out << "${first}-${second}"
+    }
+
+    def mapValueTag(Map config) {
+        out << "${config.k}"
+    }
+
+    def attrsMapTag(Map attrs) {
+        out << "${attrs.blah}"
     }
 
     def bodyTag() {

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/MethodVsClosureTagInvocationBenchmarkSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/MethodVsClosureTagInvocationBenchmarkSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.taglib
+
+import grails.artefact.Artefact
+import grails.testing.web.taglib.TagLibUnitTest
+import spock.lang.Specification
+
+class MethodVsClosureTagInvocationBenchmarkSpec extends Specification implements TagLibUnitTest<MethodVsClosureBenchmarkTagLib> {
+
+    void 'benchmark method invocation versus closure invocation for taglibs'() {
+        given:
+        int warmupIterations = 50
+        int measureIterations = 300
+        String closureTemplate = '<g:closureTag value="123" />'
+        String methodTemplate = '<g:methodTag value="123" />'
+
+        expect:
+        applyTemplate(closureTemplate) == '123'
+        applyTemplate(methodTemplate) == '123'
+
+        when:
+        warmupIterations.times {
+            applyTemplate(closureTemplate)
+            applyTemplate(methodTemplate)
+        }
+
+        long closureNanos = measureNanos(measureIterations) {
+            applyTemplate(closureTemplate)
+        }
+        long methodNanos = measureNanos(measureIterations) {
+            applyTemplate(methodTemplate)
+        }
+
+        double closurePerOpMicros = (closureNanos / (double) measureIterations) / 1_000d
+        double methodPerOpMicros = (methodNanos / (double) measureIterations) / 1_000d
+        double ratio = methodPerOpMicros / closurePerOpMicros
+
+        println "BENCHMARK taglib invocation: closure=${String.format('%.3f', closurePerOpMicros)}us/op, method=${String.format('%.3f', methodPerOpMicros)}us/op, method/closure=${String.format('%.3f', ratio)}"
+
+        then:
+        closurePerOpMicros > 0d
+        methodPerOpMicros > 0d
+    }
+
+    private static long measureNanos(int iterations, Closure<?> work) {
+        long start = System.nanoTime()
+        iterations.times {
+            work.call()
+        }
+        System.nanoTime() - start
+    }
+}
+
+@Artefact('TagLib')
+class MethodVsClosureBenchmarkTagLib {
+    Closure closureTag = { attrs ->
+        out << attrs.value
+    }
+
+    def methodTag(String value) {
+        out << value
+    }
+}

--- a/grails-test-examples/app1/grails-app/controllers/functionaltests/MiscController.groovy
+++ b/grails-test-examples/app1/grails-app/controllers/functionaltests/MiscController.groovy
@@ -43,6 +43,10 @@ class MiscController {
         [:]
     }
 
+    def tagMethods() {
+        render(view: 'tagMethods')
+    }
+
     def interceptedByInterceptor() {
     	// no op
     }

--- a/grails-test-examples/app1/grails-app/taglib/functionaltests/MethodTagLib.groovy
+++ b/grails-test-examples/app1/grails-app/taglib/functionaltests/MethodTagLib.groovy
@@ -16,23 +16,31 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+package functionaltests
+import grails.compiler.GrailsCompileStatic
 
-// tag::basic_declaration[]
-package demo
+@GrailsCompileStatic
+class MethodTagLib {
 
-class FirstTagLib {
-    static defaultEncodeAs = [taglib:'html']
+    def implicitTag() {
+        Map tagAttrs = (Map) propertyMissing('attrs')
+        out << "${tagAttrs.blah} - implicit"
+    }
 
-    static namespace = 'one'
+    def typedTag(String blah) {
+        out << "${blah} - typed"
+    }
 
-    def sayHello() {
-        out << 'BEFORE '
+    def multiTypedTag(String first, String second) {
+        out << "${first}-${second}"
+    }
 
-        // this is invoking a tag from another tag library
-        out << two.sayHello()
+    def bodyTag() {
+        Closure tagBody = (Closure) propertyMissing('body')
+        out << "before-${tagBody?.call()}-after"
+    }
 
-        out << ' AFTER'
+    Closure legacyTag = { Map attrs ->
+        out << "legacy-${attrs.blah}"
     }
 }
-// end::basic_declaration[]
-

--- a/grails-test-examples/app1/grails-app/taglib/functionaltests/SharedNsClosureTagLib.groovy
+++ b/grails-test-examples/app1/grails-app/taglib/functionaltests/SharedNsClosureTagLib.groovy
@@ -16,23 +16,12 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+package functionaltests
 
-// tag::basic_declaration[]
-package demo
+class SharedNsClosureTagLib {
+    static namespace = 'shared'
 
-class FirstTagLib {
-    static defaultEncodeAs = [taglib:'html']
-
-    static namespace = 'one'
-
-    def sayHello() {
-        out << 'BEFORE '
-
-        // this is invoking a tag from another tag library
-        out << two.sayHello()
-
-        out << ' AFTER'
+    Closure fromClosure = { attrs ->
+        out << "closure-${attrs.two}"
     }
 }
-// end::basic_declaration[]
-

--- a/grails-test-examples/app1/grails-app/taglib/functionaltests/SharedNsMethodTagLib.groovy
+++ b/grails-test-examples/app1/grails-app/taglib/functionaltests/SharedNsMethodTagLib.groovy
@@ -16,23 +16,12 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+package functionaltests
 
-// tag::basic_declaration[]
-package demo
+class SharedNsMethodTagLib {
+    static namespace = 'shared'
 
-class FirstTagLib {
-    static defaultEncodeAs = [taglib:'html']
-
-    static namespace = 'one'
-
-    def sayHello() {
-        out << 'BEFORE '
-
-        // this is invoking a tag from another tag library
-        out << two.sayHello()
-
-        out << ' AFTER'
+    def fromMethod(String one) {
+        out << "method-${one}"
     }
 }
-// end::basic_declaration[]
-

--- a/grails-test-examples/app1/grails-app/views/misc/tagMethods.gsp
+++ b/grails-test-examples/app1/grails-app/views/misc/tagMethods.gsp
@@ -1,0 +1,7 @@
+<g:implicitTag blah="duh" />
+<g:typedTag blah="duh2" />
+<g:multiTypedTag first="hello" second="world" />
+<g:bodyTag>abc</g:bodyTag>
+<g:legacyTag blah="legacy" />
+<shared:fromMethod one="1" />
+<shared:fromClosure two="2" />

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/MiscFunctionalSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/MiscFunctionalSpec.groovy
@@ -51,4 +51,18 @@ class MiscFunctionalSpec extends ContainerGebSpec {
         then:
         pageSource.contains('[test test test]')
     }
+
+    void 'Test method-defined taglibs render expected output end to end'() {
+        when:
+        go('/misc/tagMethods')
+
+        then:
+        pageSource.contains('duh - implicit')
+        pageSource.contains('duh2 - typed')
+        pageSource.contains('hello-world')
+        pageSource.contains('before-abc-after')
+        pageSource.contains('legacy-legacy')
+        pageSource.contains('method-1')
+        pageSource.contains('closure-2')
+    }
 }

--- a/grails-test-examples/demo33/grails-app/taglib/demo/SampleTagLib.groovy
+++ b/grails-test-examples/demo33/grails-app/taglib/demo/SampleTagLib.groovy
@@ -28,23 +28,23 @@ class SampleTagLib {
 
     // end::basic_declaration[]
     // tag::hello_world[]
-    def helloWorld = { attrs ->
+    def helloWorld() {
         out << 'Hello, World!'
     }
     // end::hello_world[]
     // tag::say_hello[]
-    def sayHello = { attrs ->
+    def sayHello() {
         out << "Hello, ${attrs.name}!"
     }
     // end::say_hello[]
     // tag::render_some_number[]
-    def renderSomeNumber = { attrs ->
+    def renderSomeNumber() {
         int number = attrs.int('value', -1)
         out << "The Number Is ${number}"
     }
     // end::render_some_number[]
 
-    def renderMessage = {
+    def renderMessage() {
         out << message(code: 'some.custom.message', locale: request.locale)
     }
 // tag::basic_declaration[]

--- a/grails-test-examples/demo33/grails-app/taglib/demo/SecondTagLib.groovy
+++ b/grails-test-examples/demo33/grails-app/taglib/demo/SecondTagLib.groovy
@@ -25,7 +25,7 @@ class SecondTagLib {
 
     static namespace = 'two'
 
-    def sayHello = { attrs ->
+    def sayHello() {
         out << 'Hello From SecondTagLib'
     }
 }

--- a/grails-test-examples/plugins/loadafter/build.gradle
+++ b/grails-test-examples/plugins/loadafter/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     api 'com.h2database:h2'
     api 'jakarta.servlet:jakarta.servlet-api'
 
-    implementation "org.apache.grails:grails-spring-security:$grailsSpringSecurityVersion"
+    implementation 'org.apache.grails:grails-spring-security:7.0.1'
 
     console 'org.apache.grails:grails-console'
 }


### PR DESCRIPTION
## Summary
This PR introduces method-based TagLib handlers as the recommended syntax, while preserving full backward compatibility with closure-based handlers and legacy invocation paths.

## What’s included
- Add method-defined TagLib support in core dispatch/invocation paths
- Preserve implicit method context (`attrs` and `body`) for method handlers
- Support binding named attributes directly to method signature arguments (for example `def greeting(String name)` binds from `name="..."`)
- Add compatibility shims so legacy property/direct invocations continue to work for method-defined tags
- Preserve namespaced dispatch behavior and collision handling with method-backed tags
- Add compile-time warning for closure-defined tag fields in user TagLibs
- Convert shipped Grails web/GSP taglibs to method-based handlers
- Add coverage for method-defined tags and legacy compatibility behavior
- Add benchmark spec for method vs closure invocation
- Update guides/docs to present method syntax first, with closure syntax as legacy-compatible

## Performance
The method-vs-closure benchmark added in this change set shows an approximately **7–10% improvement** for method-based invocation in the covered scenarios.

## TagLib syntax examples
### Recommended (method-based)
```groovy
class DemoTagLib {
    static namespace = 'demo'

    def greet() {
        out << "Hello, ${attrs.name}!"
    }

    def greeting(String name) {
        out << "Hello, ${name}!"
    }

    def repeat() {
        attrs.times?.toInteger()?.times { n ->
            out << body(n)
        }
    }
}
```

Usage:
```gsp
<demo:greet name="Ada" />
<demo:greeting name="Ada" />
```

### Legacy-compatible (closure field)
```groovy
class DemoTagLib {
    static namespace = 'demo'

    def greet = { attrs, body ->
        out << "Hello, ${attrs.name}!"
    }
}
```

## Validation performed
- Focused regressions:
  - `FormTagLib2Tests`
  - `FormTagLib3Tests`
  - `SelectTagTests`
  - `NamespacedTagLibMethodTests`
  - `TagLibMethodMissingSpec`
  - `MethodDefinedTagLibSpec`
- Full suite:
  - `:grails-gsp:test`
- Functional validation:
  - `:grails-test-examples-app1:integrationTest --tests functionaltests.MiscFunctionalSpec`

Co-Authored-By: Oz <oz-agent@warp.dev>
