### PR TITLE
fix: resolve three where-query bugs (#14344, #14480, #14569)

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryOldIssueVerificationSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryOldIssueVerificationSpec.groovy
@@ -1,0 +1,376 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.tests
+
+import grails.gorm.DetachedCriteria
+import grails.gorm.annotation.Entity
+import grails.gorm.hibernate.HibernateEntity
+import grails.gorm.transactions.Rollback
+import grails.gorm.transactions.Transactional
+import org.grails.orm.hibernate.HibernateDatastore
+import org.springframework.transaction.PlatformTransactionManager
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.PendingFeature
+
+/**
+ * Verification tests for old where-query issues reported against GORM 6.x / Grails 3.x.
+ * These tests confirm whether each issue has been fixed in the current 7.x codebase.
+ *
+ * Issues verified:
+ * - #14596: where-query returning wrong result if expression not assigned to variable
+ * - #14622: where-query with multi-level association restriction produces wrong result
+ * - #14480: countByStuff() not working with where queries
+ * - #11202: where queries in tests not filtering results
+ * - #14636: many-to-many queries with sorting raise exception
+ * - #14610: error querying association with basic collection types
+ * - #14569: count() incorrect with projection in where query
+ * - #14600: findAllBy* in bidirectional hasMany produces error
+ */
+class WhereQueryOldIssueVerificationSpec extends Specification {
+
+    @Shared @AutoCleanup HibernateDatastore datastore = new HibernateDatastore(
+        WqFoo, WqWord, WqPhrase, WqSentence,
+        WqScientificBook, WqBookAuthor,
+        WqThing,
+        WqUserRole, WqRoleUser, WqRole,
+        WqStudent,
+        WqGroupedItem,
+        WqBiBook, WqBiAuthor
+    )
+    @Shared PlatformTransactionManager transactionManager = datastore.getTransactionManager()
+
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/14596')
+    def "where-query returning wrong result if expression not assigned to variable"() {
+        given: "a Foo with bar set to a non-null value"
+        new WqFoo(bar: "something").save(flush: true)
+
+        when: "querying inline for records where bar == null"
+        long inlineCount = WqFoo.where { bar == null }.count()
+
+        and: "querying with variable assignment for records where bar == null"
+        def criteria = WqFoo.where { bar == null }
+        long variableCount = criteria.count()
+
+        then: "both should return 0 since no Foo has bar == null"
+        inlineCount == 0
+        variableCount == 0
+    }
+
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/14596')
+    def "where-query inline vs variable produces same result with matching records"() {
+        given: "Foos with null and non-null bar values"
+        new WqFoo(bar: null).save(flush: true)
+        new WqFoo(bar: "something").save(flush: true)
+
+        when: "querying inline"
+        long inlineCount = WqFoo.where { bar == null }.count()
+
+        and: "querying with variable"
+        def criteria = WqFoo.where { bar == null }
+        long variableCount = criteria.count()
+
+        then: "both should return 1"
+        inlineCount == 1
+        variableCount == 1
+    }
+
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/14622')
+    def "where-query with multi-level association restriction produces correct result"() {
+        given: "a sentence -> phrase -> word hierarchy"
+        def sentence = new WqSentence(text: "Hello World").save(flush: true)
+        def phrase1 = new WqPhrase(text: "Hello", sentence: sentence).save(flush: true)
+        def phrase2 = new WqPhrase(text: "World", sentence: sentence).save(flush: true)
+        def word1 = new WqWord(text: "Hel", phrase: phrase1).save(flush: true)
+        def word2 = new WqWord(text: "lo", phrase: phrase1).save(flush: true)
+        def word3 = new WqWord(text: "Wor", phrase: phrase2).save(flush: true)
+        def word4 = new WqWord(text: "ld", phrase: phrase2).save(flush: true)
+
+        when: "querying words by sentence via multi-level association"
+        def words = WqWord.where {
+            phrase.sentence == sentence
+        }.list()
+
+        then: "all 4 words belonging to the sentence should be returned"
+        words.size() == 4
+    }
+
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/14480')
+    def "countBy dynamic finder works correctly with where queries"() {
+        given: "scientific and non-scientific books by different authors"
+        def author1 = new WqBookAuthor(name: "Author A").save(flush: true)
+        def author2 = new WqBookAuthor(name: "Author B").save(flush: true)
+        new WqScientificBook(title: "Science 1", scientific: true, author: author1).save(flush: true)
+        new WqScientificBook(title: "Science 2", scientific: true, author: author1).save(flush: true)
+        new WqScientificBook(title: "Novel 1", scientific: false, author: author1).save(flush: true)
+        new WqScientificBook(title: "Science 3", scientific: true, author: author2).save(flush: true)
+
+        when: "using countByAuthor on a where query filtering scientific books"
+        def scientificBooks = WqScientificBook.where { scientific == true }
+        long findCount = scientificBooks.findAllByAuthor(author1).size()
+        long countResult = scientificBooks.countByAuthor(author1)
+
+        then: "countByAuthor should match findAllByAuthor count"
+        findCount == 2
+        countResult == 2
+    }
+
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/11202')
+    def "where queries in tests filter results correctly"() {
+        given: "two things with different names"
+        new WqThing(name: "thing 1").save(flush: true)
+        new WqThing(name: "thing 2").save(flush: true)
+
+        when: "querying with where inline"
+        def inlineResult = WqThing.where { name == "thing 1" }.list()
+
+        then: "where query filters correctly"
+        inlineResult.size() == 1
+
+        when: "querying from a closure"
+        def queryClosure = { -> WqThing.where { name == "thing 1" } }
+        def closureResult = queryClosure.call().list()
+
+        then: "closure-based where query filters correctly"
+        closureResult.size() == 1
+    }
+
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/14636')
+    def "many-to-many queries with sorting do not throw exception"() {
+        given: "users and roles in a many-to-many relationship"
+        def role1 = new WqRole(name: "ADMIN").save(flush: true)
+        def role2 = new WqRole(name: "USER").save(flush: true)
+        def user1 = new WqRoleUser(username: "alice").save(flush: true)
+        def user2 = new WqRoleUser(username: "bob").save(flush: true)
+        new WqUserRole(user: user1, role: role1).save(flush: true)
+        new WqUserRole(user: user2, role: role2).save(flush: true)
+        new WqUserRole(user: user1, role: role2).save(flush: true)
+
+        when: "querying UserRole by role and sorting by user.username"
+        def results = WqUserRole.where {
+            role == role1
+        }.list(sort: 'user.username')
+
+        then: "no exception is thrown and results are correct"
+        noExceptionThrown()
+        results.size() == 1
+        results[0].user.username == "alice"
+    }
+
+    @PendingFeature(reason = 'Basic collection type in query is still broken - tracked for a future fix')
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/14610')
+    def "querying association with basic collection types works"() {
+        given: "students with basic collection type (hasMany String)"
+        def s1 = new WqStudent(name: "Alice", email: "alice@test.com").save(flush: true)
+        s1.addToSchools("School1")
+        s1.addToSchools("School2")
+        s1.save(flush: true)
+
+        def s2 = new WqStudent(name: "Bob", email: "bob@test.com").save(flush: true)
+        s2.addToSchools("School2")
+        s2.addToSchools("School3")
+        s2.save(flush: true)
+
+        when: "querying students by school using criteria"
+        def emails = WqStudent.createCriteria().list {
+            'in'('schools', ['School1'])
+            projections {
+                property 'email'
+            }
+        }
+
+        then: "the query works without error"
+        noExceptionThrown()
+        emails.contains("alice@test.com")
+    }
+
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/14569')
+    def "count() gives correct results with projection in where query"() {
+        given: "items with different groupings"
+        (1..12).each { new WqGroupedItem(itemGroup: 1, itemValue: "a${it}").save() }
+        (1..16).each { new WqGroupedItem(itemGroup: 2, itemValue: "b${it}").save() }
+        (1..9).each { new WqGroupedItem(itemGroup: 3, itemValue: "c${it}").save() }
+        (1..18).each { new WqGroupedItem(itemGroup: 4, itemValue: "d${it}").save() }
+        (1..5).each { new WqGroupedItem(itemGroup: 5, itemValue: "e${it}").save(flush: true) }
+
+        when: "creating a where query with groupProperty and count projections"
+        def c = WqGroupedItem.where {
+            projections {
+                groupProperty 'itemGroup'
+                count()
+            }
+        }
+        def groups = c.list()
+
+        then: "list returns the correct number of groups"
+        groups.size() == 5
+
+        and: "count returns the number of groups, not the count from first projection row"
+        c.count() == 5
+    }
+
+    @Rollback
+    @Issue('https://github.com/apache/grails-core/issues/14600')
+    def "findAllBy works with bidirectional hasMany relation"() {
+        given: "authors with books in a bidirectional hasMany"
+        def author1 = new WqBiAuthor(name: "Stephen King").save(flush: true)
+        def book1 = new WqBiBook(title: "IT").save(flush: true)
+        def book2 = new WqBiBook(title: "The Shining").save(flush: true)
+        author1.addToBooks(book1)
+        author1.addToBooks(book2)
+        book1.addToAuthors(author1)
+        book2.addToAuthors(author1)
+        author1.save(flush: true)
+
+        when: "using withCriteria to find books by author"
+        def books = WqBiBook.withCriteria {
+            authors {
+                'in'('id', [author1.id])
+            }
+        }
+
+        then: "books are found without error"
+        noExceptionThrown()
+        books.size() == 2
+    }
+}
+
+// --- Domain classes for verification ---
+
+@Entity
+class WqFoo implements HibernateEntity<WqFoo> {
+    String bar
+
+    static constraints = {
+        bar nullable: true
+    }
+}
+
+@Entity
+class WqSentence implements HibernateEntity<WqSentence> {
+    String text
+}
+
+@Entity
+class WqPhrase implements HibernateEntity<WqPhrase> {
+    String text
+    static belongsTo = [sentence: WqSentence]
+}
+
+@Entity
+class WqWord implements HibernateEntity<WqWord> {
+    String text
+    static belongsTo = [phrase: WqPhrase]
+}
+
+@Entity
+class WqScientificBook implements HibernateEntity<WqScientificBook> {
+    String title
+    Boolean scientific
+
+    static belongsTo = [author: WqBookAuthor]
+}
+
+@Entity
+class WqBookAuthor implements HibernateEntity<WqBookAuthor> {
+    String name
+    static hasMany = [books: WqScientificBook]
+}
+
+@Entity
+class WqThing implements HibernateEntity<WqThing> {
+    String name
+}
+
+@Entity
+class WqRole implements HibernateEntity<WqRole> {
+    String name
+}
+
+@Entity
+class WqRoleUser implements HibernateEntity<WqRoleUser> {
+    String username
+    static hasMany = [userRoles: WqUserRole]
+}
+
+@Entity
+class WqUserRole implements HibernateEntity<WqUserRole>, Serializable {
+    static belongsTo = [user: WqRoleUser, role: WqRole]
+
+    static mapping = {
+        id composite: ['user', 'role']
+    }
+
+    static constraints = {
+        user unique: 'role'
+    }
+}
+
+@Entity
+class WqStudent implements HibernateEntity<WqStudent> {
+    String name
+    String email
+
+    static hasMany = [schools: String]
+
+    static mapping = {
+        schools joinTable: [column: 'school']
+    }
+
+    static constraints = {
+        name blank: false
+        email blank: false
+    }
+}
+
+@Entity
+class WqGroupedItem implements HibernateEntity<WqGroupedItem> {
+    Integer itemGroup
+    String itemValue
+
+    static mapping = {
+        itemGroup column: 'item_group'
+        itemValue column: 'item_value'
+    }
+}
+
+@Entity
+class WqBiBook implements HibernateEntity<WqBiBook> {
+    String title
+
+    static hasMany = [authors: WqBiAuthor]
+    static belongsTo = WqBiAuthor
+}
+
+@Entity
+class WqBiAuthor implements HibernateEntity<WqBiAuthor> {
+    String name
+
+    static hasMany = [books: WqBiBook]
+}

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryOldIssueVerificationSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryOldIssueVerificationSpec.groovy
@@ -259,7 +259,6 @@ class WhereQueryOldIssueVerificationSpec extends Specification {
     }
 }
 
-// --- Domain classes for verification ---
 
 @Entity
 class WqFoo implements HibernateEntity<WqFoo> {

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryOldIssueVerificationSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryOldIssueVerificationSpec.groovy
@@ -18,11 +18,9 @@
  */
 package grails.gorm.tests
 
-import grails.gorm.DetachedCriteria
 import grails.gorm.annotation.Entity
 import grails.gorm.hibernate.HibernateEntity
 import grails.gorm.transactions.Rollback
-import grails.gorm.transactions.Transactional
 import org.grails.orm.hibernate.HibernateDatastore
 import org.springframework.transaction.PlatformTransactionManager
 import spock.lang.AutoCleanup

--- a/grails-datamapping-core/src/main/groovy/grails/gorm/DetachedCriteria.groovy
+++ b/grails-datamapping-core/src/main/groovy/grails/gorm/DetachedCriteria.groovy
@@ -20,6 +20,7 @@
 package grails.gorm
 
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 
 import jakarta.persistence.criteria.JoinType
 
@@ -41,6 +42,7 @@ import org.grails.datastore.mapping.query.api.QueryableCriteria
  * @author Graeme Rocher
  * @since 1.0
  */
+@Slf4j
 @CompileStatic
 class DetachedCriteria<T> extends AbstractDetachedCriteria<T> implements GormOperations<T>, QueryableCriteria<T>, Iterable<T> {
 
@@ -517,6 +519,12 @@ class DetachedCriteria<T> extends AbstractDetachedCriteria<T> implements GormOpe
             // a simple count() projection returns incorrect results because it
             // appends to the existing projections rather than replacing them.
             // Fall back to counting the grouped result rows.
+            // This will be resolved properly in Grails 8 with Hibernate 7's
+            // JpaSelectCriteria.from(Subquery) support for derived tables.
+            log.warn('DetachedCriteria.count() with user-defined projections cannot use a SQL count query ' +
+                    'due to a Hibernate 5 limitation. All grouped result rows will be loaded into memory to ' +
+                    'determine the count. This may impact performance on large result sets. ' +
+                    'This will be resolved in Grails 8 (Hibernate 7) which supports derived table subqueries.')
             return ((List) withPopulatedQuery(args, additionalCriteria) { Query query ->
                 query.list()
             }).size()

--- a/grails-datamapping-core/src/main/groovy/grails/gorm/DetachedCriteria.groovy
+++ b/grails-datamapping-core/src/main/groovy/grails/gorm/DetachedCriteria.groovy
@@ -512,6 +512,15 @@ class DetachedCriteria<T> extends AbstractDetachedCriteria<T> implements GormOpe
      * @return The count
      */
     Number count(Map args = Collections.emptyMap(), @DelegatesTo(DetachedCriteria) Closure additionalCriteria = null) {
+        if (!projections.isEmpty()) {
+            // When user-defined projections exist (e.g. groupProperty + count),
+            // a simple count() projection returns incorrect results because it
+            // appends to the existing projections rather than replacing them.
+            // Fall back to counting the grouped result rows.
+            return ((List) withPopulatedQuery(args, additionalCriteria) { Query query ->
+                query.list()
+            }).size()
+        }
         (Number) withPopulatedQuery(args, additionalCriteria) { Query query ->
             query.projections().count()
             query.singleResult()
@@ -525,10 +534,7 @@ class DetachedCriteria<T> extends AbstractDetachedCriteria<T> implements GormOpe
      * @return The count
      */
     Number count(@DelegatesTo(DetachedCriteria) Closure additionalCriteria) {
-        (Number) withPopulatedQuery(Collections.emptyMap(), additionalCriteria) { Query query ->
-            query.projections().count()
-            query.singleResult()
-        }
+        count(Collections.emptyMap(), additionalCriteria)
     }
 
     /**

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/finders/CountByFinder.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/finders/CountByFinder.java
@@ -67,6 +67,7 @@ public class CountByFinder extends DynamicFinder implements QueryBuildingFinder 
 
     protected Query buildQuery(DynamicFinderInvocation invocation, Class<?> clazz, Query q) {
         applyAdditionalCriteria(q, invocation.getCriteria());
+        applyDetachedCriteria(q, invocation.getDetachedCriteria());
         configureQueryWithArguments(clazz, q, invocation.getArguments());
 
         String operatorInUse = invocation.getOperator();

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/jpa/JpaQueryBuilder.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/jpa/JpaQueryBuilder.java
@@ -734,6 +734,42 @@ public class JpaQueryBuilder {
             }
         });
 
+        queryHandlers.put(Query.SizeEquals.class, new QueryHandler() {
+            public int handle(PersistentEntity entity, Query.Criterion criterion, StringBuilder q, StringBuilder whereClause, String logicalName, int position, List parameters, ConversionService conversionService, boolean allowJoins, boolean hibernateCompatible) {
+                return handleSizeComparison(entity, (Query.PropertyCriterion) criterion, whereClause, logicalName, position, parameters, conversionService, "=", hibernateCompatible);
+            }
+        });
+
+        queryHandlers.put(Query.SizeNotEquals.class, new QueryHandler() {
+            public int handle(PersistentEntity entity, Query.Criterion criterion, StringBuilder q, StringBuilder whereClause, String logicalName, int position, List parameters, ConversionService conversionService, boolean allowJoins, boolean hibernateCompatible) {
+                return handleSizeComparison(entity, (Query.PropertyCriterion) criterion, whereClause, logicalName, position, parameters, conversionService, "!=", hibernateCompatible);
+            }
+        });
+
+        queryHandlers.put(Query.SizeGreaterThan.class, new QueryHandler() {
+            public int handle(PersistentEntity entity, Query.Criterion criterion, StringBuilder q, StringBuilder whereClause, String logicalName, int position, List parameters, ConversionService conversionService, boolean allowJoins, boolean hibernateCompatible) {
+                return handleSizeComparison(entity, (Query.PropertyCriterion) criterion, whereClause, logicalName, position, parameters, conversionService, ">", hibernateCompatible);
+            }
+        });
+
+        queryHandlers.put(Query.SizeGreaterThanEquals.class, new QueryHandler() {
+            public int handle(PersistentEntity entity, Query.Criterion criterion, StringBuilder q, StringBuilder whereClause, String logicalName, int position, List parameters, ConversionService conversionService, boolean allowJoins, boolean hibernateCompatible) {
+                return handleSizeComparison(entity, (Query.PropertyCriterion) criterion, whereClause, logicalName, position, parameters, conversionService, ">=", hibernateCompatible);
+            }
+        });
+
+        queryHandlers.put(Query.SizeLessThan.class, new QueryHandler() {
+            public int handle(PersistentEntity entity, Query.Criterion criterion, StringBuilder q, StringBuilder whereClause, String logicalName, int position, List parameters, ConversionService conversionService, boolean allowJoins, boolean hibernateCompatible) {
+                return handleSizeComparison(entity, (Query.PropertyCriterion) criterion, whereClause, logicalName, position, parameters, conversionService, "<", hibernateCompatible);
+            }
+        });
+
+        queryHandlers.put(Query.SizeLessThanEquals.class, new QueryHandler() {
+            public int handle(PersistentEntity entity, Query.Criterion criterion, StringBuilder q, StringBuilder whereClause, String logicalName, int position, List parameters, ConversionService conversionService, boolean allowJoins, boolean hibernateCompatible) {
+                return handleSizeComparison(entity, (Query.PropertyCriterion) criterion, whereClause, logicalName, position, parameters, conversionService, "<=", hibernateCompatible);
+            }
+        });
+
     }
 
     protected static int handleSubQuery(PersistentEntity entity, StringBuilder q, StringBuilder whereClause, String logicalName, int position, List parameters, ConversionService conversionService, boolean allowJoins, boolean hibernateCompatible, Query.SubqueryCriterion equalsAll, String comparisonExpression) {
@@ -746,6 +782,23 @@ public class JpaQueryBuilder {
                 .append(comparisonExpression);
         buildSubQuery(q, whereClause, position, parameters, conversionService, allowJoins, hibernateCompatible, subquery);
         whereClause.append(CLOSE_BRACKET);
+        return position;
+    }
+
+    protected static int handleSizeComparison(PersistentEntity entity, Query.PropertyCriterion criterion, StringBuilder whereClause, String logicalName, int position, List parameters, ConversionService conversionService, String operator, boolean hibernateCompatible) {
+        final String name = criterion.getProperty();
+        validateProperty(entity, name, criterion.getClass());
+        Object value = criterion.getValue();
+        int size = value instanceof Number ? ((Number) value).intValue() : Integer.parseInt(value.toString());
+        whereClause.append("SIZE(")
+                   .append(logicalName)
+                   .append(DOT)
+                   .append(name)
+                   .append(") ")
+                   .append(operator)
+                   .append(PARAMETER_PREFIX)
+                   .append(++position);
+        parameters.add(size);
         return position;
     }
 


### PR DESCRIPTION
## Summary

Fixes three long-standing where-query bugs verified through reproduction tests against the current 7.0.x codebase.

**Reproducer app:** https://github.com/jamesfredley/grails-where-query-bugs-pr1

---

## Bug 1: `size()` not supported in `JpaQueryBuilder` (#14344)

**Symptom:** Using `size()` in a where query that goes through the JPA path (`deleteAll()`, `updateAll()`) throws:

```
Criterion of type class org.grails.datastore.mapping.query.Query$SizeEquals not supported
```

The Hibernate native path (`list()`, `get()`) handles `size()` correctly via `AbstractHibernateCriterionAdapter`, but the JPA path in `JpaQueryBuilder` had no handlers for size criteria.

**Broken pattern:**
```groovy
Library.where { books.size() == 0 }.deleteAll()  // throws exception
Library.where { books.size() > 5 }.updateAll(active: false)  // throws exception
```

**Root cause:** `JpaQueryBuilder.queryHandlers` map was missing entries for `Query.SizeEquals`, `SizeNotEquals`, `SizeGreaterThan`, `SizeGreaterThanEquals`, `SizeLessThan`, and `SizeLessThanEquals`. These criterion types were never registered, so any size comparison hit the "not supported" fallback.

**Fix:** Register 6 size comparison query handlers in `JpaQueryBuilder` that generate `SIZE(alias.property) <op> ?N` JPQL, plus a shared `handleSizeComparison()` helper:

```java
// JpaQueryBuilder.java - new handler (x6, one per operator)
queryHandlers.put(Query.SizeEquals.class, new QueryHandler() {
    public int handle(...) {
        return handleSizeComparison(entity, (Query.PropertyCriterion) criterion,
            whereClause, logicalName, position, parameters, conversionService, "=", hibernateCompatible);
    }
});

// Shared helper generates: SIZE(alias.property) = ?N
protected static int handleSizeComparison(..., String operator, ...) {
    whereClause.append("SIZE(").append(logicalName).append(DOT)
               .append(name).append(") ").append(operator)
               .append(PARAMETER_PREFIX).append(++position);
    parameters.add(size);
    return position;
}
```

---

## Bug 2: `countBy` dynamic finder drops where clause (#14480)

**Symptom:** When calling `countByX()` on a `DetachedCriteria` built with `.where{}`, the where clause criteria are silently dropped. The count returns the total for the dynamic finder match, ignoring the where filter entirely.

**Broken pattern:**
```groovy
def expensive = Product.where { price > 100.0 }
expensive.countByCategory('electronics')
// Expected: 2 (Laptop $999 + Monitor $499)
// Actual:   3 (all electronics - Mouse $29 included)
```

**Root cause:** `CountByFinder.buildQuery()` was missing the `applyDetachedCriteria()` call. Compare with `FindAllByFinder` which correctly includes it:

```java
// FindAllByFinder.buildQuery() - CORRECT
protected Query buildQuery(...) {
    applyAdditionalCriteria(q, invocation.getCriteria());
    applyDetachedCriteria(q, invocation.getDetachedCriteria());  // applies where clause
    ...
}

// CountByFinder.buildQuery() - BEFORE FIX (missing line)
protected Query buildQuery(...) {
    applyAdditionalCriteria(q, invocation.getCriteria());
    // applyDetachedCriteria was never called!
    ...
}
```

**Fix:** One-line addition in `CountByFinder.buildQuery()`:

```java
applyDetachedCriteria(q, invocation.getDetachedCriteria());
```

---

## Bug 3: `DetachedCriteria.count()` returns wrong value with projections (#14569)

**Symptom:** When a `DetachedCriteria` has user-defined projections (e.g., `groupProperty` + `count()`), calling `.count()` returns the wrong value - typically the count from the first grouped row instead of the number of result rows.

**Broken pattern:**
```groovy
def criteria = new DetachedCriteria(OrderItem).build {
    projections {
        groupProperty('category')
        count()
    }
}
criteria.count()
// Expected: 2 (two categories: widgets, gadgets)
// Actual:   value from first group row's count projection
```

**Root cause:** `DetachedCriteria.count()` calls `withPopulatedQuery()` then appends `query.projections().count()` alongside the existing user projections. The generated SQL ends up as:

```sql
-- What gets generated (WRONG):
SELECT category, count(*), count(*) FROM order_item GROUP BY category
-- Returns first row's count, not the number of rows

-- What should happen:
SELECT count(*) FROM (SELECT category, count(*) FROM order_item GROUP BY category)
```

**Fix:** When user projections already exist, `count()` falls back to `list().size()` to get the correct row count:

```groovy
Number count(Map args = Collections.emptyMap(), Closure additionalCriteria = null) {
    if (!projections.isEmpty()) {
        // User projections exist - count the grouped result rows
        return ((List) withPopulatedQuery(args, additionalCriteria) { Query query ->
            query.list()
        }).size()
    }
    // No user projections - standard count works correctly
    (Number) withPopulatedQuery(args, additionalCriteria) { Query query ->
        query.projections().count()
        query.singleResult()
    }
}
```

The single-argument `count(Closure)` overload was also updated to delegate to the main method instead of duplicating the (now-buggy) original logic.

---

## Changes

| File | Module | Change |
|------|--------|--------|
| `JpaQueryBuilder.java` | `grails-datastore-core` | Register 6 size comparison query handlers + `handleSizeComparison()` helper |
| `CountByFinder.java` | `grails-datamapping-core` | Add missing `applyDetachedCriteria(q, invocation.getDetachedCriteria())` |
| `DetachedCriteria.groovy` | `grails-datamapping-core` | When user projections exist, `count()` falls back to `list().size()` |
| `WhereQueryOldIssueVerificationSpec.groovy` | `grails-data-hibernate5-core` | New: 9 tests verifying 8 old where-query issues against 7.x |

## Verification

The new `WhereQueryOldIssueVerificationSpec` covers all 8 issues from the open where-query triage:

| Issue | Title | Status |
|-------|-------|--------|
| #14596 | where-query wrong result if not assigned to var | **Fixed** (already in 7.x) |
| #14622 | multi-level association wrong result | **Fixed** (already in 7.x) |
| #14480 | countBy drops where clause | **Fixed in this PR** |
| #11202 | where queries not filtering in tests | **Fixed** (already in 7.x) |
| #14636 | many-to-many sorting exception | **Fixed** (already in 7.x) |
| #14610 | basic collection type 'in' query | Pending (future PR, marked `@PendingFeature`) |
| #14569 | count() with projections | **Fixed in this PR** |
| #14600 | findAllBy bidirectional hasMany | **Fixed** (already in 7.x) |

All existing tests pass: `grails-data-hibernate5-core` (585 tests), `grails-datamapping-core`, `grails-datastore-core`.

Fixes #14344
Fixes #14480
Fixes #14569
