### PR TITLE
fix: propagate LEFT JOIN from DetachedCriteria into subqueries (#14485)

### DIFF
--- a/grails-data-hibernate5/core/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
+++ b/grails-data-hibernate5/core/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
@@ -20,11 +20,13 @@ package grails.orm;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import groovy.lang.GroovySystem;
 
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.PluralAttribute;
+import jakarta.persistence.FetchType;
 
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
@@ -41,6 +43,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import org.grails.datastore.mapping.model.PersistentEntity;
 import org.grails.datastore.mapping.query.api.QueryableCriteria;
+import org.grails.datastore.gorm.query.criteria.AbstractDetachedCriteria;
 import org.grails.orm.hibernate.GrailsHibernateTemplate;
 import org.grails.orm.hibernate.HibernateDatastore;
 import org.grails.orm.hibernate.cfg.GrailsHibernateUtil;
@@ -234,6 +237,28 @@ public class HibernateCriteriaBuilder extends AbstractHibernateCriteriaBuilder {
     }
 
     private static void populateHibernateDetachedCriteria(AbstractHibernateQuery query, org.hibernate.criterion.DetachedCriteria detachedCriteria, QueryableCriteria<?> queryableCriteria) {
+        if (queryableCriteria instanceof AbstractDetachedCriteria) {
+            AbstractDetachedCriteria<?> abstractDetachedCriteria = (AbstractDetachedCriteria<?>) queryableCriteria;
+            Map<String, FetchType> fetchStrategies = abstractDetachedCriteria.getFetchStrategies();
+            for (Entry<String, FetchType> entry : fetchStrategies.entrySet()) {
+                String property = entry.getKey();
+                switch (entry.getValue()) {
+                    case EAGER:
+                        jakarta.persistence.criteria.JoinType gormJoinType = abstractDetachedCriteria.getJoinTypes().get(property);
+                        if (gormJoinType != null) {
+                            query.join(property, gormJoinType);
+                        }
+                        else {
+                            query.join(property);
+                        }
+                        break;
+                    case LAZY:
+                        query.select(property);
+                        break;
+                }
+            }
+        }
+
         List<org.grails.datastore.mapping.query.Query.Criterion> criteriaList = queryableCriteria.getCriteria();
         for (org.grails.datastore.mapping.query.Query.Criterion criterion : criteriaList) {
             Criterion hibernateCriterion = HibernateQuery.HIBERNATE_CRITERION_ADAPTER.toHibernateCriterion(query, criterion, null);
@@ -252,6 +277,7 @@ public class HibernateCriteriaBuilder extends AbstractHibernateCriteriaBuilder {
         }
         detachedCriteria.setProjection(projectionList);
     }
+
 
     /**
      * Closes the session if it is copen

--- a/grails-data-hibernate5/core/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
+++ b/grails-data-hibernate5/core/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
@@ -24,9 +24,9 @@ import java.util.Map.Entry;
 
 import groovy.lang.GroovySystem;
 
+import jakarta.persistence.FetchType;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.PluralAttribute;
-import jakarta.persistence.FetchType;
 
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
@@ -41,9 +41,9 @@ import org.hibernate.type.Type;
 import org.springframework.orm.hibernate5.SessionHolder;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import org.grails.datastore.gorm.query.criteria.AbstractDetachedCriteria;
 import org.grails.datastore.mapping.model.PersistentEntity;
 import org.grails.datastore.mapping.query.api.QueryableCriteria;
-import org.grails.datastore.gorm.query.criteria.AbstractDetachedCriteria;
 import org.grails.orm.hibernate.GrailsHibernateTemplate;
 import org.grails.orm.hibernate.HibernateDatastore;
 import org.grails.orm.hibernate.cfg.GrailsHibernateUtil;

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryBugFixSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryBugFixSpec.groovy
@@ -1,0 +1,122 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.tests
+
+import grails.gorm.DetachedCriteria
+import grails.gorm.annotation.Entity
+import grails.gorm.hibernate.HibernateEntity
+import org.grails.orm.hibernate.HibernateDatastore
+import org.springframework.transaction.PlatformTransactionManager
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+import grails.gorm.transactions.Rollback
+
+import jakarta.persistence.criteria.JoinType
+
+/**
+ * Tests for where-query bug fixes in PR 2.
+ */
+class WhereQueryBugFixSpec extends Specification {
+
+    @Shared @AutoCleanup HibernateDatastore datastore = new HibernateDatastore(
+        WqAuthor, WqBookItem, WqCase, WqEvent, WqPerson
+    )
+    @Shared PlatformTransactionManager transactionManager = datastore.transactionManager
+
+    @Rollback
+    @Issue("https://github.com/apache/grails-core/issues/14485")
+    def "#14485 - LEFT JOIN in DetachedCriteria subquery should not be downgraded to INNER JOIN"() {
+        given: "authors with and without books"
+        def authorWithBooks = new WqAuthor(name: 'Author A').save(flush: true, failOnError: true)
+        def authorNoBooks = new WqAuthor(name: 'Author B').save(flush: true, failOnError: true)
+        def authorWithBio = new WqAuthor(name: 'Author C').save(flush: true, failOnError: true)
+        new WqBookItem(title: 'Novel', wqAuthor: authorWithBooks).save(flush: true, failOnError: true)
+        new WqBookItem(title: 'Biography', wqAuthor: authorWithBio).save(flush: true, failOnError: true)
+
+        when: "querying authors using a subquery with LEFT JOIN on books"
+        def subquery = WqAuthor.where {
+            join('wqBookItems', JoinType.LEFT)
+            wqBookItems {
+                or {
+                    isNull('title')
+                    ilike('title', '%biography%')
+                }
+            }
+        }.id()
+
+        def results = WqAuthor.where {
+            'in'('id', subquery)
+        }.list()
+
+        then: "both authors without books (NULL from LEFT JOIN) and with biography are found"
+        results.size() == 2
+        results*.name.sort() == ['Author B', 'Author C']
+    }
+
+    @Rollback
+    @Issue("https://github.com/apache/grails-core/issues/14485")
+    def "#14485 - direct LEFT JOIN where query returns authors without books"() {
+        given: "authors with and without books"
+        def authorWithBooks = new WqAuthor(name: 'Writer A').save(flush: true, failOnError: true)
+        def authorNoBooks = new WqAuthor(name: 'Writer B').save(flush: true, failOnError: true)
+        new WqBookItem(title: 'A Novel', wqAuthor: authorWithBooks).save(flush: true, failOnError: true)
+
+        when: "querying with LEFT JOIN directly (not as subquery)"
+        def results = WqAuthor.where {
+            join('wqBookItems', JoinType.LEFT)
+            wqBookItems {
+                isNull('title')
+            }
+        }.list()
+
+        then: "author without books is found via LEFT JOIN null match"
+        results.size() == 1
+        results[0].name == 'Writer B'
+    }
+}
+
+@Entity
+class WqAuthor implements HibernateEntity<WqAuthor> {
+    String name
+    static hasMany = [wqBookItems: WqBookItem]
+}
+
+@Entity
+class WqBookItem implements HibernateEntity<WqBookItem> {
+    String title
+    static belongsTo = [wqAuthor: WqAuthor]
+}
+
+@Entity
+class WqCase implements HibernateEntity<WqCase> {
+    WqPerson person
+}
+
+@Entity
+class WqEvent implements HibernateEntity<WqEvent> {
+    WqCase generalCase
+}
+
+@Entity
+class WqPerson implements HibernateEntity<WqPerson> {
+    String fullname
+}

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryBugFixSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryBugFixSpec.groovy
@@ -18,7 +18,6 @@
  */
 package grails.gorm.tests
 
-import grails.gorm.DetachedCriteria
 import grails.gorm.annotation.Entity
 import grails.gorm.hibernate.HibernateEntity
 import org.grails.orm.hibernate.HibernateDatastore
@@ -38,7 +37,7 @@ import jakarta.persistence.criteria.JoinType
 class WhereQueryBugFixSpec extends Specification {
 
     @Shared @AutoCleanup HibernateDatastore datastore = new HibernateDatastore(
-        WqAuthor, WqBookItem, WqCase, WqEvent, WqPerson
+        WqAuthor, WqBookItem
     )
     @Shared PlatformTransactionManager transactionManager = datastore.transactionManager
 
@@ -104,19 +103,4 @@ class WqAuthor implements HibernateEntity<WqAuthor> {
 class WqBookItem implements HibernateEntity<WqBookItem> {
     String title
     static belongsTo = [wqAuthor: WqAuthor]
-}
-
-@Entity
-class WqCase implements HibernateEntity<WqCase> {
-    WqPerson person
-}
-
-@Entity
-class WqEvent implements HibernateEntity<WqEvent> {
-    WqCase generalCase
-}
-
-@Entity
-class WqPerson implements HibernateEntity<WqPerson> {
-    String fullname
 }


### PR DESCRIPTION
## Summary

Fixes LEFT JOIN being silently downgraded to INNER JOIN when a `DetachedCriteria` with `join('association', JoinType.LEFT)` is used as a subquery.

**Reproducer app:** https://github.com/jamesfredley/grails-where-query-bugs-pr2

---

## Bug: LEFT JOIN in DetachedCriteria subquery downgraded to INNER JOIN (#14485)

**Symptom:** When a `DetachedCriteria` specifies `join('books', JoinType.LEFT)` and is used as a subquery (e.g., inside `'in'('id', subquery.id())`), the LEFT JOIN is silently downgraded to INNER JOIN. The same `DetachedCriteria` executed directly produces the correct LEFT OUTER JOIN.

**Broken pattern:**
```groovy
def subquery = Author.where {
    join('books', JoinType.LEFT)
    books {
        or {
            isNull('title')        // Should match authors with NO books via LEFT JOIN
            ilike('title', '%bio%')
        }
    }
}.id()

Author.where { 'in'('id', subquery) }.list()
// Expected: authors with no books + authors with biography title
// Actual:   only authors with biography (LEFT JOIN became INNER JOIN)
```

**Generated SQL (before fix):**
```sql
-- Direct query: correctly uses LEFT OUTER JOIN
SELECT this_.id, ... FROM author this_
    LEFT OUTER JOIN book books_alia1_ ON this_.id = books_alia1_.author_id
    WHERE (books_alia1_.title IS NULL OR ...)

-- Subquery: WRONG - uses INNER JOIN instead of LEFT
SELECT this_.id FROM author this_
WHERE this_.id IN (
    SELECT this_.id FROM author this_
        INNER JOIN book books_alia1_ ON this_.id = books_alia1_.author_id
        WHERE (books_alia1_.title IS NULL OR ...)
)
```

**Root cause:** `HibernateCriteriaBuilder.populateHibernateDetachedCriteria()` converts a GORM `DetachedCriteria` to a Hibernate `DetachedCriteria` for subqueries. It copied criteria and projections but **completely ignored `fetchStrategies` and `joinTypes`**. The fresh `HibernateQuery` created for the subquery had no join types registered, so `getOrCreateAlias()` defaulted every association to INNER JOIN.

Compare the two code paths:

```java
// DynamicFinder.applyDetachedCriteria() - CORRECT (for main queries)
// Applies fetchStrategies/joinTypes to the Query before criteria processing
Map<String, FetchType> fetchStrategies = detachedCriteria.getFetchStrategies();
for (Entry<String, FetchType> entry : fetchStrategies.entrySet()) {
    String property = entry.getKey();
    switch (entry.getValue()) {
        case EAGER:
            JoinType joinType = detachedCriteria.getJoinTypes().get(property);
            if (joinType != null) query.join(property, joinType);
            else query.join(property);
            break;
        case LAZY:
            query.select(property);
    }
}

// populateHibernateDetachedCriteria() - BEFORE FIX (for subqueries)
// Only copied criteria and projections - fetchStrategies/joinTypes ignored!
```

**Fix:** Apply `fetchStrategies` and `joinTypes` from the GORM `DetachedCriteria` to the `HibernateQuery` **before** processing criteria, matching the pattern used by `DynamicFinder.applyDetachedCriteria()`:

```java
private static void populateHibernateDetachedCriteria(AbstractHibernateQuery query,
        DetachedCriteria detachedCriteria, QueryableCriteria<?> queryableCriteria) {
    // NEW: Apply fetch strategies and join types before processing criteria
    if (queryableCriteria instanceof AbstractDetachedCriteria) {
        AbstractDetachedCriteria<?> adc = (AbstractDetachedCriteria<?>) queryableCriteria;
        for (Entry<String, FetchType> entry : adc.getFetchStrategies().entrySet()) {
            String property = entry.getKey();
            switch (entry.getValue()) {
                case EAGER:
                    JoinType jt = adc.getJoinTypes().get(property);
                    if (jt != null) query.join(property, jt);
                    else query.join(property);
                    break;
                case LAZY:
                    query.select(property);
                    break;
            }
        }
    }
    // Existing: process criteria and projections...
}
```

This ensures that when `getOrCreateAlias()` runs during criterion adaptation (triggered by `books { ... }` association criteria), it finds the correct join type in the query's `joinTypes` map and uses LEFT OUTER JOIN instead of defaulting to INNER JOIN.

---

## Changes

| File | Module | Change |
|------|--------|--------|
| `HibernateCriteriaBuilder.java` | `grails-data-hibernate5-core` | Apply fetchStrategies/joinTypes to HibernateQuery in `populateHibernateDetachedCriteria()` before processing criteria |
| `WhereQueryBugFixSpec.groovy` | `grails-data-hibernate5-core` | New: 2 tests verifying LEFT JOIN propagation into subqueries |

## Verification

- 2 new tests pass (subquery LEFT JOIN + direct LEFT JOIN)
- All 13 existing `DetachedCriteriaJoinSpec` tests pass (no regression)
- Full `grails-data-hibernate5-core` suite: 578 tests, 0 failures

Fixes #14485
