### PR TITLE
Fix composite ID criteria projection regression (#14516)

### DIFF
--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriteriaBuilder.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriteriaBuilder.java
@@ -1806,7 +1806,45 @@ public abstract class AbstractHibernateCriteriaBuilder extends GroovyObjectSuppo
             if (pd != null && pd.getReadMethod() != null) {
                 final Metamodel metamodel = sessionFactory.getMetamodel();
                 final EntityType<?> entityType = metamodel.entity(targetClass);
-                final Attribute<?, ?> attribute = entityType.getAttribute(name);
+
+                Attribute<?, ?> attribute = null;
+                try {
+                    attribute = entityType.getAttribute(name);
+                } catch (IllegalArgumentException e) {
+                    // Composite ID components may not be registered as JPA Metamodel
+                    // attributes. Fall back to checking if the property type is a managed
+                    // entity so the criteria builder can navigate associations that form
+                    // part of a composite key (e.g. UserRole with composite: ['user', 'role']).
+                    Class<?> propertyType = pd.getPropertyType();
+                    try {
+                        metamodel.entity(propertyType);
+                        // Property type is a managed entity - treat as association
+                        Class oldTargetClass = targetClass;
+                        targetClass = propertyType;
+                        if (targetClass.equals(oldTargetClass) && !hasMoreThanOneArg) {
+                            joinType = org.hibernate.sql.JoinType.LEFT_OUTER_JOIN.getJoinTypeValue();
+                        }
+                        associationStack.add(name);
+                        final String associationPath = getAssociationPath();
+                        createAliasIfNeccessary(name, associationPath, joinType);
+                        logicalExpressionStack.add(new LogicalExpression(AND));
+                        invokeClosureNode(callable);
+                        aliasStack.remove(aliasStack.size() - 1);
+                        if (!aliasInstanceStack.isEmpty()) {
+                            aliasInstanceStack.remove(aliasInstanceStack.size() - 1);
+                        }
+                        LogicalExpression logicalExpression = logicalExpressionStack.remove(logicalExpressionStack.size() - 1);
+                        if (!logicalExpression.args.isEmpty()) {
+                            addToCriteria(logicalExpression.toCriterion());
+                        }
+                        associationStack.remove(associationStack.size() - 1);
+                        targetClass = oldTargetClass;
+                        return name;
+                    } catch (IllegalArgumentException ignored) {
+                        // Not a managed entity type - re-throw original exception
+                        throw e;
+                    }
+                }
 
                 if (attribute.isAssociation()) {
                     Class oldTargetClass = targetClass;

--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriteriaBuilder.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriteriaBuilder.java
@@ -1841,8 +1841,9 @@ public abstract class AbstractHibernateCriteriaBuilder extends GroovyObjectSuppo
                         targetClass = oldTargetClass;
                         return name;
                     } catch (IllegalArgumentException ignored) {
-                        // Not a managed entity type - re-throw original exception
-                        throw e;
+                        // Not a managed entity type - wrap the original exception to preserve stack trace
+                        throw new IllegalArgumentException(
+                                "Unable to locate attribute [" + name + "] on entity [" + entityType.getName() + "]", e);
                     }
                 }
 

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdCriteria.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdCriteria.groovy
@@ -138,6 +138,27 @@ class CompositeIdCriteria extends Specification {
     results.size() == 1
     results[0] == compositeIdToMany
   }
+
+  @Issue("https://github.com/apache/grails-core/issues/14516")
+  def "test that eq on composite id component works with Hibernate proxy"() {
+    given: "an entity with composite ID saved and session cleared"
+    Author _author = new Author(name:"ProxyAuthor").save(flush:true)
+    Book _book = new Book(title:"ProxyBook").save(flush:true)
+    CompositeIdToMany compositeIdToMany = new CompositeIdToMany(author:_author, book:_book).save(failOnError:true, flush:true)
+    def authorId = _author.id
+    datastore.sessionFactory.currentSession.clear()
+
+    when: "querying with eq using a Hibernate proxy (uninitialized) for the composite ID component"
+    Author proxyAuthor = Author.load(authorId)
+    def results = CompositeIdToMany.createCriteria().list {
+      eq('author', proxyAuthor)
+    }
+
+    then: "the entity is found via the proxy's ID without initializing it"
+    results.size() == 1
+    results[0].author.id == authorId
+    results[0].book.title == "ProxyBook"
+  }
 }
 
 @Entity

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdCriteria.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdCriteria.groovy
@@ -122,6 +122,22 @@ class CompositeIdCriteria extends Specification {
     results.size() == 1
     results[0] == compositeIdToMany
   }
+
+  @Issue("https://github.com/apache/grails-core/issues/14516")
+  def "test that eq on composite id component entity works"() {
+    Author _author = new Author(name:"Author3").save()
+    Book _book = new Book(title:"Book3").save()
+    CompositeIdToMany compositeIdToMany = new CompositeIdToMany(author:_author, book:_book).save(failOnError:true, flush:true)
+
+    when: "querying with eq on composite ID component association"
+    def results = CompositeIdToMany.createCriteria().list {
+      eq('author', _author)
+    }
+
+    then: "the entity is found"
+    results.size() == 1
+    results[0] == compositeIdToMany
+  }
 }
 
 @Entity

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdCriteria.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdCriteria.groovy
@@ -79,6 +79,49 @@ class CompositeIdCriteria extends Specification {
       }
     } == [compositeIdToMany]
   }
+  @Issue("https://github.com/apache/grails-core/issues/14516")
+  def "test that composite id components can be used in criteria projections"() {
+    Author _author = new Author(name:"Author").save()
+    Book _book = new Book(title:"Book").save()
+    CompositeIdToMany compositeIdToMany = new CompositeIdToMany(author:_author, book:_book).save(failOnError:true, flush:true)
+
+    when: "querying with projections navigating composite ID component associations"
+    def results = CompositeIdToMany.createCriteria().list {
+      projections {
+        book {
+          property('id')
+        }
+      }
+      author {
+        eq('id', _author.id)
+      }
+    }
+
+    then: "the projection returns the expected ID"
+    results.size() == 1
+    results[0] == _book.id
+  }
+
+  @Issue("https://github.com/apache/grails-core/issues/14516")
+  def "test that composite id components can be used in criteria restrictions"() {
+    Author _author = new Author(name:"Author2").save()
+    Book _book = new Book(title:"Book2").save()
+    CompositeIdToMany compositeIdToMany = new CompositeIdToMany(author:_author, book:_book).save(failOnError:true, flush:true)
+
+    when: "querying with restrictions on composite ID component associations"
+    def results = CompositeIdToMany.createCriteria().list {
+      author {
+        eq('name', 'Author2')
+      }
+      book {
+        eq('title', 'Book2')
+      }
+    }
+
+    then: "the entity is found"
+    results.size() == 1
+    results[0] == compositeIdToMany
+  }
 }
 
 @Entity


### PR DESCRIPTION
## Summary

Fixes #14516 - Criteria queries on domains with composite IDs (`id composite: ['user', 'role']`) fail when navigating composite key component associations.

## Symptom

```groovy
class UserRole implements Serializable {
    User user
    Role role
    static mapping = { id composite: ['user', 'role'] }
}

// Throws: IllegalArgumentException: Unable to locate Attribute
//         with the given name [role] on ManagedType [demo.UserRole]
UserRole.createCriteria().list {
    projections {
        role { property('id') }
    }
    user { eq('id', userId) }
}
```

This worked in GORM 6 but regressed in GORM 7.

## Root Cause

`AbstractHibernateCriteriaBuilder.invokeMethod()` uses the JPA Metamodel to determine property types:

```java
final EntityType<?> entityType = metamodel.entity(targetClass);
final Attribute<?, ?> attribute = entityType.getAttribute(name);  // THROWS for composite ID components
```

The JPA Metamodel's `EntityType.getAttribute()` does not expose composite ID components as regular attributes. In GORM 6, the older Hibernate-specific API handled this differently.

## Fix

Wrap `entityType.getAttribute(name)` in a try-catch. When it throws `IllegalArgumentException` for a composite ID component:

1. Check if the property type (`pd.getPropertyType()`) is a managed entity via `metamodel.entity()`
2. If it is, treat the property as an association (same code path as `attribute.isAssociation()`)
3. If not, re-throw the original exception

**Before:**
```java
final Attribute<?, ?> attribute = entityType.getAttribute(name);
if (attribute.isAssociation()) { ... }
```

**After:**
```java
Attribute<?, ?> attribute = null;
try {
    attribute = entityType.getAttribute(name);
} catch (IllegalArgumentException e) {
    // Fall back to checking if property type is a managed entity
    Class<?> propertyType = pd.getPropertyType();
    try {
        metamodel.entity(propertyType);
        // Treat as association - create alias, invoke closure, etc.
        ...
        return name;
    } catch (IllegalArgumentException ignored) {
        throw e;  // Not an entity, re-throw
    }
}
if (attribute.isAssociation()) { ... }
```

## Changes

| File | Change |
|------|--------|
| `AbstractHibernateCriteriaBuilder.java` | Handle composite ID components in `invokeMethod()` by catching `IllegalArgumentException` from `getAttribute()` and falling back to entity type checking |
| `CompositeIdCriteria.groovy` | Add 2 new tests for composite ID criteria projections and restrictions |

## Verification

- 578 existing tests pass (0 failures)
- 2 new tests added covering projections and restrictions on composite ID component associations
- All 5 CompositeIdCriteria tests pass

## Reproducer App

https://github.com/jamesfredley/grails-composite-id-criteria-14516