### PR TITLE
BUG 7.0.x - Fixes prioritization of a non-namespaced controller when no namespace is defined

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/AbstractGrailsControllerUrlMappings.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/AbstractGrailsControllerUrlMappings.groovy
@@ -61,7 +61,17 @@ abstract class AbstractGrailsControllerUrlMappings implements UrlMappings {
         }
 
         for (Map.Entry<ControllerKey, GrailsControllerClass> entry: deferredMappings.entrySet()) {
-            mappingsToGrailsControllerMap.putIfAbsent(entry.key, entry.value)
+            ControllerKey key = entry.key
+            GrailsControllerClass deferredController = entry.value
+            GrailsControllerClass existingController = mappingsToGrailsControllerMap.get(key)
+
+            if (existingController == null) {
+                mappingsToGrailsControllerMap.put(key, deferredController)
+            } else if (key.namespace == null && deferredController.namespace == null && existingController.namespace != null) {
+                // A non-namespaced controller is a better match for a null-namespace key
+                // than a namespaced controller that registered here as a fallback
+                mappingsToGrailsControllerMap.put(key, deferredController)
+            }
         }
     }
 


### PR DESCRIPTION
During `registerController()`, namespaced plugin controllers register themselves at null-namespace keys as fallbacks. The deferred merge then runs for app controllers. 

Previously, `putIfAbsent` meant an app's non-namespaced controller could never reclaim a null-namespace slot already occupied by a namespaced plugin controller. 

Now, when all three conditions are met — the key has no namespace, the deferred controller has no namespace, and the existing controller does have a namespace — the non-namespaced controller wins, because it's the exact match for a null-namespace lookup.


### Example

create a grails app with the default UrlMappings.groovy
```groovy
        "/$controller/$action?/$id?(.$format)?"{
            constraints {
                // apply constraints here
            }
        }
```

Now create a namespace controller and a non-namespace controller.

Even though no namespace is defined in the above mapping, Grails will randomly select between the 2 controllers. 
The radom behavior is determined on start up and will consistently chose the same controller after startup.  So sometimes you will get an app that starts up and only uses the namespace controller and other times you will get the non-namespace controller.

This behavior is independent of byte code.   The way I discovered it was by running a multiple instance application. 
Some instances would serve one way and others would server a different way.  All of the instances used the same jar / byte code / server configuration.

