### PR TITLE
Add no-grouping-comments rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,10 @@ class MyService { }
 
 // DON'T: javax packages
 // import javax.servlet.*  ❌ → use jakarta.servlet.*
+
+// DON'T: Section separator or grouping comments
+// // --- Domain classes ---  ❌
+// // ===== Helpers =====     ❌
 ```
 
 ## Test Isolation


### PR DESCRIPTION
## Summary

- Add a style rule to `AGENTS.md` discouraging section separator/grouping comments (e.g., `// --- Domain classes ---`, `// ===== Helpers =====`) in source files
- These comments add visual noise without value and are a common AI-generated pattern

Per reviewer feedback on #15460.