### PR TITLE
fix: remove @PendingFeature from basic collection test now that #14610 is fixed

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryOldIssueVerificationSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/WhereQueryOldIssueVerificationSpec.groovy
@@ -27,7 +27,6 @@ import spock.lang.AutoCleanup
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.PendingFeature
 
 /**
  * Verification tests for old where-query issues reported against GORM 6.x / Grails 3.x.
@@ -179,7 +178,6 @@ class WhereQueryOldIssueVerificationSpec extends Specification {
         results[0].user.username == "alice"
     }
 
-    @PendingFeature(reason = 'Basic collection type in query is still broken - tracked for a future fix')
     @Rollback
     @Issue('https://github.com/apache/grails-core/issues/14610')
     def "querying association with basic collection types works"() {


### PR DESCRIPTION
## Summary

- Remove `@PendingFeature` annotation from `WhereQueryOldIssueVerificationSpec."querying association with basic collection types works"` and its now-unused `import spock.lang.PendingFeature`

## Context

PR #15463 fixed `in()` queries on basic collection types (`hasMany` to `String`/`Integer`/etc.), which was tracked as issue #14610. PR #15460 included a verification test for this issue marked with `@PendingFeature` since the fix hadn't landed yet. After both PRs merged to `7.0.x`, the test now passes - causing Spock to throw `PendingFeatureSuccessfulError`, breaking CI on commit 0f33370.

Affected CI checks:
- `build_grails`
- `Hibernate5 Functional Tests (17)`
- `Hibernate5 Functional Tests (25)`
- `Functional Tests (17)` (also has an unrelated flaky Geb timeout in scaffolding)