### PR TITLE
fix: correct malformed Javadoc link tag in DatastoreServiceMethodInvokingFactoryBean

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
@@ -32,7 +32,7 @@ import org.grails.datastore.mapping.core.Datastore
 import org.grails.datastore.mapping.services.Service
 
 /**
- * Variant of {#link MethodInvokingFactoryBean} which returns the correct data service type instead of {@code java.lang.Object} so the Autowire with type works correctly.
+ * Variant of {@link MethodInvokingFactoryBean} which returns the correct data service type instead of {@code java.lang.Object} so the Autowire with type works correctly.
  */
 @Internal
 @CompileStatic


### PR DESCRIPTION
## Summary

- Fix malformed Groovydoc/Javadoc link tag: `{#link MethodInvokingFactoryBean}` -> `{@link MethodInvokingFactoryBean}` so generated docs render the link correctly.

Flagged by Copilot review on #15472.