### PR TITLE
fix: add null safety for getDatastoreForConnection in data service factory bean

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
@@ -31,6 +31,7 @@ import org.grails.datastore.mapping.core.Datastore
 import org.grails.datastore.mapping.core.connections.ConnectionSource
 import org.grails.datastore.mapping.core.connections.ConnectionSourcesSupport
 import org.grails.datastore.mapping.core.connections.MultipleConnectionSourceCapableDatastore
+import org.grails.datastore.mapping.core.exceptions.ConfigurationException
 import org.grails.datastore.mapping.services.Service
 
 /**
@@ -83,8 +84,16 @@ class DatastoreServiceMethodInvokingFactoryBean extends MethodInvokingFactoryBea
         if (serviceConnection != null
                 && ConnectionSource.DEFAULT != serviceConnection
                 && ConnectionSource.ALL != serviceConnection) {
-            return ((MultipleConnectionSourceCapableDatastore) defaultDatastore)
+            Datastore resolved = ((MultipleConnectionSourceCapableDatastore) defaultDatastore)
                     .getDatastoreForConnection(serviceConnection)
+            if (resolved == null) {
+                throw new ConfigurationException(
+                        "DataSource not found for connection name [${serviceConnection}] " +
+                        "specified via @Transactional on service [${serviceClass.name}]. " +
+                        'Please check your multiple data sources configuration and try again.'
+                )
+            }
+            return resolved
         }
 
         // Fall back to domain class mapping datasource
@@ -102,8 +111,17 @@ class DatastoreServiceMethodInvokingFactoryBean extends MethodInvokingFactoryBea
         if (domainConnection != null
                 && ConnectionSource.DEFAULT != domainConnection
                 && ConnectionSource.ALL != domainConnection) {
-            return ((MultipleConnectionSourceCapableDatastore) defaultDatastore)
+            Datastore resolved = ((MultipleConnectionSourceCapableDatastore) defaultDatastore)
                     .getDatastoreForConnection(domainConnection)
+            if (resolved == null) {
+                throw new ConfigurationException(
+                        "DataSource not found for connection name [${domainConnection}] " +
+                        "mapped on domain class [${domainClass.name}] " +
+                        "used by service [${serviceClass.name}]. " +
+                        'Please check your multiple data sources configuration and try again.'
+                )
+            }
+            return resolved
         }
 
         return defaultDatastore

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBeanSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBeanSpec.groovy
@@ -161,9 +161,9 @@ class DatastoreServiceMethodInvokingFactoryBeanSpec extends Specification {
     }
 
     @Service(SampleDomain)
-    private static class DomainService {
+    static class DomainService {
     }
 
-    private static class SampleDomain {
+    static class SampleDomain {
     }
 }

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBeanSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBeanSpec.groovy
@@ -1,0 +1,169 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.mapping.config
+
+import org.grails.datastore.mapping.core.Datastore
+import org.grails.datastore.mapping.core.connections.ConnectionSource
+import org.grails.datastore.mapping.core.connections.MultipleConnectionSourceCapableDatastore
+import org.grails.datastore.mapping.core.exceptions.ConfigurationException
+import org.grails.datastore.mapping.model.ClassMapping
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.datastore.mapping.model.PersistentEntity
+import org.grails.datastore.mapping.config.Entity
+import grails.gorm.transactions.Transactional
+import grails.gorm.services.Service
+import spock.lang.Specification
+
+class DatastoreServiceMethodInvokingFactoryBeanSpec extends Specification {
+
+    void "non-multiple connection datastore returns as-is"() {
+        given:
+        Datastore defaultDatastore = Mock(Datastore)
+        def factory = new DatastoreServiceMethodInvokingFactoryBean(SampleService)
+
+        when:
+        def result = factory.resolveEffectiveDatastore(defaultDatastore)
+
+        then:
+        result.is(defaultDatastore)
+    }
+
+    void "multiple connection datastore with no annotations returns default"() {
+        given:
+        MultipleConnectionSourceCapableDatastore defaultDatastore = Mock(MultipleConnectionSourceCapableDatastore)
+        def factory = new DatastoreServiceMethodInvokingFactoryBean(SampleService)
+
+        when:
+        def result = factory.resolveEffectiveDatastore(defaultDatastore)
+
+        then:
+        result.is(defaultDatastore)
+    }
+
+    void "transactional connection resolves custom datastore"() {
+        given:
+        MultipleConnectionSourceCapableDatastore defaultDatastore = Mock(MultipleConnectionSourceCapableDatastore)
+        Datastore resolvedDatastore = Mock(Datastore)
+        def factory = new DatastoreServiceMethodInvokingFactoryBean(TxService)
+
+        when:
+        def result = factory.resolveEffectiveDatastore(defaultDatastore)
+
+        then:
+        1 * defaultDatastore.getDatastoreForConnection("custom") >> resolvedDatastore
+        result.is(resolvedDatastore)
+    }
+
+    void "transactional connection throws when datastore is missing"() {
+        given:
+        MultipleConnectionSourceCapableDatastore defaultDatastore = Mock(MultipleConnectionSourceCapableDatastore)
+        def factory = new DatastoreServiceMethodInvokingFactoryBean(TxService)
+
+        when:
+        factory.resolveEffectiveDatastore(defaultDatastore)
+
+        then:
+        1 * defaultDatastore.getDatastoreForConnection("custom") >> null
+        ConfigurationException exception = thrown(ConfigurationException)
+        exception.message.contains("connection name [custom]")
+        exception.message.contains("service [${TxService.name}]")
+    }
+
+    void "domain class mapping resolves custom datastore"() {
+        given:
+        MultipleConnectionSourceCapableDatastore defaultDatastore = Mock(MultipleConnectionSourceCapableDatastore)
+        MappingContext mappingContext = Mock(MappingContext)
+        PersistentEntity entity = Mock(PersistentEntity)
+        ClassMapping classMapping = Mock(ClassMapping)
+        Entity mappedForm = new Entity()
+        Datastore resolvedDatastore = Mock(Datastore)
+        def factory = new DatastoreServiceMethodInvokingFactoryBean(DomainService)
+
+        and:
+        defaultDatastore.getMappingContext() >> mappingContext
+        mappingContext.getPersistentEntity(SampleDomain.name) >> entity
+        entity.getMapping() >> classMapping
+        classMapping.getMappedForm() >> mappedForm
+        mappedForm.datasources = ["customDomain"]
+
+        when:
+        def result = factory.resolveEffectiveDatastore(defaultDatastore)
+
+        then:
+        1 * defaultDatastore.getDatastoreForConnection("customDomain") >> resolvedDatastore
+        result.is(resolvedDatastore)
+    }
+
+    void "domain class mapping throws when datastore is missing"() {
+        given:
+        MultipleConnectionSourceCapableDatastore defaultDatastore = Mock(MultipleConnectionSourceCapableDatastore)
+        MappingContext mappingContext = Mock(MappingContext)
+        PersistentEntity entity = Mock(PersistentEntity)
+        ClassMapping classMapping = Mock(ClassMapping)
+        Entity mappedForm = new Entity()
+        def factory = new DatastoreServiceMethodInvokingFactoryBean(DomainService)
+
+        and:
+        defaultDatastore.getMappingContext() >> mappingContext
+        mappingContext.getPersistentEntity(SampleDomain.name) >> entity
+        entity.getMapping() >> classMapping
+        classMapping.getMappedForm() >> mappedForm
+        mappedForm.datasources = ["customDomain"]
+
+        when:
+        factory.resolveEffectiveDatastore(defaultDatastore)
+
+        then:
+        1 * defaultDatastore.getDatastoreForConnection("customDomain") >> null
+        ConfigurationException exception = thrown(ConfigurationException)
+        exception.message.contains("connection name [customDomain]")
+        exception.message.contains("domain class [${SampleDomain.name}]")
+        exception.message.contains("service [${DomainService.name}]")
+    }
+
+    void "transactional DEFAULT connection does not override default datastore"() {
+        given:
+        MultipleConnectionSourceCapableDatastore defaultDatastore = Mock(MultipleConnectionSourceCapableDatastore)
+        def factory = new DatastoreServiceMethodInvokingFactoryBean(TxDefaultService)
+
+        when:
+        def result = factory.resolveEffectiveDatastore(defaultDatastore)
+
+        then:
+        result.is(defaultDatastore)
+    }
+
+    private static class SampleService {
+    }
+
+    @Transactional(connection = "custom")
+    private static class TxService {
+    }
+
+    @Transactional(connection = ConnectionSource.DEFAULT)
+    private static class TxDefaultService {
+    }
+
+    @Service(SampleDomain)
+    private static class DomainService {
+    }
+
+    private static class SampleDomain {
+    }
+}

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBeanSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBeanSpec.groovy
@@ -159,11 +159,16 @@ class DatastoreServiceMethodInvokingFactoryBeanSpec extends Specification {
     @Transactional(connection = ConnectionSource.DEFAULT)
     private static class TxDefaultService {
     }
+}
 
-    @Service(SampleDomain)
-    static class DomainService {
-    }
+/**
+ * Top-level class so that the @Service AST transformation can register it
+ * via META-INF/services and ServiceLoader can instantiate it.
+ * An inner class would cause ServiceConfigurationError in DefaultServiceRegistrySpec.
+ */
+@Service(SampleDomain)
+class DomainService {
+}
 
-    static class SampleDomain {
-    }
+class SampleDomain {
 }


### PR DESCRIPTION
## Summary

- Add null guards after `getDatastoreForConnection()` calls in `DatastoreServiceMethodInvokingFactoryBean.resolveEffectiveDatastore()`, throwing a clear `ConfigurationException` with the connection name, domain class, and service class rather than silently setting a null datastore.
- Covers both the explicit `@Transactional(connection=...)` path and the domain class mapping inheritance path.

The `MultipleConnectionSourceCapableDatastore` interface doesn't guarantee non-null returns, and some implementations (e.g. Neo4j, SimpleMapDatastore) do a raw map lookup without validation. Hibernate already throws on missing connections, but this makes the factory bean defensive regardless of the underlying datastore implementation.

Flagged by Copilot review on #15472.

## Tests

Added `DatastoreServiceMethodInvokingFactoryBeanSpec` with 7 Spock tests covering all `resolveEffectiveDatastore()` code paths:

| Test | Path Covered |
|------|-------------|
| Non-multi-connection datastore passthrough | Early return for simple datastores |
| Default connection resolution | No annotation, no domain mapping |
| `@Transactional(connection)` resolution | Annotation-driven connection lookup |
| `@Transactional(connection)` null guard | **ConfigurationException** when connection missing |
| Domain class mapping resolution | Domain datasource mapping lookup |
| Domain class mapping null guard | **ConfigurationException** when connection missing |
| `DEFAULT` connection name passthrough | Annotation with DEFAULT does not override |

Functional tests in `grails-test-examples` were assessed but are not feasible for this change - the null guard paths trigger `ConfigurationException` during bean initialization, which prevents application startup and cannot be caught in a running functional test.