### PR TITLE
fix: disable publishing of /guide/pages/** in grails-doc/build.gradle

### DIFF
--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -294,7 +294,11 @@ docsTask.configure { Sync it ->
 
     it.outputs.dir mergedDocsDir
 
-    it.from manualDocsDir, apiDocsDir, dataDocsDir
+    it.from(manualDocsDir) {
+        exclude "guide/pages/**"
+    }
+
+    it.from apiDocsDir, dataDocsDir
     it.into mergedDocsDir
 }
 

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -294,6 +294,8 @@ docsTask.configure { Sync it ->
 
     it.outputs.dir mergedDocsDir
 
+    // Exclude page fragments - they have broken links/CSS/JS and are already
+    // included in the assembled guide pages (see #14986)
     it.from(manualDocsDir) {
         exclude "guide/pages/**"
     }


### PR DESCRIPTION
This PR addresses issue #14986. The html files generated in /guide/pages/ have broken links, css, js, etc. 

**Changes:**
Added an `exclude` rule to the `docs` Sync task in `grails-doc/build.gradle` to prevent the `/guide/pages/` directory from being included in the final documentation output. 

**Verification:**
Verified locally by running `.\gradlew :grails-doc:docs` and confirming that `build/docs/guide/pages/` is no longer present in the output, while the primary guide remains. 