### PR TITLE
fix: fix flaky scaffolding Geb tests and User.getAuthorities() bug

### DIFF
--- a/grails-test-examples/scaffolding/grails-app/domain/com/example/User.groovy
+++ b/grails-test-examples/scaffolding/grails-app/domain/com/example/User.groovy
@@ -56,7 +56,14 @@ class User implements UserDetails {
 
     @Override
     Collection<? extends GrantedAuthority> getAuthorities() {
-        roles.split('').collect { new SimpleGrantedAuthority(it) }
+        if (!roles) {
+            return []
+        }
+        roles
+                .split(',')
+                .collect { it.trim() }
+                .findAll { it }
+                .collect { new SimpleGrantedAuthority(it) }
     }
 
     @Override

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserCommunityControllerSpec.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserCommunityControllerSpec.groovy
@@ -29,6 +29,7 @@ import grails.testing.mixin.integration.Integration
 class UserCommunityControllerSpec extends ContainerGebSpec {
 
     void setup() {
+        clearCookiesQuietly()
         to(LoginPage).login()
     }
 

--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserControllerSpec.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/UserControllerSpec.groovy
@@ -29,6 +29,7 @@ import grails.testing.mixin.integration.Integration
 class UserControllerSpec extends ContainerGebSpec {
 
     void setup() {
+        clearCookiesQuietly()
         to(LoginPage).login()
     }
 


### PR DESCRIPTION
## Summary

- Fix flaky `UserControllerSpec` and `UserCommunityControllerSpec` Geb tests by clearing stale session cookies in `setup()` before login via `clearCookiesQuietly()`
- Fix `User.getAuthorities()` which incorrectly used `roles.split('')` splitting each character into a separate `GrantedAuthority` instead of splitting by comma delimiter

## Root Cause

CI logs showed the specs run sequentially with a shared browser instance:

```
UserCommunityControllerSpec > User list PASSED
UserControllerSpec > User list FAILED
    geb.waiting.WaitTimeoutException: title == pageTitle
    'Please sign in' != 'User List'
```

The first spec's `cleanup()` logs out, leaving stale session cookies. When the second spec's `setup()` navigates to `/login` and submits the form, the inconsistent session state causes the login to silently fail - the browser ends up back on the login page instead of being authenticated.

Adding `clearCookiesQuietly()` before login in `setup()` ensures each spec starts with a clean browser state, eliminating the stale session interference.

## CI Failures

This test has been failing intermittently across multiple CI runs on `7.0.x`:

| Run | Job | Branch/PR |
|-----|-----|----|
| [Functional Tests (25)](https://github.com/apache/grails-core/actions/runs/22535915606/job/65285991259) | `UserControllerSpec > User list FAILED` | PR #15477 |
| [Functional Tests (25)](https://github.com/apache/grails-core/actions/runs/22599804411/job/65479221071) | `UserControllerSpec > User list FAILED` | PR #15477 |
| [Functional Tests (17)](https://github.com/apache/grails-core/actions/runs/22504313780/job/65206351826) | `UserControllerSpec > User list FAILED` | 7.0.x (Merge #15460) |
| [Functional Tests (25)](https://github.com/apache/grails-core/actions/runs/22408571712) | `UserControllerSpec > User list FAILED` | 7.0.x (Merge #15455) |

## Changes

| File | Change |
|------|--------|
| `User.groovy` | `roles.split('')` -> proper comma-split with null/blank guard |
| `UserControllerSpec.groovy` | Add `clearCookiesQuietly()` in `setup()` before login |
| `UserCommunityControllerSpec.groovy` | Add `clearCookiesQuietly()` in `setup()` before login |