### PR TITLE
Fix flaky AsyncPromiseSpec ReadTimeoutException on CI

### DIFF
--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/async/AsyncPromiseSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/async/AsyncPromiseSpec.groovy
@@ -19,6 +19,7 @@
 
 package functionaltests.async
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 import groovy.json.JsonSlurper
@@ -27,6 +28,7 @@ import functionaltests.services.AsyncProcessingService
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
+import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.HttpClient
 import spock.lang.Shared
 import spock.lang.Specification
@@ -47,7 +49,11 @@ class AsyncPromiseSpec extends Specification {
     AsyncProcessingService asyncProcessingService
 
     def setup() {
-        client = client ?: HttpClient.create(new URL("http://localhost:${serverPort}"))
+        if (!client) {
+            def config = new DefaultHttpClientConfiguration()
+            config.setReadTimeout(Duration.ofSeconds(30))
+            client = HttpClient.create(new URL("http://localhost:${serverPort}"), config)
+        }
     }
 
     def cleanupSpec() {


### PR DESCRIPTION
## Summary

- Configure the Micronaut `HttpClient` in `AsyncPromiseSpec` with an explicit 30-second read timeout using `DefaultHttpClientConfiguration`
- The default timeout is insufficient on loaded CI runners where Spring `@Async` thread pool startup on first invocation combined with processing overhead can exceed the client read timeout
- Follows the same pattern already used in `FlashChainForwardSpec` for custom `HttpClient` configuration

## Problem

`AsyncPromiseSpec > async service processes string input` intermittently fails with `io.micronaut.http.client.exceptions.ReadTimeoutException` on CI (observed on JDK 17 Functional Tests). The test calls a controller endpoint that uses Spring `@Async` service methods. On a loaded CI runner, the combination of:

1. Spring `@Async` thread pool initialization (first invocation)
2. `Thread.sleep(100)` in the service
3. `future.get(5, TimeUnit.SECONDS)` server-side wait
4. Response serialization overhead

...can exceed the Micronaut `HttpClient` default read timeout.

## Fix

Replace `HttpClient.create(url)` (default config) with `HttpClient.create(url, config)` where `config` has `readTimeout = 30 seconds`. This is the same approach used in `FlashChainForwardSpec`.