### PR TITLE
fix: handle null argument in GORM domain class constructor (Groovy 4 regression)

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/NullConstructorArgSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/NullConstructorArgSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.tests
+
+import org.apache.grails.data.hibernate5.core.GrailsDataHibernate5TckManager
+import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
+
+class NullConstructorArgSpec extends GrailsDataTckSpec<GrailsDataHibernate5TckManager> {
+    void setupSpec() {
+        manager.domainClasses.addAll([Club])
+    }
+
+    void "test creating domain with no-arg constructor works"() {
+        when:
+        def club = new Club()
+
+        then:
+        club != null
+        club.name == null
+    }
+
+    void "test creating domain with null constructor argument works the same as no-arg"() {
+        when:
+        def club = new Club(null)
+
+        then:
+        club != null
+        club.name == null
+    }
+
+    void "test creating domain with null constructor argument can be saved"() {
+        when:
+        def club = new Club(null)
+        club.name = "Test Club"
+        club.save(flush: true)
+
+        then:
+        club.id != null
+        Club.get(club.id).name == "Test Club"
+    }
+}

--- a/grails-datamapping-core/src/main/groovy/org/grails/compiler/gorm/GormEntityTransformation.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/compiler/gorm/GormEntityTransformation.groovy
@@ -30,6 +30,7 @@ import org.codehaus.groovy.ast.AnnotatedNode
 import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.ConstructorNode
 import org.codehaus.groovy.ast.GenericsType
 import org.codehaus.groovy.ast.InnerClassNode
 import org.codehaus.groovy.ast.MethodNode
@@ -69,6 +70,7 @@ import jakarta.persistence.Version
 
 import grails.gorm.annotation.Entity
 import org.apache.grails.common.compiler.GroovyTransformOrder
+import org.codehaus.groovy.runtime.InvokerHelper
 import org.grails.datastore.gorm.GormEnhancer
 import org.grails.datastore.gorm.GormEntity
 import org.grails.datastore.gorm.GormEntityDirtyCheckable
@@ -83,7 +85,12 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.args
 import static org.codehaus.groovy.ast.tools.GeneralUtils.callX
 import static org.codehaus.groovy.ast.tools.GeneralUtils.classX
 import static org.codehaus.groovy.ast.tools.GeneralUtils.constX
+import static org.codehaus.groovy.ast.tools.GeneralUtils.ifS
+import static org.codehaus.groovy.ast.tools.GeneralUtils.neX
+import static org.codehaus.groovy.ast.tools.GeneralUtils.nullX
 import static org.codehaus.groovy.ast.tools.GeneralUtils.returnS
+import static org.codehaus.groovy.ast.tools.GeneralUtils.stmt
+import static org.codehaus.groovy.ast.tools.GeneralUtils.varX
 
 /**
  * An AST transformation that adds the following features:<br><br>
@@ -225,6 +232,10 @@ class GormEntityTransformation extends AbstractASTTransformation implements Comp
         if (!isJpaEntity) {
             injectToStringMethod(classNode)
         }
+
+        // inject Map constructor so that new DomainClass(null) works the same as new DomainClass()
+        // Groovy 4 no longer resolves null to the implicit map constructor at runtime
+        injectMapConstructor(classNode)
 
         // inject the GORM entity trait unless it is an RX entity
         MethodNode addToMethodNode = ADD_TO_METHOD_NODE
@@ -451,6 +462,42 @@ class GormEntityTransformation extends AbstractASTTransformation implements Comp
             return Class.forName('org.hibernate.Hibernate', false, classLoader) != null
         } catch (Throwable e) {
             return false
+        }
+    }
+
+    protected void injectMapConstructor(ClassNode classNode) {
+        ClassNode mapType = ClassHelper.MAP_TYPE.getPlainNodeReference()
+        def declaredConstructors = classNode.getDeclaredConstructors()
+        boolean hasMapConstructor = declaredConstructors.any { ConstructorNode cn ->
+            cn.parameters.length == 1 && cn.parameters[0].type == mapType
+        }
+        if (hasMapConstructor) return
+
+        Parameter mapParam = new Parameter(mapType, 'args')
+        BlockStatement body = new BlockStatement()
+
+        MethodCallExpression setPropertiesCall = callX(
+            classX(ClassHelper.make(InvokerHelper)),
+            'setProperties',
+            args(varX('this'), varX('args'))
+        )
+        body.addStatement(ifS(neX(varX('args'), nullX()), stmt(setPropertiesCall)))
+
+        ConstructorNode constructor = classNode.addConstructor(
+            Modifier.PUBLIC, [mapParam] as Parameter[], null, body
+        )
+        markAsGenerated(classNode, constructor)
+
+        // Adding any explicit constructor prevents Groovy from auto-generating
+        // the default no-arg constructor, so ensure one exists
+        boolean hasNoArgConstructor = declaredConstructors.any { ConstructorNode cn ->
+            cn.parameters.length == 0
+        }
+        if (!hasNoArgConstructor) {
+            ConstructorNode noArgConstructor = classNode.addConstructor(
+                Modifier.PUBLIC, AstUtils.ZERO_PARAMETERS, null, new BlockStatement()
+            )
+            markAsGenerated(classNode, noArgConstructor)
         }
     }
 


### PR DESCRIPTION
## Problem

Calling `new DomainClass(null)` on a GORM domain class throws:

```
groovy.lang.GroovyRuntimeException: Could not find matching constructor for: DomainClass(null)
```

This is a regression from Grails 6 / Groovy 3, where `new DomainClass(null)` was treated equivalently to `new DomainClass()`.

## Root Cause

In Groovy 3, the runtime resolved `new SomeClass(null)` by matching it to the implicit map-based constructor that Groovy provides for POGOs. When `null` was passed, the runtime simply created the object via the no-arg constructor without setting any properties.

Groovy 4 changed how constructor resolution works at runtime. The implicit map constructor is no longer matched when `null` is passed as the argument, causing the `GroovyRuntimeException`.

This is a common pattern in Grails applications — for example, when a variable that may be `null` is passed to a domain constructor:

```groovy
def props = maybeGetProperties() // could return null
def obj = new MyDomain(props)    // fails in Grails 7 / Groovy 4
```

## Fix

The `GormEntityTransformation` (the `@Entity` AST transform) now injects an explicit `Map` constructor into every GORM entity class. The constructor:

- Accepts a `Map` parameter, allowing `null` to match at runtime
- If the map is not `null`, sets properties via `InvokerHelper.setProperties(this, args)` — the same mechanism Groovy uses internally for map constructors
- If `null`, does nothing (equivalent to the no-arg constructor)
- Also ensures a no-arg constructor is preserved, since adding any explicit constructor prevents Groovy from auto-generating the default one

The constructor is injected early in the transformation (before trait composition), so trait `\$init\$` methods are properly wired into it by the Groovy trait composer.

## Tests

Added `NullConstructorArgSpec` in `grails-data-hibernate5/core` with three tests:
1. No-arg constructor works (baseline)
2. Null constructor argument works the same as no-arg
3. Domain created with null constructor argument can be saved

All 598 existing hibernate5 core tests continue to pass with 0 failures.

Co-Authored-By: Oz <oz-agent@warp.dev>