### PR TITLE
Improve Gradle build cacheability

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -130,6 +130,7 @@ class SbomPlugin implements Plugin<Project> {
         )
 
         configureSbomTask(project, sbomOutputLocation)
+        configureNormalization(project)
         ensureLicensesValidated(project)
 
         // sboms are only published to Grails jar files at this time
@@ -262,6 +263,13 @@ class SbomPlugin implements Plugin<Project> {
         }
     }
 
+    private static void configureNormalization(Project project) {
+        project.normalization { handler ->
+            handler.runtimeClasspath {
+                it.ignore("META-INF/sbom.json")
+            }
+        }
+    }
     @CompileDynamic
     private static Object pickLicense(CycloneDxTask task, String bomRef, List licenseChoices) {
         if (!bomRef) {

--- a/gradle/docs-dependencies.gradle
+++ b/gradle/docs-dependencies.gradle
@@ -43,12 +43,8 @@ String resolveProjectVersion(String artifact) {
     version
 }
 
-tasks.withType(Groovydoc).configureEach { Groovydoc gdoc ->
-    gdoc.exclude('META-INF/**', '*yml', '*properties', '*xml', '**/Application.groovy', '**/Bootstrap.groovy', '**/resources.groovy')
-    gdoc.windowTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"
-    gdoc.docTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"
-
-    gdoc.doFirst {
+def configureGroovyDoc = tasks.register('configureGroovyDoc') {
+    doLast {
         List<Map<String, String>> links = []
         def gebVersion = resolveProjectVersion('geb-spock')
         if (gebVersion) {
@@ -66,9 +62,17 @@ tasks.withType(Groovydoc).configureEach { Groovydoc gdoc ->
         if (springBootVersion) {
             links << [packages: 'org.springframework.boot.', href: "https://docs.spring.io/spring-boot/docs/${springBootVersion}/api/"]
         }
-        if (gdoc.ext.has('groovydocLinks')) {
-            links.addAll(gdoc.ext.groovydocLinks as List<Map<String, String>>)
+        if (it.ext.has('groovydocLinks')) {
+            links.addAll(it.ext.groovydocLinks as List<Map<String, String>>)
         }
-        gdoc.ext.groovydocLinks = links
+        it.ext.groovydocLinks = links
     }
+}
+
+tasks.withType(Groovydoc).configureEach { Groovydoc gdoc ->
+    dependsOn(configureGroovyDoc)
+
+    gdoc.exclude('META-INF/**', '*yml', '*properties', '*xml', '**/Application.groovy', '**/Bootstrap.groovy', '**/resources.groovy')
+    gdoc.windowTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"
+    gdoc.docTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"
 }

--- a/gradle/grails-data-tck-config.gradle
+++ b/gradle/grails-data-tck-config.gradle
@@ -41,7 +41,9 @@ extractTck.configure { Sync it ->
     it.finalizedBy(tasks.named('test', Test))
 
     it.from { zipTree(configurations.tck.singleFile) }
-    it.into(layout.buildDirectory.dir('extracted-tck-classes'))
+    it.into(layout.buildDirectory.dir('extracted-tck-classes')).exclude {
+        it.path == 'META-INF/sbom.json'
+    }
 }
 
 // There is a known issue with IntelliJ that can cause it's inspection process to lock up.

--- a/grails-gradle/build.gradle
+++ b/grails-gradle/build.gradle
@@ -47,11 +47,3 @@ ext {
 apply {
     from layout.projectDirectory.file('gradle/publish-root-config.gradle')
 }
-
-subprojects {
-    normalization {
-        runtimeClasspath {
-            ignore 'META-INF/sbom.json'
-        }
-    }
-}

--- a/grails-gradle/build.gradle
+++ b/grails-gradle/build.gradle
@@ -47,3 +47,11 @@ ext {
 apply {
     from layout.projectDirectory.file('gradle/publish-root-config.gradle')
 }
+
+subprojects {
+    normalization {
+        runtimeClasspath {
+            ignore 'META-INF/sbom.json'
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR improves Gradle build cacheability by
- Removing the non-required `base.dir` absolute path from `Test.systemProperties`
- Ignoring `sbom.json` during cache key computation
- Migrating `GroovyDoc.doFirst` block to a dedicated task [Optional as this breaks configuration cache compatibility]

### Details

Running experiment 3 of the [automated validation scripts](https://github.com/gradle/develocity-build-validation-scripts/blob/main/Gradle.md) helped to discover 587 cacheable tasks executed in 1h 31m 58.817s of serial time in the second [Build Scan](https://ge.solutions-team.gradle.com/s/nngl4lil4cbyo/timeline?cacheability=cacheable,overlapping-outputs&outcome=success).
In ideal situations, no cacheable task should run in the second build of an experiment, as they should all come from the cache.

The cache misses reasons illustrated in this [build scan comparison](https://ge.solutions-team.gradle.com/c/yurlk5t7wunlc/nngl4lil4cbyo/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure) are diverse

Here are the patterns
- `GroovyDoc`:  using `doFirst` breaks cacheability ([doc](https://docs.gradle.org/current/userguide/common_caching_problems.html#custom_actions)), however, the remediation implemented breaks configuration cache compatibility . I believe it's still worth it given CC can't be enabled for [other reasons](https://github.com/apache/grails-core/blob/2c002d3ff4e485c0cb2013812c5e5791ca150367/gradle.properties#L75)
- `GroovyCompile`, `Checkstyle`: classpath differences due to the `sbom.json` file
- `GroovyCompile`: usage of `doFirst`
- `Test`: systemProperty differences due to `base.dir` absolute path

Applying the fix reduced the number of cache misses to 242 tasks in 25m 34.176s of serial time in the [second build scan](https://ge.solutions-team.gradle.com/c/lvzkpkckzhlec/ayyw73alaxudk/task-inputs)

### Not covered

The `doFirst` block of the `GroovyCompile` task has been kept as it is a [conscious decision](https://github.com/apache/grails-core/blob/2c002d3ff4e485c0cb2013812c5e5791ca150367/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy#L198)

A bunch of tasks having a different build classpath between the 2 executions are still present:
- `FindMainClassTask`
- `AsciidoctorTask`
- `FetchTagsTask`
- `GroovyPageForkCompileTask`
- `ExtractDependenciesTask`
- `PublishGuideTask`
- `CreateReleaseDropDownTask`
