### PR TITLE
Improve Groovy Joint Validation Build CI stability

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -158,7 +158,10 @@ jobs:
       - name: "🔨 Build and test Grails using the locally built Groovy snapshot"
         run: >
           ./gradlew build
+          --continue
+          --stacktrace
           -x groovydoc
           -PskipCodeStyle
+          -PmaxTestParallel=3
         env:
           GRAILS_INCLUDE_MAVEN_LOCAL: true


### PR DESCRIPTION
## Summary

- Add `--continue` so a single flaky test failure does not abort the entire ~45-minute Groovy Joint build (the job still fails at the end - it just reports all failures in one run)
- Add `--stacktrace` for better failure diagnostics (matching the main CI workflow)
- Reduce `maxTestParallel` from 4 to 3 to lower memory pressure on CI runners

## Problem

Analysis of the last 80 Groovy Joint Validation Build runs shows 16 failures (20% failure rate) with these recurring patterns:

| Failure | Occurrences | Status |
|---------|-------------|--------|
| `AsyncPromiseSpec > async service processes string input` (ReadTimeoutException) | 2 | Fixed in #15481 |
| `UserControllerSpec > User list` (scaffolding Geb flaky login) | 2 | Fixed in #15480 |
| `DefaultServiceRegistrySpec` (ServiceConfigurationError) | 1+ | Fixed in #15474 |
| Gradle Test Executor JVM crash (all tests passed, non-zero exit) | 1 | **Addressed here** |
| `WhereQueryOldIssueVerificationSpec` (flaky hibernate5 test) | 2 | Pre-existing |
| `MicronautErsatzRoundtripSpec` (flaky Ersatz mock) | 1 | Pre-existing |
| Branch-specific failures (compile errors, test regressions) | 7 | N/A |

The Groovy Joint workflow is uniquely vulnerable because it runs **all** tests (unit + integration + functional + MongoDB) in a single job. Without `--continue`, one flaky test kills the entire build. The JVM crash occurred because 4 parallel test forks (each 768m) + Gradle daemon (5G) + MongoDB container exceeds the ~7GB runner memory.

## Changes

**`groovy-joint-workflow.yml`**:

- `--continue`: Lets the build finish and report all failures instead of aborting on the first one. The job still exits non-zero so CI stays red.
- `--stacktrace`: Provides full stack traces on failure (the main CI workflow already uses this)
- `-PmaxTestParallel=3`: Reduces parallel test forks from 4 to 3, cutting test JVM memory usage from ~3GB to ~2.3GB. This gives more headroom for the Gradle daemon and MongoDB container on the ~7GB GitHub runner.