### PR TITLE
Fix flaky Ersatz empty response body test with @Retry

### DIFF
--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzRoundtripSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzRoundtripSpec.groovy
@@ -25,6 +25,7 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
 import spock.lang.AutoCleanup
+import spock.lang.Retry
 import spock.lang.Specification
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -444,6 +445,7 @@ class MicronautErsatzRoundtripSpec extends Specification {
         ersatz.verify()
     }
 
+    @Retry(count = 2, delay = 200, exceptions = [io.micronaut.http.client.exceptions.HttpClientException])
     void "full roundtrip: ersatz mocks empty response body"() {
         given: 'ersatz mocks an endpoint returning 200 with an empty JSON object'
         ersatz.expectations({ expect ->


### PR DESCRIPTION
## Summary

- Add `@Retry(count = 2, delay = 200)` to the flaky `MicronautErsatzRoundtripSpec."full roundtrip: ersatz mocks empty response body"` test

## Problem

This test intermittently fails on CI with:

```
HttpClientException: Client 'grails-self': Error occurred reading HTTP response: Connection reset
```

Observed in Groovy Joint Validation Build run [22598688156](https://github.com/apache/grails-core/actions/runs/22598688156).

### Root Cause

The `ErsatzServer` is created per test method (`@AutoCleanup`, not `@Shared`) on a fixed port (19876). Between test methods, the server is stopped and a new one is started on the same port. The Micronaut `@Client(id = 'grails-self')` HTTP client maintains a connection pool, so stale connections from the previous test's Ersatz instance can cause `Connection reset` when reused against the new server.

### Fix

Add Spock's `@Retry` annotation scoped to `HttpClientException` only, so only transient connection issues trigger a retry (up to 2 retries with 200ms delay). This follows the standard pattern for CI-flaky network tests without masking real failures.