### PR TITLE
feat: consolidate Checkstyle and Codenarc errors into single file for GitHub workflow

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -45,13 +45,23 @@ jobs:
       - name: "🔎 Check Core Projects"
         run: ./gradlew codeStyle
       - name: "📤 Upload Failure Reports"
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v7.0.0
         with:
           name: core-reports
-          path: |
-            **/build/reports/checkstyle/
-            **/build/reports/codenarc/
+          path: build/reports/codestyle/
+      - name: "📋 Publish Code Style Report in Job Summary"
+        if: always()
+        run: |
+          echo "## 🔎 Code Style Report - Core Projects" >> $GITHUB_STEP_SUMMARY
+          for file in build/reports/codestyle/checkstyle/*.xml build/reports/codestyle/codenarc/*.xml; do
+            [ -f "$file" ] || continue
+            if grep -q "<error " "$file" || grep -q "<Violation " "$file"; then
+              echo "### ❌ $(basename $file .xml)" >> $GITHUB_STEP_SUMMARY
+              grep "<error " "$file" | awk -F'"' '{print "- **Line " $2 "**: " $8}' >> $GITHUB_STEP_SUMMARY
+              grep "<Violation " "$file" | awk -F"'" '{print "- **Line " $6 "**: " $2}' >> $GITHUB_STEP_SUMMARY
+            fi
+          done
   check_gradle_plugin_projects:
     name: "Gradle Plugin Projects"
     runs-on: ubuntu-24.04
@@ -73,13 +83,23 @@ jobs:
         working-directory: grails-gradle
         run: ./gradlew codeStyle
       - name: "📤 Upload Failure Reports"
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v7.0.0
         with:
           name: gradle-plugin-reports
-          path: |
-            grails-gradle/**/build/reports/checkstyle/
-            grails-gradle/**/build/reports/codenarc/
+          path: grails-gradle/build/reports/codestyle/
+      - name: "📋 Publish Code Style Report in Job Summary"
+        if: always()
+        run: |
+          echo "## 🔎 Code Style Report - Gradle Plugin Projects" >> $GITHUB_STEP_SUMMARY
+          for file in grails-gradle/build/reports/codestyle/checkstyle/*.xml grails-gradle/build/reports/codestyle/codenarc/*.xml; do
+            [ -f "$file" ] || continue
+            if grep -q "<error " "$file" || grep -q "<Violation " "$file"; then
+              echo "### ❌ $(basename $file .xml)" >> $GITHUB_STEP_SUMMARY
+              grep "<error " "$file" | awk -F'"' '{print "- **Line " $2 "**: " $8}' >> $GITHUB_STEP_SUMMARY
+              grep "<Violation " "$file" | awk -F"'" '{print "- **Line " $6 "**: " $2}' >> $GITHUB_STEP_SUMMARY
+            fi
+          done
   check_grails_forge_projects:
     name: "Forge Projects"
     runs-on: ubuntu-24.04
@@ -101,11 +121,20 @@ jobs:
         working-directory: grails-forge
         run: ./gradlew codeStyle
       - name: "📤 Upload Failure Reports"
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v7.0.0
         with:
           name: forge-reports
-          path: |
-            grails-forge/**/build/reports/checkstyle/
-            grails-forge/**/build/reports/checkstyleNohttp/
-            grails-forge/**/build/reports/codenarc/
+          path: grails-forge/build/reports/codestyle/
+      - name: "📋 Publish Code Style Report in Job Summary"
+        if: always()
+        run: |
+          echo "## 🔎 Code Style Report - Forge Projects" >> $GITHUB_STEP_SUMMARY
+          for file in grails-forge/build/reports/codestyle/checkstyle/*.xml grails-forge/build/reports/codestyle/codenarc/*.xml; do
+            [ -f "$file" ] || continue
+            if grep -q "<error " "$file" || grep -q "<Violation " "$file"; then
+              echo "### ❌ $(basename $file .xml)" >> $GITHUB_STEP_SUMMARY
+              grep "<error " "$file" | awk -F'"' '{print "- **Line " $2 "**: " $8}' >> $GITHUB_STEP_SUMMARY
+              grep "<Violation " "$file" | awk -F"'" '{print "- **Line " $6 "**: " $2}' >> $GITHUB_STEP_SUMMARY
+            fi
+          done

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsCodeStyleExtension.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsCodeStyleExtension.groovy
@@ -41,6 +41,12 @@ class GrailsCodeStyleExtension {
      */
     final DirectoryProperty codenarcDirectory
 
+    /**
+     * Defaults to rootProject.buildDir/reports/codestyle.
+     * All Checkstyle and Codenarc reports will be written here.
+     */
+    final DirectoryProperty reportsDirectory
+
     @Inject
     GrailsCodeStyleExtension(ObjectFactory objects, Project project) {
         checkstyleDirectory = objects.directoryProperty().convention(
@@ -48,6 +54,9 @@ class GrailsCodeStyleExtension {
         )
         codenarcDirectory = objects.directoryProperty().convention(
                 project.rootProject.layout.buildDirectory.dir('codenarc')
+        )
+        reportsDirectory = objects.directoryProperty().convention(
+                project.rootProject.layout.buildDirectory.dir('reports/codestyle')
         )
     }
 }

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsCodeStylePlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsCodeStylePlugin.groovy
@@ -178,6 +178,7 @@ class GrailsCodeStylePlugin implements Plugin<Project> {
 
             // Redirect XML report output to a single directory to consolidate
             // reports across all subprojects into one known location
+            it.reports.xml.required.set(true)
             it.reports.xml.outputLocation.set(
                     project.extensions.getByType(GrailsCodeStyleExtension)
                             .reportsDirectory.get()

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsCodeStylePlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsCodeStylePlugin.groovy
@@ -151,6 +151,15 @@ class GrailsCodeStylePlugin implements Plugin<Project> {
         project.tasks.withType(Checkstyle).configureEach {
             it.group = 'verification'
             it.onlyIf { !project.hasProperty('skipCodeStyle') }
+
+            // Redirect XML report output to a single directory to consolidate
+            // reports across all subprojects into one known location
+            it.reports.xml.outputLocation.set(
+                    project.extensions.getByType(GrailsCodeStyleExtension)
+                            .reportsDirectory.get()
+                            .dir('checkstyle')
+                            .file(project.name + '.xml')
+            )
         }
     }
 
@@ -166,6 +175,15 @@ class GrailsCodeStylePlugin implements Plugin<Project> {
         project.tasks.withType(CodeNarc).configureEach {
             it.group = 'verification'
             it.onlyIf { !project.hasProperty('skipCodeStyle') }
+
+            // Redirect XML report output to a single directory to consolidate
+            // reports across all subprojects into one known location
+            it.reports.xml.outputLocation.set(
+                    project.extensions.getByType(GrailsCodeStyleExtension)
+                            .reportsDirectory.get()
+                            .dir('codenarc')
+                            .file(project.name + '.xml')
+            )
         }
     }
 }


### PR DESCRIPTION
## Description

This PR addresses issue #15088. 

The goal is to consolidate Checkstyle and Codenarc error reports into a single known location and publish them directly to the GitHub Actions job summary, making it easier to identify failures without searching through multiple zip artifacts. 

## Changes

### `GrailsCodeStyleExtension.groovy`
- Added `reportsDirectory` property that defaults to `rootProject.buildDir/reports/codestyle`, providing a single location for all code style reports across subprojects. 

### `GrailsCodeStylePlugin.groovy`
- Configured Checkstyle tasks to redirect XML report output to `reportsDirectory/checkstyle/<projectname>.xml`.
- Configured Codenarc tasks to enable XML report output and redirect to `reportsDirectory/codenarc/<projectname>.xml`.
- Each project writes to a file named after the project to avoid overwriting. 

### `.github/workflows/codestyle.yml`
- Updated artifact upload paths to point to the new reports directory.
- Changed upload condition from `failure()` to `always()` so reports are available regardless of build outcome, aligning with the existing pattern in `rat.yml`. 
- Added "Publish Code Style Report Summary" step to each job, parsing Checkstyle and Codenarc XML reports and writing errors directly to the GitHub Actions job summary, similar to how RAT errors are already handled. 

## Testing
- Verified single report output locally by introducing intentional Checkstyle and Codenarc errors and confirming reports are written to `build/reports/codestyle`. 
- Verified via GitHub Actions on this PR. All three jobs (Core Projects, Gradle Plugin Projects, Forge Projects) passed successfully and the "Publish Code Style Report in Job Summary" step executed without errors. 