### PR TITLE
fix: cleanup liquibase dependencies and jaxb-api for Jakarta EE 10

### DIFF
--- a/grails-data-hibernate5/dbmigration/build.gradle
+++ b/grails-data-hibernate5/dbmigration/build.gradle
@@ -41,13 +41,16 @@ dependencies {
         exclude group: 'org.liquibase', module: 'liquibase-core'
     }
 
-    implementation("org.liquibase:liquibase-core:$liquibaseHibernate5Version")
+    implementation("org.liquibase:liquibase-core:$liquibaseHibernate5Version") {
+        exclude group: 'javax.xml.bind', module: 'jaxb-api'
+    }
     implementation("org.liquibase.ext:liquibase-hibernate5:$liquibaseHibernate5Version") {
         exclude group: 'org.hibernate', module: 'hibernate-core'
         exclude group: 'org.hibernate', module: 'hibernate-entitymanager'
         exclude group: 'org.hibernate', module: 'hibernate-envers'
         exclude group: 'com.h2database', module: 'h2'
         exclude group: 'org.liquibase', module: 'liquibase-commercial'
+        exclude group: 'org.liquibase', module: 'liquibase-core'
     }
 
     implementation(project(':grails-shell-cli')) {


### PR DESCRIPTION
### Description
This PR addresses dependency redundancies and Jakarta EE 10 compliance issues within the `dbmigration` module.

### Key Changes
* **Jakarta EE 10 Compliance:** Excluded `javax.xml.bind:jaxb-api` from `liquibase-core` to prevent classpath conflicts.
* **Cleanup:** Removed redundant `liquibase-core` dependencies from the `liquibase-hibernate5` extension.
* **Dependency Management:** Refined exclusions in `grails-data-hibernate5/dbmigration/build.gradle`.

Fixes #15452