### PR TITLE
build - add a gradle task to facilitate publishing all projects for easier testing locally.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
+import javax.inject.Inject
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
 ext {
     isReproducibleBuild = System.getenv("SOURCE_DATE_EPOCH") != null
     buildInstant = java.util.Optional.ofNullable(System.getenv("SOURCE_DATE_EPOCH"))
@@ -74,39 +78,41 @@ subprojects {
     }
 }
 
+interface ExecSupport {
+    @Inject ExecOperations getProcess()
+}
+tasks.register('publishAllToMavenLocal') {
+    description = 'Publishes grails-gradle, the root build, and grails-forge to the local Maven cache (in order).'
+    group = 'publishing'
+
+    def execSupport = objects.newInstance(ExecSupport)
+
+    doLast {
+        def projectRoot = layout.projectDirectory.asFile
+        def javaHome = System.getProperty('java.home')
+        def gradlew = Os.isFamily(Os.FAMILY_WINDOWS) ? 'gradlew.bat' : 'gradlew'
+
+        def runPublish = { File workingDir, String label ->
+            logger.lifecycle("--- Publishing ${label} to Maven Local ---")
+            execSupport.process.exec { ExecSpec exec ->
+                exec.environment('JAVA_HOME', javaHome)
+                exec.workingDir = workingDir
+                exec.commandLine = [new File(workingDir, gradlew).absolutePath, 'publishToMavenLocal']
+            }
+        }
+
+        // 1. Publish grails-gradle (provides Gradle plugins used by the main build)
+        runPublish(new File(projectRoot, 'grails-gradle'), 'grails-gradle')
+        // 2. Publish the root (main) build
+        runPublish(projectRoot, 'root build')
+        // 3. Publish grails-forge
+        runPublish(new File(projectRoot, 'grails-forge'), 'grails-forge')
+    }
+}
+
 apply {
     from layout.projectDirectory.file('gradle/publish-root-config.gradle')
     from layout.projectDirectory.file('gradle/rat-root-config.gradle')
-}
-
-tasks.register('publishAllToMavenLocal') {
-    group = 'publishing'
-    description = 'Publishes grails-gradle, the root build, and grails-forge to the local Maven cache (in order).'
-
-    doLast {
-        def rootDir = layout.projectDirectory.asFile
-
-        // 1. Publish grails-gradle (provides Gradle plugins used by the main build)
-        logger.lifecycle('--- Publishing grails-gradle to Maven Local ---')
-        exec {
-            workingDir file("${rootDir}/grails-gradle")
-            commandLine "${rootDir}/grails-gradle/gradlew", 'publishToMavenLocal'
-        }
-
-        // 2. Publish the root (main) build
-        logger.lifecycle('--- Publishing root build to Maven Local ---')
-        exec {
-            workingDir rootDir
-            commandLine "${rootDir}/gradlew", 'publishToMavenLocal'
-        }
-
-        // 3. Publish grails-forge
-        logger.lifecycle('--- Publishing grails-forge to Maven Local ---')
-        exec {
-            workingDir file("${rootDir}/grails-forge")
-            commandLine "${rootDir}/grails-forge/gradlew", 'publishToMavenLocal'
-        }
-    }
 }
 
 // For debugging the gradle task graph: Uncomment to show task dependencies when a task is run

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,36 @@ apply {
     from layout.projectDirectory.file('gradle/rat-root-config.gradle')
 }
 
+tasks.register('publishAllToMavenLocal') {
+    group = 'publishing'
+    description = 'Publishes grails-gradle, the root build, and grails-forge to the local Maven cache (in order).'
+
+    doLast {
+        def rootDir = layout.projectDirectory.asFile
+
+        // 1. Publish grails-gradle (provides Gradle plugins used by the main build)
+        logger.lifecycle('--- Publishing grails-gradle to Maven Local ---')
+        exec {
+            workingDir file("${rootDir}/grails-gradle")
+            commandLine "${rootDir}/grails-gradle/gradlew", 'publishToMavenLocal'
+        }
+
+        // 2. Publish the root (main) build
+        logger.lifecycle('--- Publishing root build to Maven Local ---')
+        exec {
+            workingDir rootDir
+            commandLine "${rootDir}/gradlew", 'publishToMavenLocal'
+        }
+
+        // 3. Publish grails-forge
+        logger.lifecycle('--- Publishing grails-forge to Maven Local ---')
+        exec {
+            workingDir file("${rootDir}/grails-forge")
+            commandLine "${rootDir}/grails-forge/gradlew", 'publishToMavenLocal'
+        }
+    }
+}
+
 // For debugging the gradle task graph: Uncomment to show task dependencies when a task is run
 //gradle.taskGraph.whenReady {taskGraph ->
 //    logger.lifecycle("Found ${taskGraph.allTasks.size()} tasks.")


### PR DESCRIPTION
@matrei I got sick of running `cd grails-gradle && ./gradlew publishToMavenLocal && cd .. && ./gradlew publishToMavenLocal && cd grails-forge && ./gradlew publishToMavenLocal && cd ..` to publish.  I added a gradle task to make this easier ... 