### PR TITLE
Enable running single tests with Gradle `--tests` flag

### DIFF
--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -80,73 +80,58 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testRuntimeOnly 'org.springframework:spring-aspects'
 
-
     // Testing
     testImplementation('org.spockframework:spock-core') { transitive = false }
+
     // Required by Spock's Mocking
     testRuntimeOnly 'net.bytebuddy:byte-buddy'
 }
 
 def isolatedTestPatterns = [
-        isolatedTestsOne              : [
+        isolatedTestsOne: [
                 'org.grails.core.DefaultGrailsControllerClassSpec',
                 'org.grails.web.util.WebUtilsTests'
         ],
-        isolatedTestsTwo              : [
+        isolatedTestsTwo: [
                 'grails.test.mixin.UrlMappingsTestMixinTests',
                 'grails.test.mixin.SetupTeardownInvokeTests',
                 'grails.test.mixin.TestMixinSetupTeardownInvokeTests'
         ],
-        isolatedRestRendererTests     : [
+        isolatedRestRendererTests: [
                 '*.rest.render.*Spec'
         ],
-        isolatedPersonTests           : [
+        isolatedPersonTests: [
                 'org.grails.validation.TestingValidationSpec',
                 'org.grails.validation.CascadingErrorCountSpec'
         ],
         isolatedRestfulControllerTests: [
                 'grails.test.mixin.RestfulControllerSpec',
                 'grails.test.mixin.ResourceAnnotationRestfulControllerSpec'
-        ]
+        ],
+]
+
+def testSkippingProperties = [
+        'onlyFunctionalTests',
+        'onlyHibernate5Tests',
+        'onlyMongodbTests',
+        'skipCoreTests',
+        'skipTests',
 ]
 
 isolatedTestPatterns.keySet().each { taskName ->
-    tasks.register(taskName, Test).configure { Test tTask ->
-        tTask.onlyIf {
-            ![
-                    'onlyFunctionalTests',
-                    'onlyHibernate5Tests',
-                    'onlyMongodbTests',
-                    'skipCoreTests',
-                    'skipTests'
-            ].find {
-                project.hasProperty(it)
-            }
-        }
-        tTask.group = 'verification'
-        tTask.filter.includePatterns = isolatedTestPatterns[taskName]
+    tasks.register(taskName, Test) {
+        group = 'verification'
+        filter.includePatterns = isolatedTestPatterns[taskName]
     }
 }
 
-tasks.named('isolatedTestsTwo', Test).configure {
+tasks.named('isolatedTestsTwo', Test) {
     maxParallelForks = 1
     forkEvery = 100
 }
 
 tasks.withType(Test).configureEach {
-    onlyIf {
-        ![
-                'onlyHibernate5Tests',
-                'onlyMongodbTests',
-                'skipCoreTests'
-        ].find {
-            project.hasProperty(it)
-        }
-    }
-
-    onlyIf {
-        !project.hasProperty('onlyFunctionalTests')
-    }
+    onlyIf { !testSkippingProperties.any {project.hasProperty(it) } }
     useJUnitPlatform()
     maxParallelForks = configuredTestParallel
     forkEvery = isCiBuild ? 50 : 100
@@ -154,25 +139,19 @@ tasks.withType(Test).configureEach {
     jvmArgs('--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED')
 }
 
-tasks.named('test', Test).configure {
-    onlyIf {
-        ![
-                'onlyFunctionalTests',
-                'onlyHibernate5Tests',
-                'onlyMongodbTests',
-                'skipCoreTests',
-                'skipTests'
-        ].find {
-            project.hasProperty(it)
-        }
-    }
-
+tasks.named('test', Test) {
+    // Exclude the isolated tests from the main test task
     filter.excludePatterns = isolatedTestPatterns.values().flatten()
-    dependsOn(provider {
-        tasks.findAll({
-            isolatedTestPatterns.containsKey(it.name)
-        })
-    })
+}
+
+tasks.register('testAll') {
+    group = 'verification'
+    description = 'Runs all tests, including isolated ones.'
+    dependsOn(tasks.withType(Test))
+}
+
+tasks.named('check') {
+    dependsOn('testAll')
 }
 
 tasks.withType(Groovydoc).configureEach {


### PR DESCRIPTION
In the `grails-test-suite-uber` project, the `test` task had `dependsOn` on the different isolated test tasks, which made it impossible to run just a single test. This PR releases this dependency by adding a `testAll` task to aggregate the different test tasks and this `testAll` task is in turn added as a dependency for `check`.

And some cleanup.