### PR TITLE
fix: resolve release-drafter failures on PRs and reduce API usage

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -36,7 +36,18 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: "🔢 Derive semver range from branch"
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.base.ref || github.ref_name }}"
+          if [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "range=~${BRANCH%.x}.0" >> "$GITHUB_OUTPUT"
+          fi
       - name: "📝 Update Release Draft"
         uses: release-drafter/release-drafter@v7
+        continue-on-error: true
+        with:
+          commitish: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          filter-by-range: ${{ steps.version.outputs.range }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes the `Release - Drafter` workflow failure visible on PRs like #15519
- Reduces GitHub API usage by filtering releases to the current branch series
- Prevents transient rate limit errors from blocking PR merges
- Addresses guidance from [INFRA-27602](https://issues.apache.org/jira/browse/INFRA-27602)

## Problems

### 1. Invalid `target_commitish` on PR events

When triggered by `pull_request` events, release-drafter defaults `targetCommitish` to `refs/pull/NNN/merge` - a virtual merge ref that GitHub rejects:

```
##[error]Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}
```

### 2. Fetches all 261 releases every run

Release-drafter fetches every release in the repo to find the latest one, even though it only needs releases from the current branch series (e.g. 7.0.x). This wastes API quota and increases the chance of hitting rate limits.

### 3. Transient rate limits fail the build

When the Apache org's GitHub App installation rate limit is exhausted, the step fails and marks the PR check red - even though release drafting is non-critical.

## Fixes

### Explicit `commitish` input

Passes `commitish` explicitly so release-drafter always targets a valid branch:

```yaml
commitish: ${{ github.event.pull_request.base.ref || github.ref_name }}
```

| Trigger | Resolves to |
|---------|------------|
| `pull_request` to `7.0.x` | `7.0.x` (from `base.ref`) |
| `push` to `7.0.x` | `7.0.x` (from `ref_name`) |
| `issues` | default branch (from `ref_name`) |
| `workflow_dispatch` | selected branch (from `ref_name`) |

### Dynamic `filter-by-range` from branch name

Derives a semver range from the branch name to filter releases to the current series only:

| Branch | Range | Effect |
|--------|-------|--------|
| `7.0.x` | `~7.0.0` | Only `>=7.0.0 <7.1.0` releases (~10 instead of 261) |
| `7.1.x` | `~7.1.0` | Only `>=7.1.0 <7.2.0` releases |
| `8.0.x` | `~8.0.0` | Only `>=8.0.0 <8.1.0` releases |
| Non-matching | _(empty)_ | No filtering (safe fallback) |

### `continue-on-error: true`

Release drafting is best-effort - it maintains draft release notes but should never block a PR. Transient API rate limits now show as an orange warning instead of a red failure.