### PR TITLE
URL mapping group defaults support

### DIFF
--- a/grails-doc/src/en/guide/theWebLayer/urlmappings/mappingToControllersAndActions.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/urlmappings/mappingToControllersAndActions.adoc
@@ -64,6 +64,45 @@ group "/store", {
 }
 ----
 
+==== Group Defaults
+
+Groups can specify default mapping parameters that are inherited by all child mappings. This avoids repeating the same `controller`, `namespace`, or `plugin` on every mapping within the group:
+
+[source,groovy]
+----
+group "/internal/community", namespace: 'community', controller: 'communitySearch', {
+    "/search"(action: 'internalSearch')
+    "/find-user"(action: 'internalFindUser')
+    "/user-activity"(action: 'internalUserActivity')
+}
+----
+
+This is equivalent to specifying `namespace` and `controller` on each mapping individually. Child mappings can override any default by specifying the parameter explicitly:
+
+[source,groovy]
+----
+group "/api", namespace: 'api', controller: 'defaultCtrl', {
+    "/special"(controller: 'specialCtrl', action: 'handle')  // overrides controller
+    "/normal"(action: 'index')                                // inherits controller
+}
+----
+
+Nested groups merge defaults — inner groups inherit and can extend or override outer group defaults:
+
+[source,groovy]
+----
+group "/community", namespace: 'community', {
+    group "/topics", controller: 'topic', {
+        "/gallery"(action: 'gallery')   // inherits namespace and controller
+        "/create"(action: 'create')
+    }
+    group "/members", controller: 'member', {
+        "/index"(action: 'index')       // inherits namespace, different controller
+    }
+}
+----
+
+The supported default parameters are: `controller`, `action`, `namespace`, `plugin`, `view`, and `method`.
 
 To rewrite one URI onto another explicit URI (rather than a controller/action pair) do something like this:
 

--- a/grails-test-examples/app1/grails-app/controllers/functionaltests/UrlMappings.groovy
+++ b/grails-test-examples/app1/grails-app/controllers/functionaltests/UrlMappings.groovy
@@ -88,6 +88,27 @@ class UrlMappings {
         // Redirect mapping with permanent flag
         "/api/old-endpoint"(redirect: '/api/test', permanent: true)
 
+        // Group defaults
+        group('/group-defaults', namespace: 'api', controller: 'groupDefaults') {
+            '/list'(action: 'list')
+            '/show'(action: 'show')
+        }
+
+        group('/group-override', namespace: 'api', controller: 'groupDefaults') {
+            '/special'(controller: 'groupOverride', action: 'handle')
+            '/normal'(action: 'index')
+        }
+
+        group('/group-no-defaults') {
+            '/info'(controller: 'urlMappingsTest', action: 'index')
+        }
+
+        group('/community', namespace: 'api') {
+            group('/topics', controller: 'groupDefaults') {
+                '/gallery'(action: 'gallery')
+            }
+        }
+
         // === CORS Test Routes (under /api/** which has CORS enabled) ===
         "/api/cors"(controller: 'corsTest', action: 'index')
         "/api/cors/data"(controller: 'corsTest', action: 'getData')

--- a/grails-test-examples/app1/grails-app/controllers/functionaltests/urlmappings/GroupDefaultsController.groovy
+++ b/grails-test-examples/app1/grails-app/controllers/functionaltests/urlmappings/GroupDefaultsController.groovy
@@ -1,0 +1,61 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package functionaltests.urlmappings
+
+import grails.converters.JSON
+
+class GroupDefaultsController {
+
+    static namespace = 'api'
+    static responseFormats = ['json']
+
+    def index() {
+        render([
+            controller: 'groupDefaults',
+            action: 'index',
+            namespace: 'api'
+        ] as JSON)
+    }
+
+    def list() {
+        render([
+            controller: 'groupDefaults',
+            action: 'list',
+            namespace: 'api'
+        ] as JSON)
+    }
+
+    def show() {
+        render([
+            controller: 'groupDefaults',
+            action: 'show',
+            namespace: 'api',
+            id: params.id
+        ] as JSON)
+    }
+
+    def gallery() {
+        render([
+            controller: 'groupDefaults',
+            action: 'gallery',
+            namespace: 'api'
+        ] as JSON)
+    }
+}
+

--- a/grails-test-examples/app1/grails-app/controllers/functionaltests/urlmappings/GroupOverrideController.groovy
+++ b/grails-test-examples/app1/grails-app/controllers/functionaltests/urlmappings/GroupOverrideController.groovy
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package functionaltests.urlmappings
+
+import grails.converters.JSON
+
+class GroupOverrideController {
+
+    static namespace = 'api'
+    static responseFormats = ['json']
+
+    def handle() {
+        render([
+            controller: 'groupOverride',
+            action: 'handle',
+            namespace: 'api'
+        ] as JSON)
+    }
+}

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/urlmappings/UrlMappingsSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/urlmappings/UrlMappingsSpec.groovy
@@ -206,6 +206,75 @@ class UrlMappingsSpec extends Specification implements HttpClientSupport {
         response.assertJsonContains(200, [action: 'index'])
     }
 
+    // ========== Group Default Mappings ==========
+
+    def 'group defaults are inherited by child mappings'() {
+        when: 'requesting a child mapping that relies on grouped controller and namespace defaults'
+        def response = http('/group-defaults/list')
+
+        then: 'the grouped defaults resolve to the expected controller action'
+        response.assertJson(200, [
+            namespace: 'api',
+            controller: 'groupDefaults',
+            action: 'list'
+        ])
+
+        when: 'requesting another child mapping that inherits the same defaults'
+        response = http('/group-defaults/show')
+
+        then: 'the inherited defaults still apply to the second child mapping'
+        response.assertJsonContains(200, [
+            namespace: 'api',
+            controller: 'groupDefaults',
+            action: 'show'
+        ])
+    }
+
+    def 'child mappings can override grouped defaults'() {
+        when: 'requesting the child mapping that overrides the grouped controller and action'
+        def response = http('/group-override/special')
+
+        then: 'the child mapping uses its explicit controller and action values'
+        response.assertJson(200, [
+            namespace: 'api',
+            controller: 'groupOverride',
+            action: 'handle'
+        ])
+
+        when: 'requesting the child mapping that does not provide an override'
+        response = http('/group-override/normal')
+
+        then: 'the grouped defaults remain in effect for that child mapping'
+        response.assertJson(200, [
+            namespace: 'api',
+            controller: 'groupDefaults',
+            action: 'index'
+        ])
+    }
+
+    def 'groups without defaults still support explicit child mappings'() {
+        when: 'requesting a child mapping that provides its own controller and action'
+        def response = http('/group-no-defaults/info')
+
+        then: 'the explicit child mapping resolves successfully'
+        response.assertJsonContains(200, [
+            controller: 'urlMappingsTest',
+            action: 'index'
+        ])
+    }
+
+    def 'nested groups combine outer and inner defaults'() {
+        when: 'requesting a mapping inside nested groups'
+        def response = http('/community/topics/gallery')
+
+        then: 'the request inherits namespace and controller defaults from both groups'
+        response.assertJson(200, [
+            namespace: 'api',
+            controller: 'groupDefaults',
+            action: 'gallery'
+        ])
+    }
+
     // ========== Default Controller/Action Mapping ==========
 
     def "default mapping with controller and action"() {

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
@@ -418,6 +418,69 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             }
         }
 
+        /**
+         * Define a group with default mapping parameters that are inherited by child mappings.
+         * Child mappings can override any default by specifying the parameter explicitly.
+         *
+         * <p>Example usage:
+         * <pre>
+         * group "/api", namespace: 'api', controller: 'resource', {
+         *     "/list"(action: 'list')    // inherits namespace and controller
+         *     "/show"(action: 'show')    // inherits namespace and controller
+         * }
+         * </pre>
+         *
+         * @param defaults Map of default parameters (controller, action, namespace, plugin, view)
+         * @param uri The URI prefix for the group
+         * @param mappingsClosure The mappings in the group
+         * @since 7.1
+         */
+        public void group(Map<String, Object> defaults, String uri, Closure<?> mappingsClosure) {
+            try {
+                var parentResource = new ParentResource(null, uri, true, true);
+                parentResources.push(parentResource);
+                var mappingInfo = pushNewMetaMappingInfo();
+                applyGroupDefaults(mappingInfo, defaults);
+                var builder = new UrlGroupMappingRecursionBuilder(this, parentResource);
+                mappingsClosure.setDelegate(builder);
+                mappingsClosure.setResolveStrategy(Closure.DELEGATE_FIRST);
+                mappingsClosure.call();
+            } finally {
+                mappingInfoDeque.pop();
+                parentResources.pop();
+            }
+        }
+
+        private void applyGroupDefaults(MetaMappingInfo mappingInfo, Map<String, Object> defaults) {
+            if (defaults == null || defaults.isEmpty()) {
+                return;
+            }
+            // Merge defaults with any inherited group defaults
+            if (mappingInfo.getGroupDefaults() == null) {
+                mappingInfo.setGroupDefaults(new HashMap<>(defaults));
+            } else {
+                mappingInfo.getGroupDefaults().putAll(defaults);
+            }
+            if (defaults.containsKey(CONTROLLER)) {
+                mappingInfo.setController(defaults.get(CONTROLLER));
+            }
+            if (defaults.containsKey(ACTION)) {
+                mappingInfo.setAction(defaults.get(ACTION));
+            }
+            if (defaults.containsKey(NAMESPACE)) {
+                mappingInfo.setNamespace(defaults.get(NAMESPACE));
+            }
+            if (defaults.containsKey(PLUGIN)) {
+                mappingInfo.setPlugin(defaults.get(PLUGIN));
+            }
+            if (defaults.containsKey(VIEW)) {
+                mappingInfo.setView(defaults.get(VIEW));
+            }
+            if (defaults.containsKey(HTTP_METHOD)) {
+                mappingInfo.setHttpMethod(defaults.get(HTTP_METHOD).toString());
+            }
+        }
+
         @Override
         public Object invokeMethod(String methodName, Object arg) {
             if (binding == null) {
@@ -1231,6 +1294,12 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
                         mappingInfo.getConstraints().add(new DefaultConstrainedProperty(UrlMapping.class, parentResource.controllerName + "Id", String.class, constraintRegistry));
                     }
                 }
+                // Inherit group defaults (only explicitly set via group defaults, not from normal mapping processing)
+                var parentGroupDefaults = parentMappingInfo.getGroupDefaults();
+                if (parentGroupDefaults != null && !parentGroupDefaults.isEmpty()) {
+                    mappingInfo.setGroupDefaults(new HashMap<>(parentGroupDefaults));
+                    applyGroupDefaults(mappingInfo, parentGroupDefaults);
+                }
             }
             if (!previousConstraints.isEmpty()) {
                 mappingInfo.getConstraints().addAll(previousConstraints);
@@ -1281,6 +1350,14 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
                 uri = parentResource.uri.concat(uri);
             }
             super.group(uri, mappings);
+        }
+
+        @Override
+        public void group(Map<String, Object> defaults, String uri, Closure<?> mappings) {
+            if (parentResource != null) {
+                uri = parentResource.uri.concat(uri);
+            }
+            super.group(defaults, uri, mappings);
         }
     }
 }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
@@ -430,7 +430,7 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
          * }
          * </pre>
          *
-         * @param defaults Map of default parameters (controller, action, namespace, plugin, view)
+         * @param defaults Map of default parameters (controller, action, namespace, plugin, view, method/HTTP_METHOD)
          * @param uri The URI prefix for the group
          * @param mappingsClosure The mappings in the group
          * @since 7.1

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/MetaMappingInfo.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/MetaMappingInfo.groovy
@@ -40,4 +40,5 @@ class MetaMappingInfo {
     def redirectInfo
     String httpMethod
     List<ConstrainedProperty> constraints = []
+    Map<String, Object> groupDefaults
 }

--- a/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/GroupDefaultsSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/GroupDefaultsSpec.groovy
@@ -1,0 +1,130 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.mapping
+
+import grails.util.GrailsWebMockUtil
+import grails.web.mapping.AbstractUrlMappingsSpec
+import org.springframework.web.context.request.RequestContextHolder
+
+class GroupDefaultsSpec extends AbstractUrlMappingsSpec {
+
+    void "group defaults are inherited by child mappings"() {
+        given:
+        def holder = getUrlMappingsHolder {
+            group "/api", namespace: 'api', controller: 'resource', {
+                "/list"(action: 'list')
+                "/show"(action: 'show')
+            }
+        }
+
+        when:
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
+        def infos = holder.matchAll('/api/list')
+
+        then:
+        infos.length == 1
+        infos[0].controllerName == 'resource'
+        infos[0].namespace == 'api'
+        infos[0].actionName == 'list'
+
+        when:
+        webRequest.resetParams()
+        infos = holder.matchAll('/api/show')
+
+        then:
+        infos.length == 1
+        infos[0].controllerName == 'resource'
+        infos[0].namespace == 'api'
+        infos[0].actionName == 'show'
+    }
+
+    void "child mappings can override group defaults"() {
+        given:
+        def holder = getUrlMappingsHolder {
+            group "/api", namespace: 'api', controller: 'defaultCtrl', {
+                "/special"(controller: 'specialCtrl', action: 'handle')
+                "/normal"(action: 'index')
+            }
+        }
+
+        when:
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
+        def infos = holder.matchAll('/api/special')
+
+        then: "the child override takes effect"
+        infos.length == 1
+        infos[0].controllerName == 'specialCtrl'
+        infos[0].namespace == 'api'
+        infos[0].actionName == 'handle'
+
+        when: "the child inherits the default controller"
+        webRequest.resetParams()
+        infos = holder.matchAll('/api/normal')
+
+        then:
+        infos.length == 1
+        infos[0].controllerName == 'defaultCtrl'
+        infos[0].namespace == 'api'
+        infos[0].actionName == 'index'
+    }
+
+    void "group without defaults still works"() {
+        given:
+        def holder = getUrlMappingsHolder {
+            group "/legacy", {
+                "/foo"(controller: 'foo', action: 'bar')
+            }
+        }
+
+        when:
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
+        def infos = holder.matchAll('/legacy/foo')
+
+        then:
+        infos.length == 1
+        infos[0].controllerName == 'foo'
+        infos[0].actionName == 'bar'
+    }
+
+    void "nested groups inherit outer group defaults"() {
+        given:
+        def holder = getUrlMappingsHolder {
+            group "/community", namespace: 'community', {
+                group "/topics", controller: 'topic', {
+                    "/gallery"(action: 'gallery')
+                    "/create"(action: 'create')
+                }
+            }
+        }
+
+        when:
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
+        def infos = holder.matchAll('/community/topics/gallery')
+
+        then:
+        infos.length == 1
+        infos[0].controllerName == 'topic'
+        infos[0].namespace == 'community'
+        infos[0].actionName == 'gallery'
+    }
+
+    void cleanup() {
+        RequestContextHolder.resetRequestAttributes()
+    }
+}

--- a/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/GroupDefaultsSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/GroupDefaultsSpec.groovy
@@ -18,113 +18,114 @@
  */
 package org.grails.web.mapping
 
-import grails.util.GrailsWebMockUtil
 import grails.web.mapping.AbstractUrlMappingsSpec
-import org.springframework.web.context.request.RequestContextHolder
 
 class GroupDefaultsSpec extends AbstractUrlMappingsSpec {
 
-    void "group defaults are inherited by child mappings"() {
-        given:
-        def holder = getUrlMappingsHolder {
-            group "/api", namespace: 'api', controller: 'resource', {
-                "/list"(action: 'list')
-                "/show"(action: 'show')
+    void 'inherits group defaults in child mappings'() {
+        given: 'a group with shared namespace and controller defaults'
+        def mappings = getUrlMappingsHolder {
+            group('/api', namespace: 'api', controller: 'resource') {
+                '/list'(action: 'list')
+                '/show'(action: 'show')
             }
         }
 
-        when:
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
-        def infos = holder.matchAll('/api/list')
+        when: 'matching the list child mapping'
+        def matches = mappings.matchAll('/api/list')
 
-        then:
-        infos.length == 1
-        infos[0].controllerName == 'resource'
-        infos[0].namespace == 'api'
-        infos[0].actionName == 'list'
+        then: 'the list mapping inherits the group defaults'
+        matches.length == 1
+        with(matches.first()) {
+            namespace == 'api'
+            controllerName == 'resource'
+            actionName == 'list'
+        }
 
-        when:
-        webRequest.resetParams()
-        infos = holder.matchAll('/api/show')
+        when: 'matching the show child mapping'
+        matches = mappings.matchAll('/api/show')
 
-        then:
-        infos.length == 1
-        infos[0].controllerName == 'resource'
-        infos[0].namespace == 'api'
-        infos[0].actionName == 'show'
+        then: 'the show mapping inherits the group defaults'
+        matches.length == 1
+        with(matches.first()) {
+            namespace == 'api'
+            controllerName == 'resource'
+            actionName == 'show'
+        }
     }
 
-    void "child mappings can override group defaults"() {
-        given:
-        def holder = getUrlMappingsHolder {
-            group "/api", namespace: 'api', controller: 'defaultCtrl', {
-                "/special"(controller: 'specialCtrl', action: 'handle')
-                "/normal"(action: 'index')
+    void 'allows child mappings to override group defaults'() {
+        given: 'a group with controller defaults and an overriding child mapping'
+        def mappings = getUrlMappingsHolder {
+            group('/api', namespace: 'api', controller: 'defaultCtrl') {
+                '/special'(controller: 'specialCtrl', action: 'handle')
+                '/normal'(action: 'index')
             }
         }
 
-        when:
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
-        def infos = holder.matchAll('/api/special')
+        when: 'matching the overriding child mapping'
+        def matches = mappings.matchAll('/api/special')
 
-        then: "the child override takes effect"
-        infos.length == 1
-        infos[0].controllerName == 'specialCtrl'
-        infos[0].namespace == 'api'
-        infos[0].actionName == 'handle'
+        then: 'the child mapping uses its explicit controller and action'
+        matches.length == 1
+        with(matches.first()) {
+            namespace == 'api'
+            controllerName == 'specialCtrl'
+            actionName == 'handle'
+        }
 
-        when: "the child inherits the default controller"
-        webRequest.resetParams()
-        infos = holder.matchAll('/api/normal')
+        when: 'matching the child mapping without an override'
+        matches = mappings.matchAll('/api/normal')
 
-        then:
-        infos.length == 1
-        infos[0].controllerName == 'defaultCtrl'
-        infos[0].namespace == 'api'
-        infos[0].actionName == 'index'
+        then: 'the child mapping inherits the group defaults'
+        matches.length == 1
+        with(matches.first()) {
+            namespace == 'api'
+            controllerName == 'defaultCtrl'
+            actionName == 'index'
+        }
     }
 
-    void "group without defaults still works"() {
-        given:
-        def holder = getUrlMappingsHolder {
-            group "/legacy", {
-                "/foo"(controller: 'foo', action: 'bar')
+    void 'matches groups without defaults using explicit child mappings'() {
+        given: 'a group without default namespace or controller values'
+        def mappings = getUrlMappingsHolder {
+            group('/legacy') {
+                '/foo'(controller: 'foo', action: 'bar')
             }
         }
 
-        when:
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
-        def infos = holder.matchAll('/legacy/foo')
+        when: 'matching the explicit child mapping'
+        def matches = mappings.matchAll('/legacy/foo')
 
-        then:
-        infos.length == 1
-        infos[0].controllerName == 'foo'
-        infos[0].actionName == 'bar'
+        then: 'the explicit child mapping resolves without inherited defaults'
+        matches.length == 1
+        with(matches.first()) {
+            namespace == null
+            controllerName == 'foo'
+            actionName == 'bar'
+        }
     }
 
-    void "nested groups inherit outer group defaults"() {
-        given:
-        def holder = getUrlMappingsHolder {
-            group "/community", namespace: 'community', {
-                group "/topics", controller: 'topic', {
-                    "/gallery"(action: 'gallery')
-                    "/create"(action: 'create')
+    void 'inherits outer group defaults across nested groups'() {
+        given: 'nested groups with defaults at different levels'
+        def mappings = getUrlMappingsHolder {
+            group('/community', namespace: 'community') {
+                group('/topics', controller: 'topic') {
+                    '/gallery'(action: 'gallery')
+                    '/create'(action: 'create')
                 }
             }
         }
 
-        when:
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest()
-        def infos = holder.matchAll('/community/topics/gallery')
+        when: 'matching a child mapping inside the nested groups'
+        def matches = mappings.matchAll('/community/topics/gallery')
 
-        then:
-        infos.length == 1
-        infos[0].controllerName == 'topic'
-        infos[0].namespace == 'community'
-        infos[0].actionName == 'gallery'
-    }
-
-    void cleanup() {
-        RequestContextHolder.resetRequestAttributes()
+        then: 'the child mapping inherits defaults from the outer and inner groups'
+        matches.length == 1
+        with(matches.first()) {
+            namespace == 'community'
+            controllerName == 'topic'
+            actionName == 'gallery'
+        }
     }
 }


### PR DESCRIPTION
Dramatically simplifies group url mappings by allowing parameter inheritance.

e.g.

```groovy
group "/api", namespace: 'api', controller: 'defaultCtrl', {
    "/special"(controller: 'specialCtrl', action: 'handle')  // overrides controller
    "/normal"(action: 'index')                                // inherits controller
}
```

you can even do
```groovy
group "/members", namespace: 'api', controller: 'member', {
    "/$action?"()  // supports / and action resolution
    "/$username"(action: 'profile') 
}
```
