### PR TITLE
Upgrade to Spring Boot 3.5.13

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,7 @@ ext {
             'jna.version'                   : '5.17.0',
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
-            'spring-boot.version'           : '3.5.11',
+            'spring-boot.version'           : '3.5.13',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly


### PR DESCRIPTION
Upgrades Spring Boot from 3.5.11 to 3.5.13.

## Security

This upgrade addresses four CVEs across Spring Boot and Spring Framework 6.2.17 (bundled in 3.5.13):

**Spring Boot (fixed in 3.5.12):**
- **[CVE-2026-22731](https://spring.io/security/cve-2026-22731)** (High, CVSS 8.2) — Authentication bypass under Actuator Health group paths
- **[CVE-2026-22733](https://spring.io/security/cve-2026-22733)** (High, CVSS 8.2) — Authentication bypass under Actuator CloudFoundry endpoints

**Spring Framework 6.2.17 (bundled in Spring Boot 3.5.12+):**
- **[CVE-2026-22735](https://spring.io/security/cve-2026-22735)** (Low, CVSS 2.6) — Server-Sent Event stream corruption in Spring MVC/WebFlux
- **[CVE-2026-22737](https://spring.io/security/cve-2026-22737)** — Information disclosure via path traversal in script view templates

## Notable changes in 3.5.13

- Jackson upgraded to 2.21.2 — the Jackson team has ended support for 2.19.x and 2.20.x
- Hibernate 6.6.45.Final
- Tomcat 10.1.53
- Netty 4.1.132.Final
- Undertow 2.3.24.Final

Full release notes: https://github.com/spring-projects/spring-boot/releases/tag/v3.5.13