### PR TITLE
Fix build cache hits for FindMainClassTask and GroovyPageForkCompileTask

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -734,9 +734,6 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 it.dependsOn(project.tasks.named('compileGroovy', GroovyCompile), project.tasks.named('classes'))
                 it.mustRunAfter(project.tasks.named('classes'))
                 it.mainClassCacheFile.set(mainClassFileContainer)
-                it.outputs.upToDateWhen {
-                    mainClassFileContainer.orNull?.asFile?.exists()
-                }
             }
 
             project.afterEvaluate {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/views/gsp/GroovyPagePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/views/gsp/GroovyPagePlugin.groovy
@@ -55,6 +55,7 @@ class GroovyPagePlugin implements Plugin<Project> {
         SourceSetOutput output = mainSourceSet?.output
         FileCollection classesDirs = resolveClassesDirs(output, project)
         Provider<Directory> destDir = project.layout.buildDirectory.dir('gsp-classes/main')
+        Provider<Directory> webappDestDir = project.layout.buildDirectory.dir('gsp-classes/webapp')
         output?.dir('gsp-classes')
 
         FileCollection allClasspath = project.getObjects().fileCollection().from(
@@ -75,7 +76,7 @@ class GroovyPagePlugin implements Plugin<Project> {
         }
 
         def compileWebappGroovyPages = tasks.register('compileWebappGroovyPages', GroovyPageForkCompileTask) {
-            it.destinationDirectory.set(destDir)
+            it.destinationDirectory.set(webappDestDir)
             it.source = project.layout.projectDirectory.dir('src/main/webapp')
             it.tmpDirPath = getTmpDirPath(project)
             it.serverpath.set('/')
@@ -96,14 +97,18 @@ class GroovyPagePlugin implements Plugin<Project> {
                 war.from(destDir) { CopySpec it ->
                     it.into('WEB-INF/classes')
                 }
+                war.from(webappDestDir) { CopySpec it ->
+                    it.into('WEB-INF/classes')
+                }
             } else if (war.name == 'war') {
                 war.from(destDir)
+                war.from(webappDestDir)
             }
 
             if (war.classpath) {
-                war.classpath = war.classpath + project.files(destDir)
+                war.classpath = war.classpath + project.files(destDir, webappDestDir)
             } else {
-                war.classpath = project.files(destDir)
+                war.classpath = project.files(destDir, webappDestDir)
             }
         }
 
@@ -115,8 +120,12 @@ class GroovyPagePlugin implements Plugin<Project> {
                     jar.from(destDir) { CopySpec it ->
                         it.into('BOOT-INF/classes')
                     }
+                    jar.from(webappDestDir) { CopySpec it ->
+                        it.into('BOOT-INF/classes')
+                    }
                 } else if (jar.name == 'jar') {
                     jar.from(destDir)
+                    jar.from(webappDestDir)
                 }
             }
         }

--- a/grails-gradle/tasks/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
+++ b/grails-gradle/tasks/src/main/groovy/org/grails/gradle/plugin/run/FindMainClassTask.groovy
@@ -93,11 +93,6 @@ abstract class FindMainClassTask extends DefaultTask {
     @TaskAction
     void setMainClassProperty() {
         File cacheFile = mainClassCacheFile.get().asFile
-        if (cacheFile.exists()) {
-            // the only time this task should invoke is when gradle has deemed it necessary to run, always remove the
-            // the cache file to prevent invalid states when running tasks other than bootRun, bootJar, or bootWar
-            cacheFile.delete()
-        }
 
         if (mainClassName.isPresent()) {
             def overrideClassName = mainClassName.get()


### PR DESCRIPTION
## Summary

### FindMainClassTask: remove upToDateWhen preventing cache hits
- Remove `outputs.upToDateWhen` closure that checked if the cache file exists — per Gradle docs, returning false prevents both up-to-date checks **and** build cache loading, making `@CacheableTask` ineffective
- Remove redundant manual cache file deletion in the task action — Gradle automatically cleans task outputs before re-execution

Both checks are redundant since Gradle already tracks the `@OutputFile` annotation and knows to re-execute when the output is missing.

### GroovyPageForkCompileTask: fix overlapping outputs
- `compileGroovyPages` and `compileWebappGroovyPages` both wrote to `build/gsp-classes/main`, causing Gradle to detect overlapping outputs and disable caching for both tasks
- Give `compileWebappGroovyPages` its own output directory (`build/gsp-classes/webapp`) and update War/Jar packaging to include both directories
- Runtime classpath is unaffected because `output.dir('gsp-classes')` already registers the parent directory