### PR TITLE
Add test slicing to the build

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,5 +44,27 @@ These can be set on the command line like so:
 * `skipMongodbTests` - does not run mongo related tests
 * `skipTests` - no tests will run
 
+## Test slicing
+
+Test classes tagged with `@spock.lang.Tag('some-tag')` can be run separately.\
+Tags are inherited from superclasses, so a test class is also included if any of its ancestors is tagged.
+
+Example:
+
+```bash
+./gradlew iT -PincludeTestTags=geb
+```
+
+Available project properties:
+
+* `includeTestTags` - comma-separated list of test tags to include
+* `excludeTestTags` - comma-separated list of test tags to exclude
+
+Example with multiple tags:
+
+```bash
+./gradlew iT -PincludeTestTags=geb,api
+```
+
 ## Start a mongo docker container (containers will start by default)
 `docker run -d  --name mongo-on-docker  -p 27017:27017 mongo`

--- a/gradle/functional-test-config.gradle
+++ b/gradle/functional-test-config.gradle
@@ -95,7 +95,20 @@ tasks.withType(Test).configureEach { Test task ->
         task.outputs.dir rootProject.layout.buildDirectory.dir('mongo-test-serialize')
     }
 
-    task.useJUnitPlatform()
+    task.useJUnitPlatform {
+        if (project.hasProperty('includeTestTags')) {
+            // Will only run tests that are tagged with specific tags
+            // e.g. @spock.lang.Tag('geb')
+            // Run with: ./gradlew iT -PincludeTags=geb (comma-separated list)
+            includeTags((project.property('includeTestTags') as String).split(',')*.trim() as String[])
+        }
+        if (project.hasProperty('excludeTestTags')) {
+            // Will not run tests that are tagged with specific tags
+            // e.g. @spock.lang.Tag('geb')
+            // Run with: ./gradlew iT -PincludeTags=geb
+            excludeTags((project.property('excludeTestTags') as String).split(',')*.trim() as String[])
+        }
+    }
     task.testLogging {
         events('passed', 'skipped', 'failed', 'standardOut', 'standardError')
         showExceptions = true

--- a/gradle/functional-test-config.gradle
+++ b/gradle/functional-test-config.gradle
@@ -99,13 +99,13 @@ tasks.withType(Test).configureEach { Test task ->
         if (project.hasProperty('includeTestTags')) {
             // Will only run tests that are tagged with specific tags
             // e.g. @spock.lang.Tag('geb')
-            // Run with: ./gradlew iT -PincludeTags=geb (comma-separated list)
+            // Run with: ./gradlew iT -PincludeTestTags=geb (comma-separated list)
             includeTags((project.property('includeTestTags') as String).split(',')*.trim() as String[])
         }
         if (project.hasProperty('excludeTestTags')) {
             // Will not run tests that are tagged with specific tags
             // e.g. @spock.lang.Tag('geb')
-            // Run with: ./gradlew iT -PincludeTags=geb
+            // Run with: ./gradlew iT -PincludeTestTags=geb
             excludeTags((project.property('excludeTestTags') as String).split(',')*.trim() as String[])
         }
     }

--- a/grails-geb/src/testFixtures/groovy/grails/plugin/geb/ContainerGebSpec.groovy
+++ b/grails-geb/src/testFixtures/groovy/grails/plugin/geb/ContainerGebSpec.groovy
@@ -24,6 +24,7 @@ import geb.Page
 import geb.test.GebTestManager
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.plugin.geb.support.ContainerSupport
 import grails.plugin.geb.support.ReportingSupport
@@ -55,6 +56,8 @@ import grails.plugin.geb.support.delegate.PageDelegate
  * @author James Daugherty
  * @since 4.1
  */
+@Tag('geb')
+@Tag('container-geb')
 @CompileStatic
 abstract class ContainerGebSpec extends Specification implements ContainerSupport, ReportingSupport, BrowserDelegate, PageDelegate, DriverDelegate, DownloadSupportDelegate {
 

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/AtResourceSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/AtResourceSpec.groovy
@@ -19,11 +19,13 @@
 package functionaltests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class AtResourceSpec extends Specification implements HttpClientSupport {
 
     def "A domain class annotated with @Resources exposes an endpoint"() {

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/BookRestfulControllerSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/BookRestfulControllerSpec.groovy
@@ -19,11 +19,13 @@
 package functionaltests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class BookRestfulControllerSpec extends Specification implements HttpClientSupport {
 
     def "A RestfulController exposes an index endpoint for a domain class"() {

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/GspInWebappDirSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/GspInWebappDirSpec.groovy
@@ -19,11 +19,13 @@
 package functionaltests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class GspInWebappDirSpec extends Specification implements HttpClientSupport {
 
     def 'GSP in src/main/webapp renders'() {

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/async/AsyncPromiseSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/async/AsyncPromiseSpec.groovy
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit
 
 import functionaltests.services.AsyncProcessingService
 import spock.lang.Specification
+import spock.lang.Tag
 import spock.lang.Unroll
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -34,6 +35,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * Tests various async patterns including tasks, promises, chaining, and error handling.
  */
 @Integration
+@Tag('http-client')
 class AsyncPromiseSpec extends Specification implements HttpClientSupport {
 
     @Autowired AsyncProcessingService asyncProcessingService

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/binding/AdvancedDataBindingSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/binding/AdvancedDataBindingSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.binding
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -42,6 +43,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * - String trimming
  */
 @Integration
+@Tag('http-client')
 class AdvancedDataBindingSpec extends Specification implements HttpClientSupport {
 
     // ========== Map-Based Binding Tests ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/caching/CachingSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/caching/CachingSpec.groovy
@@ -20,6 +20,7 @@ package functionaltests.caching
 
 import spock.lang.Narrative
 import spock.lang.Specification
+import spock.lang.Tag
 
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -42,6 +43,7 @@ Grails caching provides method-level caching via annotations @Cacheable,
 @CacheEvict, and @CachePut. This allows expensive operations to be cached
 and only recomputed when necessary.
 ''')
+@Tag('http-client')
 class CachingSpec extends Specification implements HttpClientSupport {
 
     @Autowired CacheTestService cacheTestService

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/codecs/SecurityCodecsSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/codecs/SecurityCodecsSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.codecs
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -38,6 +39,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * - Hash consistency verification
  */
 @Integration
+@Tag('http-client')
 class SecurityCodecsSpec extends Specification implements HttpClientSupport {
 
     // ========== HTML Encoding Tests (XSS Prevention) ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/commanddi/CommandObjectDISpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/commanddi/CommandObjectDISpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.commanddi
 
 import spock.lang.Specification
+import spock.lang.Tag
 import spock.lang.Unroll
 
 import grails.testing.mixin.integration.Integration
@@ -29,6 +30,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * Tests the ability to inject Spring services into Grails command objects.
  */
 @Integration
+@Tag('http-client')
 class CommandObjectDISpec extends Specification implements HttpClientSupport {
 
     // ========== Basic Service Injection Tests ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/contentneg/ContentNegotiationSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/contentneg/ContentNegotiationSpec.groovy
@@ -20,6 +20,7 @@ package functionaltests.contentneg
 
 import spock.lang.Narrative
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -37,6 +38,7 @@ Grails provides content negotiation that allows the same controller action
 to return different response formats (JSON, XML, HTML) based on the client's
 Accept header or URL extension.
 ''')
+@Tag('http-client')
 class ContentNegotiationSpec extends Specification implements HttpClientSupport {
 
     // ========== Accept Header-Based Negotiation ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/cors/CorsAdvancedSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/cors/CorsAdvancedSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.cors
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -30,6 +31,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * Note: CORS is enabled for /api/** in application.yml
  */
 @Integration
+@Tag('http-client')
 class CorsAdvancedSpec extends Specification implements HttpClientSupport {
 
     // ========== Basic CORS Header Tests ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/errorhandling/ErrorHandlingSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/errorhandling/ErrorHandlingSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.errorhandling
 
 import spock.lang.Specification
+import spock.lang.Tag
 import spock.lang.Unroll
 
 import grails.testing.mixin.integration.Integration
@@ -30,6 +31,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * and error response headers.
  */
 @Integration
+@Tag('http-client')
 class ErrorHandlingSpec extends Specification implements HttpClientSupport {
 
     // ========== HTTP Status Code Tests ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/fileupload/FileUploadSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/fileupload/FileUploadSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.fileupload
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -31,6 +32,7 @@ import org.apache.grails.testing.http.client.MultipartBody
  * file validation, and metadata extraction.
  */
 @Integration
+@Tag('http-client')
 class FileUploadSpec extends Specification implements HttpClientSupport {
 
     // ========== Single File Upload Tests ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/flow/FlashChainForwardSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/flow/FlashChainForwardSpec.groovy
@@ -22,6 +22,7 @@ import java.net.http.HttpClient
 
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -38,6 +39,7 @@ import org.apache.grails.testing.http.client.TestHttpResponse
  * flash scope and chain model which rely on HTTP session state.
  */
 @Integration
+@Tag('http-client')
 class FlashChainForwardSpec extends Specification implements HttpClientSupport {
 
     @Shared

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/i18n/InternationalizationSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/i18n/InternationalizationSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.i18n
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -37,6 +38,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * - Accept-Language header handling
  */
 @Integration
+@Tag('http-client')
 class InternationalizationSpec extends Specification implements HttpClientSupport {
 
     // ========== Basic Message Resolution Tests ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/interceptors/InterceptorAdvancedMatchingSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/interceptors/InterceptorAdvancedMatchingSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.interceptors
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -34,6 +35,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * - Combined matching criteria
  */
 @Integration
+@Tag('http-client')
 class InterceptorAdvancedMatchingSpec extends Specification implements HttpClientSupport {
 
     def setup() {

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/interceptors/InterceptorOrderingSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/interceptors/InterceptorOrderingSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.interceptors
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -36,6 +37,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * - Timing/performance tracking
  */
 @Integration
+@Tag('http-client')
 class InterceptorOrderingSpec extends Specification implements HttpClientSupport {
 
     def setup() {

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/requestresponse/RequestResponseSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/requestresponse/RequestResponseSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.requestresponse
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -28,6 +29,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * headers, cookies, session management, and request attributes.
  */
 @Integration
+@Tag('http-client')
 class RequestResponseSpec extends Specification implements HttpClientSupport {
 
     // ========== Request Header Tests ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/springevents/SpringEventsSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/springevents/SpringEventsSpec.groovy
@@ -20,6 +20,7 @@ package functionaltests.springevents
 
 import spock.lang.Narrative
 import spock.lang.Specification
+import spock.lang.Tag
 
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -38,6 +39,7 @@ Spring's ApplicationEvent mechanism allows decoupled communication between
 components. Grails integrates with Spring events via @EventListener annotations
 and ApplicationEventPublisher.
 ''')
+@Tag('http-client')
 class SpringEventsSpec extends Specification implements HttpClientSupport {
 
     @Autowired EventListenerService eventListenerService

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/taglib/TagLibSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/taglib/TagLibSpec.groovy
@@ -19,6 +19,7 @@
 package functionaltests.taglib
 
 import spock.lang.Specification
+import spock.lang.Tag
 import spock.lang.Unroll
 
 import grails.testing.mixin.integration.Integration
@@ -29,6 +30,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
  * Tests both custom tag libraries and built-in Grails tags.
  */
 @Integration
+@Tag('http-client')
 class TagLibSpec extends Specification implements HttpClientSupport {
 
     // ========== Custom Tag: hello ==========

--- a/grails-test-examples/app1/src/integration-test/groovy/functionaltests/urlmappings/UrlMappingsSpec.groovy
+++ b/grails-test-examples/app1/src/integration-test/groovy/functionaltests/urlmappings/UrlMappingsSpec.groovy
@@ -20,6 +20,7 @@ package functionaltests.urlmappings
 
 import spock.lang.Narrative
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
@@ -35,6 +36,7 @@ import org.apache.grails.testing.http.client.HttpClientSupport
 Grails URL mappings provide flexible routing of HTTP requests to controller actions.
 This includes path variables, constraints, HTTP method-based routing, and redirects.
 ''')
+@Tag('http-client')
 class UrlMappingsSpec extends Specification implements HttpClientSupport {
 
     // ========== Static Path Mappings ==========

--- a/grails-test-examples/async-events-pubsub-demo/src/integration-test/groovy/pubsub/demo/TaskControllerSpec.groovy
+++ b/grails-test-examples/async-events-pubsub-demo/src/integration-test/groovy/pubsub/demo/TaskControllerSpec.groovy
@@ -19,11 +19,13 @@
 package pubsub.demo
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class TaskControllerSpec extends Specification implements HttpClientSupport {
 
     void 'test async error handling'() {

--- a/grails-test-examples/cache/src/integration-test/groovy/com/demo/AdvancedCachingIntegrationSpec.groovy
+++ b/grails-test-examples/cache/src/integration-test/groovy/com/demo/AdvancedCachingIntegrationSpec.groovy
@@ -20,6 +20,7 @@ package com.demo
 
 import spock.lang.Narrative
 import spock.lang.Specification
+import spock.lang.Tag
 
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -42,6 +43,7 @@ Advanced Grails caching scenarios tested via HTTP endpoints.
 These tests verify that complex caching behaviors work correctly
 in a full application context.
 ''')
+@Tag('http-client')
 class AdvancedCachingIntegrationSpec extends Specification implements HttpClientSupport {
 
     @Autowired AdvancedCachingService advancedCachingService

--- a/grails-test-examples/demo33/src/integration-test/groovy/demo/JsonControllerSpec.groovy
+++ b/grails-test-examples/demo33/src/integration-test/groovy/demo/JsonControllerSpec.groovy
@@ -19,11 +19,13 @@
 package demo
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class JsonControllerSpec extends Specification implements HttpClientSupport {
 
     void "test a json view is rendered"() {

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/src/integration-test/groovy/functionaltests/MultiDataSourceWithSessionSpec.groovy
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/src/integration-test/groovy/functionaltests/MultiDataSourceWithSessionSpec.groovy
@@ -21,12 +21,14 @@ package functionaltests
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Stepwise
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Stepwise
 @Integration
+@Tag('http-client')
 class MultiDataSourceWithSessionSpec extends Specification implements HttpClientSupport {
 
     @Issue('https://github.com/apache/grails-core/issues/14333')

--- a/grails-test-examples/hibernate5/issue450/src/integration-test/groovy/example/BookControllerSpec.groovy
+++ b/grails-test-examples/hibernate5/issue450/src/integration-test/groovy/example/BookControllerSpec.groovy
@@ -19,11 +19,13 @@
 package example
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class BookControllerSpec extends Specification implements HttpClientSupport {
 
     void 'test books can be fetched'() {

--- a/grails-test-examples/issue-11102/src/integration-test/groovy/issue11102/TestControllerSpec.groovy
+++ b/grails-test-examples/issue-11102/src/integration-test/groovy/issue11102/TestControllerSpec.groovy
@@ -19,11 +19,13 @@
 package issue11102
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class TestControllerSpec extends Specification implements HttpClientSupport {
 
     void 'can forward a request from a GET to another GET action'() {

--- a/grails-test-examples/issue-11767/src/integration-test/groovy/issue11767/app/ConfigLoadingSpec.groovy
+++ b/grails-test-examples/issue-11767/src/integration-test/groovy/issue11767/app/ConfigLoadingSpec.groovy
@@ -19,12 +19,14 @@
 package issue11767.app
 
 import spock.lang.Specification
+import spock.lang.Tag
 import spock.lang.Unroll
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class ConfigLoadingSpec extends Specification implements HttpClientSupport {
 
     @Unroll

--- a/grails-test-examples/issue-15228/src/integration-test/groovy/issue11767/app/GsonViewRespondSpec.groovy
+++ b/grails-test-examples/issue-15228/src/integration-test/groovy/issue11767/app/GsonViewRespondSpec.groovy
@@ -19,11 +19,13 @@
 package issue11767.app
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class GsonViewRespondSpec extends Specification implements HttpClientSupport {
 
     void 'respond with Error gson view'() {

--- a/grails-test-examples/issue-views-182/src/integration-test/groovy/views182/CustomErrorSpec.groovy
+++ b/grails-test-examples/issue-views-182/src/integration-test/groovy/views182/CustomErrorSpec.groovy
@@ -19,11 +19,13 @@
 package views182
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class CustomErrorSpec extends Specification implements HttpClientSupport {
 
     void 'it is possible to use gson views for handling exception errors'() {

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzAdvancedSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzAdvancedSpec.groovy
@@ -27,6 +27,7 @@ import micronaut.client.MicronautHeaderClient
 import micronaut.client.MicronautTestClient
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+import spock.lang.Tag
 
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -34,6 +35,7 @@ import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class MicronautErsatzAdvancedSpec extends Specification implements HttpClientSupport {
 
     @Autowired MicronautApplicationContext micronautContext

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzPatternSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzPatternSpec.groovy
@@ -27,6 +27,7 @@ import micronaut.client.MicronautReactiveClient
 import micronaut.client.MicronautRetryableClient
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+import spock.lang.Tag
 
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -34,6 +35,7 @@ import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class MicronautErsatzPatternSpec extends Specification implements HttpClientSupport {
 
     @Autowired ExternalApiService externalApiService

--- a/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzRoundtripSpec.groovy
+++ b/grails-test-examples/micronaut/src/integration-test/groovy/micronaut/MicronautErsatzRoundtripSpec.groovy
@@ -24,6 +24,7 @@ import io.micronaut.http.client.exceptions.HttpClientException
 import spock.lang.AutoCleanup
 import spock.lang.Retry
 import spock.lang.Specification
+import spock.lang.Tag
 
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -31,6 +32,7 @@ import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class MicronautErsatzRoundtripSpec extends Specification implements HttpClientSupport {
 
     @Autowired ExternalApiService externalApiService

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/BookSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/BookSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class BookSpec extends Specification implements HttpClientSupport {
 
     void 'Test errors view rendering'() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/BulletinSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/BulletinSpec.groovy
@@ -20,11 +20,13 @@ package functional.tests
 
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class BulletinSpec extends Specification implements HttpClientSupport {
 
     @Issue('https://github.com/apache/grails-views/issues/175')

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/CircularSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/CircularSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class CircularSpec extends Specification implements HttpClientSupport {
 
     void "test deep rendering of circular domain relationships"() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/CustomerSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/CustomerSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class CustomerSpec extends Specification implements HttpClientSupport {
 
     void "Test that circular references are correctly rendered for one to many relationship"() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/EmbeddedSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/EmbeddedSpec.groovy
@@ -20,11 +20,13 @@ package functional.tests
 
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class EmbeddedSpec extends Specification implements HttpClientSupport {
 
     void 'Test render can handle a domain with an embedded src/groovy class'() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/InheritanceSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/InheritanceSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class InheritanceSpec extends Specification implements HttpClientSupport {
 
     void "Test template is found for proxy instance that is initialized"() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ModelInterceptorIntSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ModelInterceptorIntSpec.groovy
@@ -19,6 +19,7 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 import spock.lang.Unroll
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,6 +28,7 @@ import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class ModelInterceptorIntSpec extends Specification implements HttpClientSupport {
 
     @Autowired

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ObjectTemplateSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ObjectTemplateSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class ObjectTemplateSpec extends Specification implements HttpClientSupport {
 
     void "Test that if there is a global /object/_object template it is rendered if no template found"() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/PersonInheritanceSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/PersonInheritanceSpec.groovy
@@ -20,11 +20,13 @@ package functional.tests
 
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class PersonInheritanceSpec extends Specification implements HttpClientSupport {
 
     void 'test template inheritance produces correct json'() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ProductSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ProductSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class ProductSpec extends Specification implements HttpClientSupport {
 
     void testEmptyProducts() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ProjectSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ProjectSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class ProjectSpec extends Specification implements HttpClientSupport {
 
     void "Test that circular references are correctly rendered for many to many relationship"() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ProxySpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/ProxySpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class ProxySpec extends Specification implements HttpClientSupport {
 
     void "Test template is found for proxy instance that is initialized"() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/TeamSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/TeamSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class TeamSpec extends Specification implements HttpClientSupport {
 
     void 'Test association template rendering'() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/TestControllerSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/TestControllerSpec.groovy
@@ -20,11 +20,13 @@ package functional.tests
 
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class TestControllerSpec extends Specification implements HttpClientSupport {
 
     @Issue('https://github.com/apache/grails-core/issues/10582')

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/TestGmlControllerSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/TestGmlControllerSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class TestGmlControllerSpec extends Specification implements HttpClientSupport {
 
     void "Test GML response from action that returns a model"() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/TestGsonControllerSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/TestGsonControllerSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class TestGsonControllerSpec extends Specification implements HttpClientSupport {
 
     void 'Test that responding with a map is possible'() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/VehicleSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/VehicleSpec.groovy
@@ -19,11 +19,13 @@
 package functional.tests
 
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class VehicleSpec extends Specification implements HttpClientSupport {
 
     void "Test that domain subclasses render their properties"() {

--- a/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/api/NamespacedBookSpec.groovy
+++ b/grails-test-examples/views-functional-tests/src/integration-test/groovy/functional/tests/api/NamespacedBookSpec.groovy
@@ -20,11 +20,13 @@ package functional.tests.api
 
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Tag
 
 import grails.testing.mixin.integration.Integration
 import org.apache.grails.testing.http.client.HttpClientSupport
 
 @Integration
+@Tag('http-client')
 class NamespacedBookSpec extends Specification implements HttpClientSupport {
 
     void 'test view rendering with a namespace'() {


### PR DESCRIPTION
Add test slicing via Gradle properties `includeTestTags` and `excludeTestTags` and tag test classes with `geb`, `container-geb`, and `http-client`.