### PR TITLE
fix: add Groovy proxy support to HibernateProxyHandler.isInitialized()

### DIFF
--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/proxy/GroovyProxyInterceptorLogic.java
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/proxy/GroovyProxyInterceptorLogic.java
@@ -109,5 +109,17 @@ public class GroovyProxyInterceptorLogic {
         return null;
     }
 
+    /**
+     * Check if a Groovy proxy is initialized.
+     * @return {@code true} if initialized, {@code false} if not initialized, or {@code null} if the object is not a Groovy proxy
+     */
+    public static Boolean isInitialized(Object o) {
+        ProxyInstanceMetaClass proxyMc = getProxyInstanceMetaClass(o);
+        if (proxyMc != null) {
+            return proxyMc.isProxyInitiated();
+        }
+        return null;
+    }
+
     public record InterceptorState(String entityName, Class<?> persistentClass, Object identifier) {}
 }

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/proxy/HibernateProxyHandler.java
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/proxy/HibernateProxyHandler.java
@@ -58,9 +58,9 @@ public class HibernateProxyHandler implements ProxyHandler, ProxyFactory {
             return li.wasInitialized();
         }
 
-        Boolean groovyProxyInit = GroovyProxyInterceptorLogic.isInitialized(o);
-        if (groovyProxyInit != null) {
-            return groovyProxyInit;
+        Boolean groovyProxyInitialized = GroovyProxyInterceptorLogic.isInitialized(o);
+        if (groovyProxyInitialized != null) {
+            return groovyProxyInitialized;
         }
 
         return Hibernate.isInitialized(o);

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/proxy/HibernateProxyHandler.java
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/proxy/HibernateProxyHandler.java
@@ -58,6 +58,11 @@ public class HibernateProxyHandler implements ProxyHandler, ProxyFactory {
             return li.wasInitialized();
         }
 
+        Boolean groovyProxyInit = GroovyProxyInterceptorLogic.isInitialized(o);
+        if (groovyProxyInit != null) {
+            return groovyProxyInit;
+        }
+
         return Hibernate.isInitialized(o);
     }
 

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/proxy/HibernateProxyHandler7Spec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/proxy/HibernateProxyHandler7Spec.groovy
@@ -25,6 +25,7 @@ import org.apache.grails.data.testing.tck.domains.Location
 import org.apache.grails.data.testing.tck.domains.Person
 import org.apache.grails.data.testing.tck.domains.Pet
 import org.grails.datastore.gorm.proxy.GroovyProxyFactory
+import org.grails.datastore.gorm.proxy.ProxyInstanceMetaClass
 import org.hibernate.Hibernate
 import spock.lang.Shared
 
@@ -156,6 +157,7 @@ class HibernateProxyHandler7Spec extends HibernateGormDatastoreSpec {
         Location proxyLocation = Location.proxy(location.id)
 
         expect:
+        proxyLocation.metaClass instanceof ProxyInstanceMetaClass
         !proxyHandler.isInitialized(proxyLocation)
 
         cleanup:

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/proxy/HibernateProxyHandler7Spec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/proxy/HibernateProxyHandler7Spec.groovy
@@ -145,6 +145,23 @@ class HibernateProxyHandler7Spec extends HibernateGormDatastoreSpec {
         proxyHandler.isInitialized(location)
     }
 
+    void "test isInitialized for a Groovy proxy before initialization"() {
+        given:
+        def originalFactory = manager.session.mappingContext.proxyFactory
+        manager.session.mappingContext.proxyFactory = new GroovyProxyFactory()
+        Location location = new Location(name: "Test Location").save(flush: true)
+        manager.session.clear()
+        manager.hibernateSession.clear()
+
+        Location proxyLocation = Location.proxy(location.id)
+
+        expect:
+        !proxyHandler.isInitialized(proxyLocation)
+
+        cleanup:
+        manager.session.mappingContext.proxyFactory = originalFactory
+    }
+
     void "test unwrap for a Groovy proxy"() {
         given:
         def originalFactory = manager.session.mappingContext.proxyFactory


### PR DESCRIPTION
## Summary

- **Bug**: `HibernateProxyHandler.isInitialized()` in Hibernate 7 was missing Groovy proxy support, causing uninitialized Groovy proxies to be incorrectly reported as initialized. The fallback `Hibernate.isInitialized()` returns `true` for any non-Hibernate object, masking the bug.
- **Fix**: Add `GroovyProxyInterceptorLogic.isInitialized()` helper that checks `ProxyInstanceMetaClass.isProxyInitiated()`, and invoke it from `HibernateProxyHandler.isInitialized()` before the Hibernate fallback.
- **Parity**: The Hibernate 5 implementation already had this check. This restores behavioral parity with Hibernate 5.

## Changes

| File | Change |
|------|--------|
| `GroovyProxyInterceptorLogic.java` | Add `isInitialized(Object)` static helper method |
| `HibernateProxyHandler.java` | Call `GroovyProxyInterceptorLogic.isInitialized()` before `Hibernate.isInitialized()` fallback |
| `HibernateProxyHandler7Spec.groovy` | Add test: "test isInitialized for a Groovy proxy before initialization" |

## Testing

All 21 `HibernateProxyHandler7Spec` tests pass, including the new Groovy proxy `isInitialized` test.