### PR TITLE
fix: normalize Groovy GString to String in Hibernate 7 criteria queries

### DIFF
--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/query/PredicateGenerator.java
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/query/PredicateGenerator.java
@@ -219,11 +219,11 @@ public class PredicateGenerator {
         } else if (pc instanceof Query.Like c) {
             return cb.like((Expression<String>) fullyQualifiedPath, c.getValue().toString());
         } else if (pc instanceof Query.Equals c) {
-            return cb.equal(fullyQualifiedPath, c.getValue());
+            return cb.equal(fullyQualifiedPath, normalizeValue(c.getValue()));
         } else if (pc instanceof Query.NotEquals c) {
-            return cb.or(cb.notEqual(fullyQualifiedPath, c.getValue()), cb.isNull(fullyQualifiedPath));
+            return cb.or(cb.notEqual(fullyQualifiedPath, normalizeValue(c.getValue())), cb.isNull(fullyQualifiedPath));
         } else if (pc instanceof Query.IdEquals c) {
-            return cb.equal(root.get("id"), c.getValue());
+            return cb.equal(root.get("id"), normalizeValue(c.getValue()));
         } else if (pc instanceof Query.GreaterThan c) {
             return cb.gt((Expression<? extends Number>) fullyQualifiedPath, getNumericValue(c));
         } else if (pc instanceof Query.GreaterThanEquals c) {
@@ -233,9 +233,9 @@ public class PredicateGenerator {
         } else if (pc instanceof Query.LessThanEquals c) {
             return cb.le((Expression<? extends Number>) fullyQualifiedPath, getNumericValue(c));
         } else if (pc instanceof Query.SizeEquals c) {
-            return cb.equal(cb.size((Expression) fullyQualifiedPath), c.getValue());
+            return cb.equal(cb.size((Expression) fullyQualifiedPath), normalizeValue(c.getValue()));
         } else if (pc instanceof Query.SizeNotEquals c) {
-            return cb.notEqual(cb.size((Expression) fullyQualifiedPath), c.getValue());
+            return cb.notEqual(cb.size((Expression) fullyQualifiedPath), normalizeValue(c.getValue()));
         } else if (pc instanceof Query.SizeGreaterThan c) {
             return cb.gt(cb.size((Expression) fullyQualifiedPath), getNumericValue(c));
         } else if (pc instanceof Query.SizeGreaterThanEquals c) {
@@ -245,7 +245,7 @@ public class PredicateGenerator {
         } else if (pc instanceof Query.SizeLessThanEquals c) {
             return cb.le(cb.size((Expression) fullyQualifiedPath), getNumericValue(c));
         } else if (pc instanceof Query.Between c) {
-            return cb.between((Expression) fullyQualifiedPath, (Comparable) c.getFrom(), (Comparable) c.getTo());
+            return cb.between((Expression) fullyQualifiedPath, (Comparable) normalizeValue(c.getFrom()), (Comparable) normalizeValue(c.getTo()));
         }
         return null;
     }
@@ -539,6 +539,19 @@ public class PredicateGenerator {
         return criterion instanceof Query.In ?
                 ((Query.In) criterion).getSubquery() :
                 ((Query.NotIn) criterion).getSubquery();
+    }
+
+    /**
+     * Normalizes a criterion value for use with JPA Criteria API.
+     * Hibernate 7's SqmCriteriaNodeBuilder requires strict Java types and cannot
+     * coerce Groovy types like GString. This method converts CharSequence (including
+     * GString) to String so Hibernate can process the value correctly.
+     */
+    private static Object normalizeValue(Object value) {
+        if (value instanceof CharSequence && !(value instanceof String)) {
+            return value.toString();
+        }
+        return value;
     }
 
     private Number getNumericValue(Query.PropertyCriterion criterion) {

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/connections/MultipleDataSourceConnectionsSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/connections/MultipleDataSourceConnectionsSpec.groovy
@@ -26,7 +26,6 @@ import org.grails.orm.hibernate.HibernateDatastore
 import org.hibernate.Session
 import org.hibernate.dialect.H2Dialect
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -119,7 +118,6 @@ class MultipleDataSourceConnectionsSpec extends Specification {
         }
     }
 
-    @PendingFeature(reason = 'executeQuery with named parameters fails on multi-datasource entity in Hibernate 7 - QueryParameterException')
     void "static GORM operations use first non-default datasource for multi datasource entity"() {
         given: "a unique book name"
         def uniqueName = "The Stand ${UUID.randomUUID()}"


### PR DESCRIPTION
## Summary

- Hibernate 7's `SqmCriteriaNodeBuilder.valueParameter()` throws `HibernateException` when encountering Groovy's `GStringImpl`, unlike Hibernate 5 which silently coerced it
- Added `normalizeValue()` utility method to `PredicateGenerator` that converts `CharSequence` (including GString) to `String` before passing to JPA Criteria predicates
- Applied to `Equals`, `NotEquals`, `IdEquals`, `SizeEquals`, `SizeNotEquals`, and `Between` handlers (`Like`/`ILike` already called `.toString()`)
- Removed `@PendingFeature` from `MultipleDataSourceConnectionsSpec` - all 4 tests now pass

## Root Cause

The `@PendingFeature` annotation stated `executeQuery` with named parameters failed, but the actual failure was in `withCriteria` where a Groovy GString (`"The Stand ${UUID.randomUUID()}"`) was passed as a criteria value. Hibernate 7's strict type checking rejected the `GStringImpl` type.

The HQL path (`HibernateHqlQuery.populateQueryWithNamedArguments()`) already handled `CharSequence` correctly at line 295-296.

## Test Results

- **H7**: 2086 tests completed, 0 failed, 68 skipped
- **H5**: 639 passed, 0 failed
- **Shared modules** (`grails-datastore-core`, `grails-datamapping-core`): BUILD SUCCESSFUL

## Files Changed

- `grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/query/PredicateGenerator.java` - Added `normalizeValue()`, applied to 6 criterion handlers
- `grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/connections/MultipleDataSourceConnectionsSpec.groovy` - Removed `@PendingFeature` and unused import