### PR TITLE
Spring Boot Follow-ups

### DIFF
--- a/grails-core/build.gradle
+++ b/grails-core/build.gradle
@@ -44,15 +44,12 @@ dependencies {
     implementation 'com.github.ben-manes.caffeine:caffeine'
     api 'org.apache.groovy:groovy'
     api 'org.springframework.boot:spring-boot'
+    api 'org.springframework.boot:spring-boot-web-server'
     api 'org.springframework:spring-core'
     api 'org.springframework:spring-tx'
     api 'org.springframework:spring-beans'
     api 'org.springframework:spring-context'
     api 'org.springframework.boot:spring-boot-autoconfigure'
-
-    implementation 'org.springframework.boot:spring-boot-web-server', {
-        // impl: WebServerApplicationContext
-    }
 
     compileOnly 'org.springframework:spring-test'
     compileOnly 'org.apache.groovy:groovy-templates'

--- a/grails-web-boot/build.gradle
+++ b/grails-web-boot/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     testImplementation project(':grails-controllers')
 
     testImplementation 'org.apache.tomcat.embed:tomcat-embed-core'
+    testImplementation 'org.springframework.boot:spring-boot-tomcat'
     testRuntimeOnly project(':grails-url-mappings')
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'

--- a/grails-web-boot/src/test/groovy/grails/boot/EmbeddedContainerWithGrailsSpec.groovy
+++ b/grails-web-boot/src/test/groovy/grails/boot/EmbeddedContainerWithGrailsSpec.groovy
@@ -18,31 +18,63 @@
  */
 package grails.boot
 
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory
+import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.web.context.support.StandardServletEnvironment
+
 import grails.artefact.Artefact
 import grails.boot.config.GrailsAutoConfiguration
 import grails.web.Controller
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import spock.lang.PendingFeature
+import org.springframework.boot.web.server.servlet.context.AnnotationConfigServletWebServerApplicationContext
+import org.springframework.context.annotation.Bean
 import spock.lang.Specification
 
+import org.apache.grails.core.plugins.DefaultPluginDiscovery
+import org.apache.grails.core.plugins.PluginDiscovery
+
 /**
- * Tests loading Grails in an embedded server configuration.
- *
- * TODO: Rework for Spring Boot 4.0 modularized embedded server APIs.
- * Embedded server classes moved to spring-boot-web-server and spring-boot-tomcat modules
- * and require updated test patterns.
+ * Created by graemerocher on 28/05/14.
  */
 class EmbeddedContainerWithGrailsSpec extends Specification {
 
-    @PendingFeature(reason = "TODO: BOOT4 - Embedded server test infrastructure needs rework for Spring Boot 4.0 modularized APIs (spring-boot-web-server, spring-boot-tomcat)")
+    AnnotationConfigServletWebServerApplicationContext context
+
+    void cleanup() {
+        context.close()
+    }
+
     void "Test that you can load Grails in an embedded server config"() {
-        // TODO: Restore embedded server assertions after reworking for Spring Boot 4.0 modularized APIs
-        expect:
-        false
+        given: 'bootstrapped context'
+        ConfigurableEnvironment env = new StandardServletEnvironment()
+        PluginDiscovery pluginDiscovery = new DefaultPluginDiscovery()
+        pluginDiscovery.init(env)
+
+        when: "An embedded server config is created"
+        this.context = new AnnotationConfigServletWebServerApplicationContext()
+        // simulate spring's environment setup
+        this.context.setEnvironment(env)
+        // simulate what the bootstrap registry would do
+        this.context.registerBean(PluginDiscovery.BEAN_NAME, PluginDiscovery, () -> pluginDiscovery)
+        // mark the application for actual load
+        this.context.register(Application)
+        // load it
+        this.context.refresh()
+
+        then: "The context is valid"
+        context != null
+        new URL("http://localhost:${context.webServer.port}/foo/bar").text == 'hello world'
+        new URL("http://localhost:${context.webServer.port}/foos").text == 'all foos'
     }
 
     @EnableAutoConfiguration
     static class Application extends GrailsAutoConfiguration {
+
+        @Bean
+        ConfigurableServletWebServerFactory webServerFactory() {
+            new TomcatServletWebServerFactory(0)
+        }
     }
 
 }

--- a/grails-web-boot/src/test/groovy/grails/boot/GrailsSpringApplicationSpec.groovy
+++ b/grails-web-boot/src/test/groovy/grails/boot/GrailsSpringApplicationSpec.groovy
@@ -18,28 +18,45 @@
  */
 package grails.boot
 
+import org.springframework.boot.web.server.servlet.context.AnnotationConfigServletWebServerApplicationContext
+
 import grails.boot.config.GrailsAutoConfiguration
+import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import spock.lang.PendingFeature
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory
+import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory
+import org.springframework.context.annotation.Bean
 import spock.lang.Specification
 
 /**
- * Tests running Grails via SpringApplication with an embedded server.
- *
- * TODO: Rework for Spring Boot 4.0 modularized embedded server APIs.
- * Embedded server classes moved to spring-boot-web-server and spring-boot-tomcat modules
- * and require updated test patterns.
+ * Created by graemerocher on 28/05/14.
  */
 class GrailsSpringApplicationSpec extends Specification {
 
-    @PendingFeature(reason = "TODO: BOOT4 - Embedded server test infrastructure needs rework for Spring Boot 4.0 modularized APIs (spring-boot-web-server, spring-boot-tomcat)")
-    void "Test run Grails via SpringApplication"() {
-        // TODO: Restore embedded server assertions after reworking for Spring Boot 4.0 modularized APIs
-        expect:
-        false
+    AnnotationConfigServletWebServerApplicationContext context
+
+    void cleanup() {
+        context.close()
     }
+
+    void "Test run Grails via SpringApplication"() {
+        when: "SpringApplication is used to run a Grails app"
+        SpringApplication springApplication = new SpringApplication(Application)
+        springApplication.allowBeanDefinitionOverriding = true
+        context = (AnnotationConfigServletWebServerApplicationContext) springApplication.run()
+
+        then: "The application runs"
+        context != null
+        new URL("http://localhost:${context.webServer.port}/foo/bar").text == 'hello world'
+    }
+
 
     @EnableAutoConfiguration
     static class Application extends GrailsAutoConfiguration {
+
+        @Bean
+        ConfigurableServletWebServerFactory webServerFactory() {
+            TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory(0)
+        }
     }
 }


### PR DESCRIPTION
@jamesfredley your AI was hallucinating on these tests.  The embedded servlet context class is now 'AnnotationConfigServletWebServerApplicationContext'.  The tests pass once this was updated. 

I've also restored the `@CompileStatic` that was removed by your PR in the GrailsApplicationBuilder