### PR TITLE
Do not fail mergeTestReports for partial previous test task runs

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/TestPhasesGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/TestPhasesGradlePlugin.groovy
@@ -25,6 +25,8 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.SourceSetOutput
@@ -139,19 +141,42 @@ class TestPhasesGradlePlugin implements Plugin<Project> {
 
     private static void registerMergeTestReports(Project project) {
         project.tasks.register(MERGE_TEST_REPORTS_TASK_NAME, TestReport) {
-            it.mustRunAfter(project.tasks.withType(Test).toArray())
+            it.mustRunAfter(project.tasks.withType(Test))
             it.destinationDirectory.set(project.layout.buildDirectory.dir('reports/tests'))
             it.testResults.from(
+                    // WARNING: this must be a path & not a reference to the test task so Gradle doesn't force other tests to run
                     project.files(project.layout.buildDirectory.dir('test-results/test/binary'))
             )
+
+            def testResultDirectory = project.layout.buildDirectory.dir('test-results')
+            it.doFirst {
+                // because a test task could be interrupted, support cleaning up bad data to prevent unnecessary errors from previous, partial runs
+                cleanOrphanedBinaryResults(testResultDirectory)
+            }
         }
     }
 
     private static void addPhaseToMergeTestReports(Project project, String phaseName) {
         project.tasks.named(MERGE_TEST_REPORTS_TASK_NAME, TestReport) {
             it.testResults.from(
-                    project.files(project.layout.buildDirectory.dir("test-results/${phaseName}/binary"))
+                    // WARNING: this must be a path & not a reference to the test task so Gradle doesn't force other tests to run
+                    project.files(project.layout.buildDirectory.dir("test-results/${phaseName}/binary" as String))
             )
+        }
+    }
+
+    private static void cleanOrphanedBinaryResults(Provider<Directory> testResultDirectory) {
+        File testResultsDir = testResultDirectory.get().asFile
+        if (!testResultsDir.exists()) {
+            return
+        }
+        testResultsDir.eachDir { File phaseDir ->
+            File binaryDir = new File(phaseDir, 'binary')
+            File outputBin = new File(binaryDir, 'output.bin')
+            File outputBinIdx = new File(binaryDir, 'output.bin.idx')
+            if (outputBin.exists() && !outputBinIdx.exists()) {
+                outputBin.delete()
+            }
         }
     }
 

--- a/grails-test-examples/test-phases/grails-app/controllers/testphases/UrlMappings.groovy
+++ b/grails-test-examples/test-phases/grails-app/controllers/testphases/UrlMappings.groovy
@@ -25,10 +25,6 @@ class UrlMappings {
             constraints {
             }
         }
-
-        '/'(view: '/index')
-        '500'(view: '/error')
-        '404'(view: '/notFound')
     }
 
 }


### PR DESCRIPTION
If a user: 
1. runs integrationTest - and it's terminated (OOM, etc) before finish 
2. then runs smokeTest 

The mergeTestReports will fail b/c it's partially run, an error like this will show: 

      Caused by: java.lang.IllegalStateException: Test outputs data file '$PROJECT_DIR/build/test-results/gebTest/binary/output.bin' exists but the index file '$PROJECT_DIR/build/test-results/gebTest/binary/output.bin.idx' does not
        at org.gradle.api.internal.tasks.testing.junit.result.TestOutputStore$Reader.<init>(TestOutputStore.java:231)
        at org.gradle.api.internal.tasks.testing.junit.result.TestOutputStore.reader(TestOutputStore.java:391)
        at org.gradle.api.internal.tasks.testing.junit.result.TestOutputStoreBackedResultsProvider.<init>(TestOutputStoreBackedResultsProvider.java:28)
        at org.gradle.api.internal.tasks.testing.junit.result.BinaryResultBackedTestResultsProvider.<init>(BinaryResultBackedTestResultsProvider.java:27)
        at org.gradle.util.internal.CollectionUtils.collect(CollectionUtils.java:192)
        at org.gradle.api.internal.tasks.testing.LegacyTestReportGenerator.lambda$createAggregateProvider$1(LegacyTestReportGenerator.java:54)
        at org.gradle.api.internal.tasks.testing.LegacyTestReportGenerator.hasResults(LegacyTestReportGenerator.java:71)
        at org.gradle.api.tasks.testing.TestReport.generateReport(TestReport.java:186)
        ... 125 more


This is because the index file isn't generated until after the task finishes.  This PR simply removes these invalid states so the test report task doesn't fail.