### PR TITLE
Fix forge dockerBuildNative by using a Java 21 GraalVM base image

### DIFF
--- a/grails-forge/grails-forge-analytics-postgres/build.gradle
+++ b/grails-forge/grails-forge-analytics-postgres/build.gradle
@@ -60,7 +60,10 @@ micronaut {
 }
 tasks.named('dockerfileNative') {
     // https://www.graalvm.org/latest/docs/getting-started/container-images/
-    baseImage('ghcr.io/graalvm/jdk:ol8-java17-22.3.3')
+    // The GraalVM Native Image Community image bundles the `native-image` tool and matches the
+    // Java 21 baseline used to compile the Forge modules. The previous Java 17 image caused
+    // dockerBuildNative to fail with `UnsupportedClassVersionError` (class file version 65.0).
+    baseImage('ghcr.io/graalvm/native-image-community:21')
 }
 
 tasks.named('dockerBuildNative') {

--- a/grails-forge/grails-forge-analytics-postgres/build.gradle
+++ b/grails-forge/grails-forge-analytics-postgres/build.gradle
@@ -63,7 +63,9 @@ tasks.named('dockerfileNative') {
     // The GraalVM Native Image Community image bundles the `native-image` tool and matches the
     // Java 21 baseline used to compile the Forge modules. The previous Java 17 image caused
     // dockerBuildNative to fail with `UnsupportedClassVersionError` (class file version 65.0).
-    baseImage('ghcr.io/graalvm/native-image-community:21')
+    // Pin to a specific patch + OS so dockerBuildNative is reproducible (21.0.2 is the final
+    // GraalVM Community release for JDK 21; later GraalVM Community releases target JDK 22+).
+    baseImage('ghcr.io/graalvm/native-image-community:21.0.2-ol9')
 }
 
 tasks.named('dockerBuildNative') {

--- a/grails-forge/grails-forge-web-netty/build.gradle
+++ b/grails-forge/grails-forge-web-netty/build.gradle
@@ -59,7 +59,10 @@ micronaut {
 }
 tasks.named('dockerfileNative') {
     // https://www.graalvm.org/latest/docs/getting-started/container-images/
-    baseImage('ghcr.io/graalvm/jdk:ol8-java17-22.3.3')
+    // The GraalVM Native Image Community image bundles the `native-image` tool and matches the
+    // Java 21 baseline used to compile the Forge modules. The previous Java 17 image caused
+    // dockerBuildNative to fail with `UnsupportedClassVersionError` (class file version 65.0).
+    baseImage('ghcr.io/graalvm/native-image-community:21')
 }
 
 tasks.named('dockerBuildNative') {

--- a/grails-forge/grails-forge-web-netty/build.gradle
+++ b/grails-forge/grails-forge-web-netty/build.gradle
@@ -62,7 +62,9 @@ tasks.named('dockerfileNative') {
     // The GraalVM Native Image Community image bundles the `native-image` tool and matches the
     // Java 21 baseline used to compile the Forge modules. The previous Java 17 image caused
     // dockerBuildNative to fail with `UnsupportedClassVersionError` (class file version 65.0).
-    baseImage('ghcr.io/graalvm/native-image-community:21')
+    // Pin to a specific patch + OS so dockerBuildNative is reproducible (21.0.2 is the final
+    // GraalVM Community release for JDK 21; later GraalVM Community releases target JDK 22+).
+    baseImage('ghcr.io/graalvm/native-image-community:21.0.2-ol9')
 }
 
 tasks.named('dockerBuildNative') {


### PR DESCRIPTION
## Summary

- The Forge prev-snapshot GCP deploy workflow ([example failed run](https://github.com/apache/grails-core/actions/runs/24477778496)) builds the application with Java 21 (`actions/setup-java` + `javaVersion=21` in `gradle.properties`), but the `dockerfileNative` task pinned `baseImage('ghcr.io/graalvm/jdk:ol8-java17-22.3.3')`. That GraalVM image runs `native-image` on Java 17, so it rejects the Java 21 bytecode and aborts with `UnsupportedClassVersionError` (class file version 65.0).
- Both `grails-forge-web-netty:dockerBuildNative` and `grails-forge-analytics-postgres:dockerBuildNative` failed for the same reason.
- Switch the `baseImage` in both modules to `ghcr.io/graalvm/native-image-community:21`, the canonical GraalVM Community image for Java 21 that ships with the `native-image` tool, matching the project's Java baseline.

## Failure excerpt

```
Fatal error: java.lang.UnsupportedClassVersionError: org/grails/forge/netty/Application
  has been compiled by a more recent version of the Java Runtime (class file version 65.0),
  this version of the Java Runtime only recognizes class file versions up to 61.0
Error: Image build request failed with exit status 1
> Task :grails-forge-web-netty:dockerBuildNative FAILED
```

## Verification

- `dockerBuildNative` cannot be exercised in this environment (no Docker runtime), but the new image is the standard GraalVM Community Java 21 image used by the upstream Micronaut Starter project for the same task.
- No application code changes; only the GraalVM build container reference is updated.

## Notes for reviewers

- Targeting `8.0.x` because that is the branch where the deploy workflow runs and where the failure was observed.
- The `fix/` branch prefix should auto-label this PR as a bug per `.github/release-drafter.yml`.